### PR TITLE
chat 写代码体验 P0–P2：对标 Claude Code / Codex（v1.0.29）

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.0.28"
+__version__ = "1.0.29"

--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -18,7 +18,7 @@ from .providers import LLMProvider
 SYSTEM_PROMPT = """你是 Ivyea Agent，一个亚马逊运营助手。专长是广告巡检，也能处理日常运营杂活。
 广告：run_patrol(巡检) → propose_actions(看动作) → execute_actions(逐条人工审批执行) → 必要时 rollback。
 通用：read_file/list_dir/web_fetch/web_search 读取信息；write_file/edit_file 产出文件；run_python(可用 pandas/openpyxl 读 Excel、算数)、run_command 执行——这些写/执行操作都会弹人工审批。
-代码：面对代码库先用 grep(内容正则)/code_search(找相关文件)/code_symbols/code_impact 定位，再 read_file 看真实内容，别瞎猜路径。改代码走 code_apply_patch(默认 dry-run 校验，execute=true 才写并自动跑测试)→失败用 run_tests/code_repair 闭环修复。
+代码：先 grep(内容正则)/code_search(找相关文件)/code_symbols/code_impact 定位，再 read_file 看真实内容（改前必读，别瞎猜路径）。改代码按场景选一个写工具：改单个文件的某一处→edit_file(唯一 old→new)；新建或整体重写文件→write_file；跨多文件/多处关联改动或要顺带跑测试→code_apply_patch(一次提交全部 ops)。每个写工具都是一次调用即审批落盘——**一次逻辑改动只用一个工具，不要先 dry-run 再 execute、也不要同一处既 edit_file 又 code_apply_patch 重复弹审批**。改完测试失败用 run_tests/code_repair 闭环修复。
 委派：需要多角度/独立的调研，可用 dispatch_subagent 派只读子 agent 并行查清，避免主线被探索细节塞满。
 MCP：用户接了 MCP 服务器时，用 mcp_list_tools/mcp_list_resources/mcp_list_prompts 发现，mcp_read_resource/mcp_get_prompt 取内容，mcp_call_tool 调用工具（写类会审批）。
 原则：先拿证据再动手；写操作一律经人工审批，绝不自作主张直接写；动作绑数据、简洁可执行；信息不足就澄清，不要瞎编 ASIN/规格/数字。读文件优先用 read_file 看真实内容，不要假设；**大文件读某几行用 read_file 的 offset/limit，别用 run_command/python 分段读**（那会反复弹审批）。"""

--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -137,7 +137,7 @@ def _dispatch_tool_calls(ctx: ToolContext, messages: list, status: TurnStatus, t
         for call_idx, tc in enumerate(tool_calls, start=1):
             status.record_tool_call()
             narrate(ui.tool_call(tc["name"], tc.get("arguments") or {},
-                                 step=f"{step_idx + 1}/{max_steps}.{call_idx}∥"))
+                                 step=f"{step_idx + 1}/{max_steps} ∥{call_idx}"))
         with ThreadPoolExecutor(max_workers=min(len(tool_calls), 8)) as ex:
             outcomes = list(ex.map(lambda tc: _run_one(tc, ctx), tool_calls))
         for tc, (res, dur) in zip(tool_calls, outcomes):
@@ -146,7 +146,7 @@ def _dispatch_tool_calls(ctx: ToolContext, messages: list, status: TurnStatus, t
     for call_idx, tc in enumerate(tool_calls, start=1):
         status.record_tool_call()
         narrate(ui.tool_call(tc["name"], tc.get("arguments") or {},
-                             step=f"{step_idx + 1}/{max_steps}.{call_idx}"))
+                             step=f"{step_idx + 1}/{max_steps}"))
         res, dur = _run_one(tc, ctx)
         _record_tool_result(ctx, messages, tc, res, dur, narrate)
 

--- a/ivyea_agent/agent_tools.py
+++ b/ivyea_agent/agent_tools.py
@@ -38,6 +38,7 @@ class ToolContext:
     ops_bridge: dict[str, Any] = field(default_factory=dict)  # IvyeaOps 嵌入模式工具桥接
     ops_context: dict[str, Any] = field(default_factory=dict)  # 当前 Ops 页面/板块上下文
     provider: Any = None                                       # 当前主脑 provider（供 dispatch_subagent）
+    read_paths: set = field(default_factory=set)               # 本会话已 read_file 过的绝对路径（改前必读软护栏）
 
 
 # OpenAI function-calling schema

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -11,6 +11,7 @@ import argparse
 import getpass
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -1205,24 +1206,65 @@ SLASH_COMMANDS = [
 ]
 
 
+# 亚马逊广告域信号：命中任一则本轮按广告任务处理，注入内置知识/skill。
+_AMAZON_TERMS = (
+    "广告", "否词", "否定", "竞价", "出价", "bid", "预算", "budget", "acos", "acoas", "roas",
+    "tacos", "asin", "listing", "关键词", "搜索词", "投放", "活动", "campaign", "浪费词",
+    "转化", "点击", "曝光", "ctr", "cpc", "cvr", "店铺", "销量", "库存", "类目", "竞品",
+    "sp广告", "sb广告", "sd广告", "亚马逊", "amazon", "运营", "领星", "lingxing",
+    "sku", "review", "qa", "offer",
+)
+
+
+def _is_amazon_domain(query: str) -> bool:
+    """本轮是否带亚马逊广告/运营域信号。无信号的工程任务据此跳过内置知识注入。"""
+    q = (query or "").lower()
+    return any(t in q for t in _AMAZON_TERMS)
+
+
+# 代码/工程任务信号：源码文件后缀 + 代码语义词。比 engineering_context 的术语表更宽，
+# 用来兜住「给 calc.py 加 docstring」这类不含'优化/bug'但分明是写代码的请求。
+_CODE_HINTS = re.compile(
+    r"\.(py|js|ts|tsx|jsx|go|rs|java|kt|rb|php|cs|cpp|cc|hpp|sh|sql|ya?ml|toml|ini|css|html?|vue)\b"
+    r"|docstring|traceback|stack ?trace|函数|方法|变量|类型|形参|参数列表|报错|异常|栈|仓库|repo\b"
+    r"|分支|commit|merge|pull ?request|\bdef \b|\bclass \b|\bimport \b|编译|断点|单元测试|代码|脚本",
+    re.I,
+)
+
+
+def _looks_like_code_task(query: str) -> bool:
+    """本轮是否是写代码/工程任务（用于决定是否跳过亚马逊知识注入）。"""
+    from . import engineering_context
+    return engineering_context.should_include(query) or bool(_CODE_HINTS.search(query or ""))
+
+
 class _LiveSpinner:
-    """生成时的轻量转圈反馈（不打印 token；收尾渲染 markdown）。"""
+    """生成时的轻量转圈反馈：转圈 + 已耗时 + 估算输出 token + 中断提示（不打印正文，收尾渲染 markdown）。"""
     _F = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
     def __init__(self):
         self.i = 0
         self.on = False
+        self.start = None
+        self.chars = 0
 
-    def tick(self, _text: str = "") -> None:
+    def tick(self, text: str = "") -> None:
+        if self.start is None:
+            self.start = time.time()
+        self.chars += len(text or "")
         self.i += 1
         frame = self._F[self.i % len(self._F)]
-        sys.stdout.write(f"\r{_C['c']}{frame}{_C['x']} {_C['d']}生成中…{_C['x']}")
+        elapsed = int(time.time() - self.start)
+        toks = self.chars // 3   # 中英混排粗估 ~3 字符/token，仅作进度感
+        tok_s = f" · ~{toks / 1000:.1f}k tok" if toks >= 1000 else (f" · ~{toks} tok" if toks else "")
+        # \033[K 清到行尾，避免上一帧更长状态残留
+        sys.stdout.write(f"\r\033[K{_C['c']}{frame}{_C['x']} {_C['d']}生成中 · {elapsed}s{tok_s} · Ctrl-C 中断{_C['x']}")
         sys.stdout.flush()
         self.on = True
 
     def clear(self) -> None:
         if self.on:
-            sys.stdout.write("\r" + " " * 20 + "\r")
+            sys.stdout.write("\r\033[K")
             sys.stdout.flush()
             self.on = False
 
@@ -1553,9 +1595,15 @@ def _cmd_chat(args: argparse.Namespace) -> int:
                 print(ui.message("info", "已暂停。调整上限：ivyea config set daily_cost_limit_cny <元>"))
                 continue
         from . import engineering_context, knowledge, skills
-        kctx, kids = knowledge.context_for_query(line, limit=3)
-        sctx, sids = skills.context_for_query(line, limit=2)
         ectx = engineering_context.build(os.getcwd(), line)
+        # 门控：工程/代码任务且无广告域信号(也无 ASIN) → 不注入亚马逊知识/skill，
+        # 避免污染上下文、烧 token、把模型往运营方向带偏。广告/通用/模糊任务一律照常注入。
+        _inject_domain = (
+            bool(getattr(ctx, "asin", "")) or _is_amazon_domain(line)
+            or not _looks_like_code_task(line)
+        )
+        kctx, kids = knowledge.context_for_query(line, limit=3) if _inject_domain else ("", [])
+        sctx, sids = skills.context_for_query(line, limit=2) if _inject_domain else ("", [])
         user_content = line
         if ectx:
             user_content += "\n\n[工程上下文]\n" + ectx

--- a/ivyea_agent/tools_general.py
+++ b/ivyea_agent/tools_general.py
@@ -50,6 +50,16 @@ def _disp(p) -> str:
         return str(p)
 
 
+def _read_nudge(ctx, paths) -> str:
+    """改前必读软护栏：列出本会话未 read_file 过的目标文件，返回温和提示行（不阻断）。"""
+    read = getattr(ctx, "read_paths", None) or set()
+    unread = [p for p in paths if str(p) not in read and Path(p).exists()]
+    if not unread:
+        return ""
+    names = "、".join(_disp(p) for p in unread)
+    return f"⚠ 本会话未读过 {names}，建议先 read_file 核对再改\n"
+
+
 def _gate(ctx, kind: str, preview: str) -> tuple[bool, str]:
     """写/执行前门控：计划模式拒绝；否则人工审批。返回 (放行?, 拒绝消息)。"""
     if getattr(ctx, "plan_mode", False):
@@ -76,6 +86,10 @@ def t_read_file(args: dict, ctx) -> str:
         text = p.read_text(encoding="utf-8", errors="replace")
     except Exception as e:  # noqa: BLE001
         return f"读取失败：{e}"
+    try:
+        ctx.read_paths.add(str(p))   # 记录已读，供 edit_file/code_apply_patch 的改前必读软护栏
+    except AttributeError:
+        pass
     offset = args.get("offset")
     limit = args.get("limit")
     if offset is None and limit is None:
@@ -241,23 +255,41 @@ def t_code_impact(args: dict, ctx) -> str:
 
 # ── 代码闭环（结构化补丁 / 测试 / 修复计划）──────────────────────────────────
 def t_code_apply_patch(args: dict, ctx) -> str:
-    """校验/应用结构化补丁并跑测试。默认 dry-run（只校验、不写）；execute=true 才真写，
-    且经人工审批。补丁 ops=[{path, old, new}]，old 必须在文件中唯一出现。"""
+    """一次性应用结构化补丁并跑测试（多文件/多处关联改动优先用它）。
+    内部固定流程：先校验(不写)→失败直接返回；通过则给彩色 diff 预览→一次人工审批→落盘+跑测试。
+    补丁 ops=[{path, old, new}]，old 必须在文件中唯一出现。"""
+    from . import code_agent, patcher
     ops = args.get("ops")
     if not isinstance(ops, list) or not ops:
         return "ops 为空：需要 [{path, old, new}, ...]，old 必须在文件中唯一出现。"
-    execute = bool(args.get("execute"))
-    if execute:
-        preview = "应用结构化补丁并执行测试：\n" + "\n".join(
-            f"  · {o.get('path')}" for o in ops if isinstance(o, dict))
-        ok, msg = _gate(ctx, "code_apply_patch", preview)
-        if not ok:
-            return msg
-    from . import code_agent
+    spec = {"ops": ops}
+    root = _ws_root(ctx)
+    # 1) 先校验，不写。校验失败不弹审批，直接把问题回给模型。
+    validation = patcher.validate_spec(spec, root=root)
+    if not validation.get("ok"):
+        return _truncate(patcher.render_validation(validation))
+    # 2) 构造彩色 diff 预览 + 改前必读提示
+    abs_paths = [str((Path(root) / o.get("path", "")).resolve()) for o in ops if isinstance(o, dict) and o.get("path")]
+    n = len([o for o in ops if isinstance(o, dict)])
+    lines = [f"应用结构化补丁（{n} 处）并跑测试："]
+    for o in ops:
+        if not isinstance(o, dict):
+            continue
+        lines.append(f"  · {_disp((Path(root) / o.get('path', '')).resolve())}")
+        try:
+            lines.append(panels.render_diff(o.get("old", ""), o.get("new", ""), str(o.get("path", ""))))
+        except Exception:
+            pass
+    preview = _read_nudge(ctx, abs_paths) + "\n".join(lines)
+    # 3) 一次审批
+    ok, msg = _gate(ctx, "code_apply_patch", preview)
+    if not ok:
+        return msg
+    # 4) 落盘 + 跑测试
     try:
         result = code_agent.patch_apply_loop(
-            {"ops": ops}, root=_ws_root(ctx),
-            test_command=args.get("test_command", "") or "", execute=execute)
+            spec, root=root,
+            test_command=args.get("test_command", "") or "", execute=True)
     except Exception as e:  # noqa: BLE001
         return f"补丁执行出错：{e}"
     return _truncate(code_agent.render_run(result))
@@ -486,7 +518,7 @@ def t_edit_file(args: dict, ctx) -> str:
         return "未找到要替换的原文（old 不匹配）。"
     if cnt > 1:
         return f"原文出现 {cnt} 次，不唯一；请提供更长的 old 以唯一定位。"
-    preview = f"编辑 {_disp(p)}：替换 1 处\n" + panels.render_diff(old, new, p.name)
+    preview = _read_nudge(ctx, [str(p)]) + f"编辑 {_disp(p)}：替换 1 处\n" + panels.render_diff(old, new, p.name)
     ok, msg = _gate(ctx, "edit_file", preview)
     if not ok:
         return msg
@@ -660,9 +692,10 @@ GENERAL_TOOL_SCHEMAS = [
          "limit": {"type": "integer", "description": "最多读多少行；配合 offset 读区间"}}, ["path"]),
     _fn("list_dir", "列出目录内容（只读）。",
         {"path": {"type": "string", "description": "目录路径，默认当前目录"}}),
-    _fn("write_file", "写入/覆盖本地文件（写操作，会弹人工审批）。",
+    _fn("write_file", "新建或整体重写文件（写操作，一次调用即审批落盘）。改已有文件的某一处别用它，用 edit_file。",
         {"path": {"type": "string"}, "content": {"type": "string"}}, ["path", "content"]),
-    _fn("edit_file", "对文件做唯一字符串替换（写操作，会弹审批）。old 必须在文件中唯一出现。",
+    _fn("edit_file", "改单个文件的某一处：唯一字符串替换 old→new（写操作，一次调用即审批落盘）。"
+        "old 必须在文件中唯一出现。单处改动首选它；跨多文件/多处或要顺带跑测试用 code_apply_patch。",
         {"path": {"type": "string"}, "old": {"type": "string"}, "new": {"type": "string"}},
         ["path", "old", "new"]),
     _fn("run_python", "在沙箱(限工作目录/超时)运行 Python 代码取 stdout（执行，会弹审批）。可用 pandas/openpyxl 等。",
@@ -683,12 +716,12 @@ GENERAL_TOOL_SCHEMAS = [
         {"query": {"type": "string", "description": "可选，过滤符号名"}, "limit": {"type": "integer"}}),
     _fn("code_impact", "查某个符号或文件的调用方、导入方与受影响测试（改动影响面）。只读。改代码前先看它。",
         {"target": {"type": "string", "description": "符号名或文件路径"}, "limit": {"type": "integer"}}, ["target"]),
-    _fn("code_apply_patch", "校验/应用结构化补丁并跑测试。默认 dry-run 只校验不写；execute=true 才真写(经人工审批)。"
-        "ops=[{path,old,new}]，old 必须在文件中唯一出现。多文件/要顺带跑测试时优先用它而非 edit_file。",
+    _fn("code_apply_patch", "一次性应用一组结构化补丁并跑测试（跨多文件/多处关联改动，或要顺带跑测试时用它）。"
+        "内部先校验→给彩色 diff 预览→一次人工审批→落盘+跑测试，不需要分 dry-run/execute 两步。"
+        "ops=[{path,old,new}]，old 必须在文件中唯一出现。单文件单处改动用 edit_file 即可。",
         {"ops": {"type": "array", "items": {"type": "object", "properties": {
             "path": {"type": "string"}, "old": {"type": "string"}, "new": {"type": "string"}}}},
-         "test_command": {"type": "string", "description": "可选：execute 后跑的测试命令"},
-         "execute": {"type": "boolean", "description": "true=真写并测试(审批)，默认 false 只校验"}}, ["ops"]),
+         "test_command": {"type": "string", "description": "可选：落盘后跑的测试命令，默认自动挑选"}}, ["ops"]),
     _fn("run_tests", "在工作目录跑测试命令并返回结果（执行，会弹审批）。默认 python -m pytest。",
         {"command": {"type": "string"}, "timeout": {"type": "integer"}}),
     _fn("code_repair", "解析失败测试输出，生成下一轮修复计划（可疑文件/失败摘要/重跑命令）。只读。",

--- a/ivyea_agent/tools_general.py
+++ b/ivyea_agent/tools_general.py
@@ -41,6 +41,15 @@ def _dangerous_command(command: str) -> str:
     return ""
 
 
+def _disp(p) -> str:
+    """审批预览用的友好路径：在 cwd 下显示相对路径，否则原样。仅展示用，写入仍用绝对路径。"""
+    try:
+        rel = os.path.relpath(p, os.getcwd())
+        return rel if not rel.startswith("..") else str(p)
+    except Exception:
+        return str(p)
+
+
 def _gate(ctx, kind: str, preview: str) -> tuple[bool, str]:
     """写/执行前门控：计划模式拒绝；否则人工审批。返回 (放行?, 拒绝消息)。"""
     if getattr(ctx, "plan_mode", False):
@@ -441,7 +450,7 @@ def t_write_file(args: dict, ctx) -> str:
     if not ok:
         return msg
     exists = p.exists()
-    preview = f"写文件 {p}（{'覆盖' if exists else '新建'}，{len(content)} 字）"
+    preview = f"写文件 {_disp(p)}（{'覆盖' if exists else '新建'}，{len(content)} 字）"
     if exists:
         try:
             preview += "\n" + panels.render_diff(p.read_text(encoding="utf-8"), content, p.name)
@@ -477,7 +486,7 @@ def t_edit_file(args: dict, ctx) -> str:
         return "未找到要替换的原文（old 不匹配）。"
     if cnt > 1:
         return f"原文出现 {cnt} 次，不唯一；请提供更长的 old 以唯一定位。"
-    preview = f"编辑 {p}：替换 1 处\n" + panels.render_diff(old, new, p.name)
+    preview = f"编辑 {_disp(p)}：替换 1 处\n" + panels.render_diff(old, new, p.name)
     ok, msg = _gate(ctx, "edit_file", preview)
     if not ok:
         return msg

--- a/ivyea_agent/tui.py
+++ b/ivyea_agent/tui.py
@@ -42,6 +42,7 @@ def _fallback(title: str, body: str, options: list[tuple[str, str]],
 
 def _interactive(title: str, body: str, options: list[tuple[str, str]], kind: str) -> str:
     from prompt_toolkit.application import Application
+    from prompt_toolkit.formatted_text import ANSI, to_formatted_text
     from prompt_toolkit.key_binding import KeyBindings
     from prompt_toolkit.layout import Layout
     from prompt_toolkit.layout.containers import HSplit, Window
@@ -54,7 +55,12 @@ def _interactive(title: str, body: str, options: list[tuple[str, str]], kind: st
     def render():
         frags = [("class:title", f"  ▌ {title}\n")]
         for line in str(body).splitlines() or [""]:
-            frags.append(("class:dim", f"    {line}\n"))
+            frags.append(("class:dim", "    "))
+            if "\x1b" in line:   # 行内带 ANSI（如 diff 的绿+/红-）→ 解析为片段以恢复配色，而非字面量
+                frags.extend(to_formatted_text(ANSI(line)))
+            else:
+                frags.append(("class:dim", line))
+            frags.append(("", "\n"))
         frags.append(("", "\n"))
         for i, (_, lbl) in enumerate(options):
             if i == state["idx"]:

--- a/ivyea_agent/ui.py
+++ b/ivyea_agent/ui.py
@@ -124,22 +124,72 @@ def panel(title: str, body: str | list[str], *, kind: str = "info",
     return "\n".join(out)
 
 
+def _short_path(value: str) -> str:
+    """审视用的友好路径：cwd 下转相对路径，否则保留文件名优先的短形式。"""
+    s = str(value or "")
+    try:
+        rel = os.path.relpath(s, os.getcwd())
+        return rel if not rel.startswith("..") else s
+    except (ValueError, OSError):
+        return s
+
+
+def _code_tool_suffix(name: str, args: dict) -> str | None:
+    """把写代码/检索类工具调用渲染成人读摘要（而非 repr 截断）。未知工具返回 None。"""
+    g = args.get
+    if name in ("read_file", "view_file"):
+        return f" {_short_path(g('path'))}" if g("path") else None
+    if name == "write_file":
+        n = len(str(g("content") or ""))
+        return f" {_short_path(g('path'))}（{n} 字）" if g("path") else None
+    if name == "edit_file":
+        return f" {_short_path(g('path'))} · 替换 1 处" if g("path") else None
+    if name == "code_apply_patch":
+        ops = g("ops") or []
+        paths = [_short_path(o.get("path")) for o in ops if isinstance(o, dict) and o.get("path")]
+        if not paths:
+            return None
+        head = paths[0] + (f" 等 {len(paths)} 文件" if len(paths) > 1 else "")
+        return f" {head}（{len(paths)} 处补丁）"
+    if name in ("grep", "search_code"):
+        pat = g("pattern") or g("query") or ""
+        scope = g("glob") or g("path") or ""
+        return f" '{pat}'" + (f" in {scope}" if scope else "")
+    if name in ("run_python", "run_shell", "bash"):
+        cmd = str(g("command") or g("code") or "").strip().splitlines()
+        return f" {cmd[0][:60]}" if cmd else None
+    return None
+
+
 def tool_call(name: str, args: dict | None = None, *, color: bool | None = None,
               step: str = "") -> str:
     args = args or {}
-    pairs = []
-    for key, value in args.items():
-        text = repr(security.redact_obj(value))
-        if len(text) > 60:
-            text = text[:57] + "..."
-        pairs.append(f"{key}={text}")
-    suffix = f"({', '.join(pairs)})" if pairs else "()"
+    suffix = _code_tool_suffix(name, args)
+    if suffix is not None:
+        suffix = security.redact_text(suffix)
+        if len(suffix) > 72:
+            suffix = suffix[:69] + "..."
+    else:
+        pairs = []
+        for key, value in args.items():
+            text = repr(security.redact_obj(value))
+            if len(text) > 60:
+                text = text[:57] + "..."
+            pairs.append(f"{key}={text}")
+        suffix = f"({', '.join(pairs)})" if pairs else "()"
     prefix = f"[{step}] " if step else ""
     return f"{paint(_ICONS['tool'], 'info', color=color)} {paint(prefix, 'muted', color=color)}{paint(name, _B, color=color)}{paint(suffix, 'muted', color=color)}"
 
 
 def tool_result(text: str, *, color: bool | None = None) -> str:
-    first = (security.redact_text(text or "").splitlines()[0]) if text else "完成，无文本输出"
+    if not text:
+        return f"  {paint(_ICONS['result'], 'muted', color=color)} {paint('完成，无文本输出', 'muted', color=color)}"
+    redacted = security.redact_text(text)
+    lines = redacted.splitlines() or [""]
+    first = lines[0]
     if len(first) > 120:
         first = first[:117] + "..."
+    extra = len([ln for ln in lines[1:] if ln.strip()])
+    if extra:
+        first = f"{first}  …(+{extra} 行)"
     return f"  {paint(_ICONS['result'], 'muted', color=color)} {paint(first, 'muted', color=color)}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ivyea-agent"
-version = "1.0.28"
+version = "1.0.29"
 description = "Ivyea Agent — 自托管的亚马逊运营 CLI Agent（对话式 + 多模型 + 领星广告读写审批 + 通用工具 + 记忆）"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_code_edit_tools.py
+++ b/tests/test_code_edit_tools.py
@@ -12,33 +12,46 @@ def _repo(tmp_path):
     return tmp_path
 
 
-def test_apply_patch_dry_run_does_not_write(tmp_path):
+def test_apply_patch_denied_does_not_write(tmp_path, monkeypatch):
+    # 一次性语义：先校验通过 → 弹审批；用户拒绝则不落盘。
     root = _repo(tmp_path)
+    monkeypatch.setattr(permission, "request_intent", lambda *a, **k: permission.DENY)
     ctx = ToolContext(workspace=str(root))
     out = dispatch("code_apply_patch", {"ops": [
         {"path": "pkg/calc.py", "old": "return a + b\n", "new": "return a + b + 0\n"}]}, ctx)
-    assert "dry" in out.lower() or "校验" in out or "valid" in out.lower()
-    # nothing written in dry-run
+    assert "跳过" in out or "deny" in out.lower()
     assert (root / "pkg" / "calc.py").read_text(encoding="utf-8").endswith("return a + b\n")
 
 
-def test_apply_patch_execute_requires_approval_and_writes(tmp_path, monkeypatch):
+def test_apply_patch_approve_writes(tmp_path, monkeypatch):
+    # 无需 execute 两步：一次审批即落盘。
     root = _repo(tmp_path)
-    # auto-approve so the gate passes in the test
     monkeypatch.setattr(permission, "request_intent", lambda *a, **k: permission.APPROVE)
     ctx = ToolContext(workspace=str(root), execute=True)
     out = dispatch("code_apply_patch", {"ops": [
-        {"path": "pkg/calc.py", "old": "return a + b\n", "new": "return a + b + 0\n"}],
-        "execute": True}, ctx)
+        {"path": "pkg/calc.py", "old": "return a + b\n", "new": "return a + b + 0\n"}]}, ctx)
     assert "应用" in out or "applied" in out.lower() or "execute" in out.lower()
     assert (root / "pkg" / "calc.py").read_text(encoding="utf-8").endswith("return a + b + 0\n")
 
 
-def test_apply_patch_execute_blocked_in_plan_mode(tmp_path):
+def test_apply_patch_invalid_returns_without_approval(tmp_path, monkeypatch):
+    # 校验失败（old 不匹配）直接返回，不应弹审批、不落盘。
+    root = _repo(tmp_path)
+    def _boom(*a, **k):
+        raise AssertionError("校验失败时不应请求审批")
+    monkeypatch.setattr(permission, "request_intent", _boom)
+    ctx = ToolContext(workspace=str(root))
+    out = dispatch("code_apply_patch", {"ops": [
+        {"path": "pkg/calc.py", "old": "不存在的原文\n", "new": "x\n"}]}, ctx)
+    assert (root / "pkg" / "calc.py").read_text(encoding="utf-8").endswith("return a + b\n")
+    assert out  # 返回了校验诊断
+
+
+def test_apply_patch_blocked_in_plan_mode(tmp_path):
     root = _repo(tmp_path)
     ctx = ToolContext(workspace=str(root), plan_mode=True)
     out = dispatch("code_apply_patch", {"ops": [
-        {"path": "pkg/calc.py", "old": "return a + b\n", "new": "x\n"}], "execute": True}, ctx)
+        {"path": "pkg/calc.py", "old": "return a + b\n", "new": "x\n"}]}, ctx)
     assert "计划模式" in out
     assert (root / "pkg" / "calc.py").read_text(encoding="utf-8").endswith("return a + b\n")
 


### PR DESCRIPTION
真实跑动 `ivyea chat` 写代码任务后定位并修复的三期交互/视觉优化。

## P0 视觉硬伤
- 审批弹窗 diff 不再把 ANSI 当字面量打出乱码，恢复 +绿/-红/@@dim 配色（prompt_toolkit `ANSI` 解析）
- 审批预览改相对路径（不再绝对路径断词换行）
- 工具步数标记 `[1/48.1]` → `[1/48]`（消除"版本号"错觉）

## P1 信息密度
- 知识/skill 注入门控：纯代码任务不再注入亚马逊广告知识卡（污染上下文/烧 token/带偏模型）；广告/通用任务不变
- 工具调用/结果人读化：`edit_file calc.py · 替换 1 处`、结果 `…(+N 行)`，脱敏保留
- 生成 spinner：`生成中 · 12s · ~1.2k tok · Ctrl-C 中断`

## P2 统一写工具（对标 Claude Code / Codex）
- system prompt 决策树：单处→edit_file、新建/重写→write_file、多文件/多处→code_apply_patch
- `code_apply_patch` 改一次性（去 dry-run/execute 两步）：校验→彩色 diff 预览→一次审批→落盘+测试
- 改前必读软护栏（read_paths）
- 不碰 `patch_apply_loop` / `ivyea code` CLI

## 实测 before→after（同一任务）
工具调用 6→3 · 写工具 2→1 · 审批 2→1 · diff 乱码→彩色 · 代码任务广告注入→无

ruff 干净；450 单测全过；pty 端到端复测通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)