### PR TITLE
chore: release v1.0.24

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.0.23"
+__version__ = "1.0.24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ivyea-agent"
-version = "1.0.23"
+version = "1.0.24"
 description = "Ivyea Agent — 自托管的亚马逊运营 CLI Agent（对话式 + 多模型 + 领星广告读写审批 + 通用工具 + 记忆）"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump for the ops-bridge call-timeout fix (PR #15) so the local agent serving the IvyeaOps dock runs slow panel report tools (market/playbook/deep generate_report) without timing out.