### PR TITLE
chore: release v1.0.20 — fix doctor PATH hint for pipx

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.0.19"
+__version__ = "1.0.20"

--- a/ivyea_agent/self_manage.py
+++ b/ivyea_agent/self_manage.py
@@ -577,10 +577,14 @@ def _startup_templates(host: str, port: int) -> dict[str, str]:
 
 
 def _path_fix(info: dict[str, Any]) -> str:
-    if sys.platform.startswith("win"):
+    # 入口所在的 bin 目录因安装方式而异：pipx 默认放 ~/.local/bin，
+    # 离线 wheelhouse（ivyea-runtime）放 ~/.ivyea/bin。别一律指向 ~/.ivyea/bin。
+    if info.get("method") == "ivyea-runtime":
         candidate = str(Path.home() / ".ivyea" / "bin")
-        return f"重开 PowerShell；仍不可用时把 {candidate} 加入用户 PATH。"
-    candidate = str(Path.home() / ".local" / "bin")
+    else:
+        candidate = str(Path.home() / ".local" / "bin")
+    if sys.platform.startswith("win"):
+        return f"重开 PowerShell（安装时已把该目录加入用户 PATH）；仍不可用时把 {candidate} 加入用户 PATH。"
     return f"重开终端，或先执行：export PATH=\"{candidate}:$PATH\""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ivyea-agent"
-version = "1.0.19"
+version = "1.0.20"
 description = "Ivyea Agent — 自托管的亚马逊运营 CLI Agent（对话式 + 多模型 + 领星广告读写审批 + 通用工具 + 记忆）"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What
`ivyea self doctor` told pipx users to add `~/.ivyea/bin` to PATH, but pipx installs `ivyea.exe` to `~/.local/bin` (`~/.ivyea/bin` is only the offline-wheelhouse launcher dir). `_path_fix` now selects the directory by install method.

Bump version to **1.0.20**.

## Test
- `tests/test_self_manage.py`: 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)