### PR TITLE
fix(install): survive GitHub API 403 + fix git/pipx fallbacks

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,6 +11,10 @@
 #   $env:IVYEA_WITH_SEMANTIC = "1"，同时安装本地语义检索依赖 sentence-transformers
 $ErrorActionPreference = "Stop"
 
+# 让中文提示在 GBK 控制台也不乱码；并在老 PowerShell 上启用 TLS 1.2，否则 GitHub 连接会失败。
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+try { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 } catch {}
+
 $ownerRepo = if ($env:IVYEA_GITHUB_REPO) { $env:IVYEA_GITHUB_REPO } else { "Hector-xue/ivyea-agent" }
 $repo = if ($env:IVYEA_REPO) { $env:IVYEA_REPO } else { "https://github.com/$ownerRepo.git" }
 $version = if ($env:IVYEA_VERSION) { $env:IVYEA_VERSION } else { "latest" }
@@ -102,7 +106,24 @@ if (-not (Get-Command pipx -ErrorAction SilentlyContinue)) {
   $env:Path = "$env:APPDATA\Python\Scripts;$env:LOCALAPPDATA\Programs\Python\Scripts;$env:Path"
 }
 
-function Get-ReleaseWheel($ownerRepo, $version) {
+# 通过 github.com 的 releases/latest 跳转解析最新 tag —— 不走限流严重的 api.github.com，
+# 国内/共享出口 IP 常因 API 限流拿到 403，这条路几乎不会。
+function Resolve-LatestTag($ownerRepo) {
+  try {
+    $req = [System.Net.HttpWebRequest]::Create("https://github.com/$ownerRepo/releases/latest")
+    $req.AllowAutoRedirect = $false
+    $req.UserAgent = "ivyea-install"
+    $req.Timeout = 30000
+    $resp = $req.GetResponse()
+    $loc = $resp.Headers["Location"]
+    $resp.Close()
+    if ($loc -and ($loc -match "/tag/([^/?#]+)")) { return $Matches[1] }
+  } catch {}
+  return $null
+}
+
+# API 发现（私有仓库带 token、或资产命名不符约定时的兜底）。
+function Get-ReleaseWheelUrl($ownerRepo, $version) {
   $api = "https://api.github.com/repos/$ownerRepo/releases"
   $url = if (($version -eq "") -or ($version -eq "latest")) { "$api/latest" } else { "$api/tags/$version" }
   $headers = @{ "Accept" = "application/vnd.github+json"; "User-Agent" = "ivyea-install" }
@@ -113,39 +134,57 @@ function Get-ReleaseWheel($ownerRepo, $version) {
   return $asset.browser_download_url
 }
 
-# 3) 安装 / 升级
-$pipxArgs = @("install", "--force")
-if ($env:IVYEA_LOCAL) {
-  $spec = $env:IVYEA_LOCAL
-} elseif ($ref) {
-  $spec = "git+$repo@$ref"
-} else {
-  Info "查找 GitHub Release wheel（$ownerRepo@$version）…"
-  try {
-    $spec = Get-ReleaseWheel $ownerRepo $version
-  } catch {
-    Info "Release wheel 不可用：$($_.Exception.Message)"
-    Info "回退到 git main 安装。私有仓库请先配置 GitHub 凭据，或设置 GITHUB_TOKEN/IVYEA_REF。"
-    $spec = "git+$repo@main"
+function Get-InstallSpec($ownerRepo, $repo, $version, $ref) {
+  if ($env:IVYEA_LOCAL) { return $env:IVYEA_LOCAL }
+  if ($ref) { return "git+$repo@$ref" }
+
+  $tag = if ($version -and ($version -ne "latest")) { $version } else { Resolve-LatestTag $ownerRepo }
+
+  # 1) 直接从 releases/download 下载 wheel —— 不依赖 api.github.com，规避 403。
+  if ($tag) {
+    $ver = $tag -replace '^v', ''
+    $wheelName = "ivyea_agent-$ver-py3-none-any.whl"
+    $wheelUrl = "https://github.com/$ownerRepo/releases/download/$tag/$wheelName"
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) $wheelName
+    try {
+      Info "下载 Release wheel：$tag …"
+      $iwr = @{ Uri = $wheelUrl; OutFile = $tmp; UseBasicParsing = $true; TimeoutSec = 180 }
+      if ($env:GITHUB_TOKEN) { $iwr["Headers"] = @{ Authorization = "Bearer $env:GITHUB_TOKEN" } }
+      Invoke-WebRequest @iwr
+      return $tmp
+    } catch {
+      Info "直接下载 wheel 失败（$($_.Exception.Message)），改用 GitHub API…"
+    }
   }
+
+  # 2) API 兜底
+  try { return (Get-ReleaseWheelUrl $ownerRepo $version) } catch {
+    Info "Release API 不可用：$($_.Exception.Message)"
+  }
+
+  # 3) git 兜底：优先用解析到的 tag（uv 对 tag 解析正确；用分支名 main 在 uv 下会被当成 tag 而失败）。
+  if ($tag) { Info "回退到 git tag 安装：$tag"; return "git+$repo@$tag" }
+  Info "回退到 git main 分支安装。私有仓库请配置 GitHub 凭据或 GITHUB_TOKEN/IVYEA_REF。"
+  return "git+$repo@refs/heads/main"
 }
+
+# 3) 安装 / 升级
+Info "查找安装来源（$ownerRepo@$version）…"
+$spec = Get-InstallSpec $ownerRepo $repo $version $ref
 Info "安装 ivyea-agent（来源：$spec）…"
-$pipxArgs += $spec
-& $py -m pipx @pipxArgs
+& $py -m pipx install --force $spec
 if ($env:IVYEA_WITH_SEMANTIC -eq "1") {
   Info "安装本地语义检索依赖（sentence-transformers）…"
   & $py -m pipx inject ivyea-agent "sentence-transformers>=3.0"
 }
 
-Info "✓ 安装完成。重开 PowerShell 后："
-try {
-  & $py -m ivyea_agent.cli self doctor
-} catch {
-  Info "安装后诊断未运行：$($_.Exception.Message)"
-}
-try {
-  & $py -m ivyea_agent.cli retrieval sync --json | Out-Null
-} catch {
-  Info "检索索引初始化未运行：$($_.Exception.Message)"
-}
+# pipx 把 ivyea 装进隔离 venv，并放一个启动器到 bin 目录；用它做安装后自检，
+# 不要用系统 python -m ivyea_agent.cli（那个 venv 之外没有这个模块）。
+$pipxBin = if ($env:PIPX_BIN_DIR) { $env:PIPX_BIN_DIR } else { Join-Path $HOME ".local\bin" }
+$ivyeaExe = Join-Path $pipxBin "ivyea.exe"
+if (-not (Test-Path $ivyeaExe)) { $ivyeaExe = "ivyea" }
+
+Info "✓ 安装完成。若 ivyea 不能直接执行，请重开 PowerShell（PATH 已加入 $pipxBin）。"
+try { & $ivyeaExe self doctor } catch { Info "安装后诊断未运行：$($_.Exception.Message)" }
+try { & $ivyeaExe retrieval sync --json | Out-Null } catch { Info "检索索引初始化未运行：$($_.Exception.Message)" }
 Info "  ivyea config   然后  ivyea chat"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,57 +161,100 @@ fi
 command -v pipx >/dev/null 2>&1 || { export PATH="$HOME/.local/bin:$PATH"; }
 command -v pipx >/dev/null 2>&1 || die "pipx 安装失败，请手动 'python3 -m pip install --user pipx'。"
 
-release_spec() {
-  "$PY" - "$OWNER_REPO" "$VERSION" <<'PY'
-import json
-import os
-import sys
-import urllib.request
+# 解析安装来源：优先「从 releases/download 直链下载 wheel」——不走限流严重的
+# api.github.com（国内/共享出口 IP 常因 API 限流拿到 403）。失败再退 API，最后退 git。
+install_spec() {
+  "$PY" - "$OWNER_REPO" "$VERSION" "$REPO" <<'PY'
+import json, os, sys, urllib.request, urllib.error
 
-repo, version = sys.argv[1], sys.argv[2]
-api = f"https://api.github.com/repos/{repo}/releases"
-url = f"{api}/latest" if version in ("", "latest") else f"{api}/tags/{version}"
-req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json", "User-Agent": "ivyea-install"})
+repo, version, repo_url = sys.argv[1], sys.argv[2], sys.argv[3]
 token = os.environ.get("GITHUB_TOKEN", "")
-if token:
-    req.add_header("Authorization", f"Bearer {token}")
-with urllib.request.urlopen(req, timeout=30) as resp:
-    data = json.load(resp)
-assets = data.get("assets") or []
-for asset in assets:
-    name = asset.get("name", "")
-    if name.endswith(".whl"):
-        print(asset["browser_download_url"])
-        break
-else:
-    raise SystemExit("release 中没有 wheel 资产")
+UA = {"User-Agent": "ivyea-install"}
+
+def head_ok(url):
+    req = urllib.request.Request(url, method="HEAD", headers=dict(UA))
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status < 400
+    except Exception:
+        return False
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, *a, **k):
+        return None
+
+def latest_tag():
+    # 用 github.com 的 releases/latest 跳转拿到最新 tag，绕开 api 限流。
+    op = urllib.request.build_opener(_NoRedirect)
+    try:
+        op.open(urllib.request.Request(f"https://github.com/{repo}/releases/latest", headers=dict(UA)), timeout=30)
+    except urllib.error.HTTPError as e:
+        loc = e.headers.get("Location", "") or ""
+        if "/tag/" in loc:
+            return loc.split("/tag/", 1)[1].strip()
+    except Exception:
+        pass
+    return ""
+
+tag = version if version and version not in ("", "latest") else latest_tag()
+
+# 1) 直链 wheel（约定命名 ivyea_agent-<ver>-py3-none-any.whl）
+if tag:
+    ver = tag[1:] if tag.startswith("v") else tag
+    url = f"https://github.com/{repo}/releases/download/{tag}/ivyea_agent-{ver}-py3-none-any.whl"
+    if head_ok(url):
+        print(url)
+        raise SystemExit(0)
+
+# 2) API 兜底（资产命名不符约定 / 私有仓库带 token）
+try:
+    api = f"https://api.github.com/repos/{repo}/releases"
+    u = f"{api}/latest" if version in ("", "latest") else f"{api}/tags/{version}"
+    req = urllib.request.Request(u, headers={**UA, "Accept": "application/vnd.github+json"})
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.load(resp)
+    for a in (data.get("assets") or []):
+        if a.get("name", "").endswith(".whl"):
+            print(a["browser_download_url"])
+            raise SystemExit(0)
+except SystemExit:
+    raise
+except Exception:
+    pass
+
+# 3) git 兜底：优先用解析到的 tag（部分解析器会把分支名 main 误当 tag）。
+print(f"git+{repo_url}@{tag}" if tag else f"git+{repo_url}@refs/heads/main")
 PY
 }
 
 # 4) 安装 / 升级 ivyea-agent
-PIPX_ARGS=()
 if [ -n "${IVYEA_LOCAL:-}" ]; then
   SPEC="$IVYEA_LOCAL"
 elif [ -n "$REF" ]; then
   SPEC="git+${REPO}@${REF}"
 else
-  say "查找 GitHub Release wheel（${OWNER_REPO}@${VERSION}）…"
-  if SPEC="$(release_spec 2>/tmp/ivyea-install-release.err)"; then
-    :
-  else
-    say "Release wheel 不可用：$(cat /tmp/ivyea-install-release.err 2>/dev/null || true)"
+  say "查找安装来源（${OWNER_REPO}@${VERSION}）…"
+  SPEC="$(install_spec 2>/tmp/ivyea-install-release.err || true)"
+  if [ -z "$SPEC" ]; then
+    say "解析安装来源失败：$(cat /tmp/ivyea-install-release.err 2>/dev/null || true)"
     say "回退到 git main 安装。私有仓库请先配置 GitHub 凭据，或设置 GITHUB_TOKEN/IVYEA_REF。"
-    SPEC="git+${REPO}@main"
+    SPEC="git+${REPO}@refs/heads/main"
   fi
 fi
 say "安装 ivyea-agent（来源：$SPEC）…"
-pipx install --force "${PIPX_ARGS[@]}" "$SPEC"
+pipx install --force "$SPEC"
 if [ "${IVYEA_WITH_SEMANTIC:-0}" = "1" ]; then
   say "安装本地语义检索依赖（sentence-transformers）…"
   pipx inject ivyea-agent "sentence-transformers>=3.0"
 fi
 
 say "✓ 安装完成。"
+# pipx 把 ivyea 装进 ~/.local/bin；当前 shell 可能还没更新 PATH，先临时加上再自检。
+export PATH="$HOME/.local/bin:$PATH"
 if ! command -v ivyea >/dev/null 2>&1; then
   say "提示：重开终端，或先执行  export PATH=\"\$HOME/.local/bin:\$PATH\""
 else


### PR DESCRIPTION
## Why
A Windows one-line install failed: `api.github.com` returned **403** (rate limit), the `git+repo@main` fallback failed because uv resolves `main` as a tag (`refs/tags/main`), and the post-install check hit `No module named 'ivyea_agent'` (ran system `python -m ivyea_agent.cli` instead of the pipx venv).

## What
- Resolve latest tag via the `releases/latest` redirect (no rate-limited API) and download the wheel directly from `releases/download/<tag>/...`; API kept as fallback.
- git fallback pins the resolved **tag** (uv-safe) instead of `main`.
- Post-install self-check uses the pipx-installed `ivyea`, not system Python.
- `install.ps1`: UTF-8 console + TLS 1.2; `install.sh`: PATH export before self-check.

## Test
- `install.sh`: `bash -n` OK; the tag-resolver + direct-wheel HEAD verified on Linux (resolves `v1.0.19`, wheel 200).
- `install.ps1`: portable .NET calls, reviewed but **not executed on Windows** — recommend a real Windows re-run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)