### PR TITLE
feat(sessions): DELETE /v1/chat/sessions/{id}

### DIFF
--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -982,6 +982,12 @@ def chat_session_detail(session_id: str) -> dict[str, Any]:
     return {"ok": True, "session": _public_session_detail(data)}
 
 
+def chat_session_delete(session_id: str) -> dict[str, Any]:
+    if not sessions.delete(session_id):
+        raise FileNotFoundError(f"会话不存在：{session_id}")
+    return {"ok": True, "deleted": session_id}
+
+
 def chat_session_create(payload: dict[str, Any]) -> dict[str, Any]:
     session_id = str(payload.get("id") or "") or sessions.new_id()
     initial = str(payload.get("message") or payload.get("title") or "").strip()
@@ -1335,6 +1341,13 @@ class _Handler(BaseHTTPRequestHandler):
             try:
                 self._json(200, knowledge_file_delete(_first(qs, "path")))
             except (FileNotFoundError, ValueError) as exc:
+                self._json(404, {"ok": False, "error": str(exc)})
+            return
+        if parsed.path.startswith("/v1/chat/sessions/"):
+            session_id = parsed.path.rsplit("/", 1)[-1]
+            try:
+                self._json(200, chat_session_delete(session_id))
+            except FileNotFoundError as exc:
                 self._json(404, {"ok": False, "error": str(exc)})
             return
         self._json(404, {"ok": False, "error": "not_found", "path": parsed.path})

--- a/ivyea_agent/sessions.py
+++ b/ivyea_agent/sessions.py
@@ -58,6 +58,23 @@ def latest_id() -> Optional[str]:
     return files[0].stem if files else None
 
 
+def delete(sid: str) -> bool:
+    """Delete one persisted session file. Returns True if a file was removed.
+    Guards against path traversal — only deletes inside the sessions dir."""
+    if not sid:
+        return False
+    p = path_for(sid)
+    try:
+        if p.resolve().parent != _dir().resolve():
+            return False
+        if p.exists():
+            p.unlink()
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def listing(limit: int = 20) -> list[dict[str, Any]]:
     out = []
     files = sorted(_dir().glob("*.json"), key=lambda f: f.stat().st_mtime, reverse=True)


### PR DESCRIPTION
Adds session delete (with path-traversal guard) so the IvyeaOps dock can delete chat history. 🤖 Generated with [Claude Code](https://claude.com/claude-code)