### PR TITLE
chat 优化 roadmap 11 项 + P3：对标 Claude Code / Codex（v1.0.30）

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.0.29"
+__version__ = "1.0.30"

--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -15,7 +15,7 @@ from . import config, context, traces, ui
 from .agent_tools import PARALLEL_SAFE, TOOL_SCHEMAS, ToolContext, dispatch_result
 from .providers import LLMProvider
 
-SYSTEM_PROMPT = """你是 Ivyea Agent，一个亚马逊运营助手。专长是广告巡检，也能处理日常运营杂活。
+SYSTEM_PROMPT = """你是 Ivyea Agent：既是资深亚马逊运营专家，也是合格的编码/工程助手——两类任务都是你的一等本职。按用户当前需求自然切换：运营就按运营流程走，写代码就按工程流程走。
 广告：run_patrol(巡检) → propose_actions(看动作) → execute_actions(逐条人工审批执行) → 必要时 rollback。
 通用：read_file/list_dir/web_fetch/web_search 读取信息；write_file/edit_file 产出文件；run_python(可用 pandas/openpyxl 读 Excel、算数)、run_command 执行——这些写/执行操作都会弹人工审批。
 代码：先 grep(内容正则)/glob(按文件名找文件)/code_search(找相关文件)/code_symbols/code_impact 定位，再 read_file 看真实内容（改前必读，别瞎猜路径）。改代码按场景选一个写工具：改单个文件的某一处→edit_file(唯一 old→new)；新建或整体重写文件→write_file；跨多文件/多处关联改动或要顺带跑测试→code_apply_patch(一次提交全部 ops)。每个写工具都是一次调用即审批落盘——**一次逻辑改动只用一个工具，不要先 dry-run 再 execute、也不要同一处既 edit_file 又 code_apply_patch 重复弹审批**。改完测试失败用 run_tests/code_repair 闭环修复。

--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -18,7 +18,7 @@ from .providers import LLMProvider
 SYSTEM_PROMPT = """你是 Ivyea Agent，一个亚马逊运营助手。专长是广告巡检，也能处理日常运营杂活。
 广告：run_patrol(巡检) → propose_actions(看动作) → execute_actions(逐条人工审批执行) → 必要时 rollback。
 通用：read_file/list_dir/web_fetch/web_search 读取信息；write_file/edit_file 产出文件；run_python(可用 pandas/openpyxl 读 Excel、算数)、run_command 执行——这些写/执行操作都会弹人工审批。
-代码：先 grep(内容正则)/code_search(找相关文件)/code_symbols/code_impact 定位，再 read_file 看真实内容（改前必读，别瞎猜路径）。改代码按场景选一个写工具：改单个文件的某一处→edit_file(唯一 old→new)；新建或整体重写文件→write_file；跨多文件/多处关联改动或要顺带跑测试→code_apply_patch(一次提交全部 ops)。每个写工具都是一次调用即审批落盘——**一次逻辑改动只用一个工具，不要先 dry-run 再 execute、也不要同一处既 edit_file 又 code_apply_patch 重复弹审批**。改完测试失败用 run_tests/code_repair 闭环修复。
+代码：先 grep(内容正则)/glob(按文件名找文件)/code_search(找相关文件)/code_symbols/code_impact 定位，再 read_file 看真实内容（改前必读，别瞎猜路径）。改代码按场景选一个写工具：改单个文件的某一处→edit_file(唯一 old→new)；新建或整体重写文件→write_file；跨多文件/多处关联改动或要顺带跑测试→code_apply_patch(一次提交全部 ops)。每个写工具都是一次调用即审批落盘——**一次逻辑改动只用一个工具，不要先 dry-run 再 execute、也不要同一处既 edit_file 又 code_apply_patch 重复弹审批**。改完测试失败用 run_tests/code_repair 闭环修复。
 委派：需要多角度/独立的调研，可用 dispatch_subagent 派只读子 agent 并行查清，避免主线被探索细节塞满。
 MCP：用户接了 MCP 服务器时，用 mcp_list_tools/mcp_list_resources/mcp_list_prompts 发现，mcp_read_resource/mcp_get_prompt 取内容，mcp_call_tool 调用工具（写类会审批）。
 原则：先拿证据再动手；写操作一律经人工审批，绝不自作主张直接写；动作绑数据、简洁可执行；信息不足就澄清，不要瞎编 ASIN/规格/数字。读文件优先用 read_file 看真实内容，不要假设；**大文件读某几行用 read_file 的 offset/limit，别用 run_command/python 分段读**（那会反复弹审批）。"""

--- a/ivyea_agent/agent_tools.py
+++ b/ivyea_agent/agent_tools.py
@@ -526,7 +526,7 @@ _DISPATCH = {
 # 可安全并行的只读工具：纯文件系统/网络读，不弹审批、不写共享状态（DB/索引文件）。
 # 故意保守：DB 检索（knowledge/skill/recall）和会写索引文件的 code_search/symbols/impact
 # 不在此列，避免 SQLite 跨线程或索引文件写竞争。
-PARALLEL_SAFE = {"read_file", "list_dir", "web_fetch", "web_search", "grep"}
+PARALLEL_SAFE = {"read_file", "list_dir", "web_fetch", "web_search", "grep", "glob", "code_search", "code_symbols"}
 
 
 @dataclass

--- a/ivyea_agent/chat_ui.py
+++ b/ivyea_agent/chat_ui.py
@@ -1,0 +1,140 @@
+"""chat 对话模式的纯展示层 helper（从 cli.py 拆出，降低 god-file 体量）。
+
+只含无状态/自包含的工具：域判定、终端宽度、生成 spinner、完整流式打印器。
+不依赖 cli 内部，避免循环导入；颜色码本地定义一份。
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import time
+
+_C = {"g": "\033[32m", "c": "\033[36m", "d": "\033[2m", "b": "\033[1m", "x": "\033[0m"}
+
+
+# 亚马逊广告域信号：命中任一则本轮按广告任务处理，注入内置知识/skill。
+_AMAZON_TERMS = (
+    "广告", "否词", "否定", "竞价", "出价", "bid", "预算", "budget", "acos", "acoas", "roas",
+    "tacos", "asin", "listing", "关键词", "搜索词", "投放", "活动", "campaign", "浪费词",
+    "转化", "点击", "曝光", "ctr", "cpc", "cvr", "店铺", "销量", "库存", "类目", "竞品",
+    "sp广告", "sb广告", "sd广告", "亚马逊", "amazon", "运营", "领星", "lingxing",
+    "sku", "review", "qa", "offer",
+)
+
+
+def _is_amazon_domain(query: str) -> bool:
+    """本轮是否带亚马逊广告/运营域信号。无信号的工程任务据此跳过内置知识注入。"""
+    q = (query or "").lower()
+    return any(t in q for t in _AMAZON_TERMS)
+
+
+# 代码/工程任务信号：源码文件后缀 + 代码语义词。比 engineering_context 的术语表更宽，
+# 用来兜住「给 calc.py 加 docstring」这类不含'优化/bug'但分明是写代码的请求。
+_CODE_HINTS = re.compile(
+    r"\.(py|js|ts|tsx|jsx|go|rs|java|kt|rb|php|cs|cpp|cc|hpp|sh|sql|ya?ml|toml|ini|css|html?|vue)\b"
+    r"|docstring|traceback|stack ?trace|函数|方法|变量|类型|形参|参数列表|报错|异常|栈|仓库|repo\b"
+    r"|分支|commit|merge|pull ?request|\bdef \b|\bclass \b|\bimport \b|编译|断点|单元测试|代码|脚本",
+    re.I,
+)
+
+
+def _looks_like_code_task(query: str) -> bool:
+    """本轮是否是写代码/工程任务（用于决定是否跳过亚马逊知识注入）。"""
+    from . import engineering_context
+    return engineering_context.should_include(query) or bool(_CODE_HINTS.search(query or ""))
+
+
+def _dwidth(s: str) -> int:
+    """终端显示宽度（CJK 全角算 2 格），用于状态行不换行截断。"""
+    return sum(2 if ord(c) > 0x2E7F else 1 for c in s)
+
+
+class _LiveSpinner:
+    """生成时的实时反馈：转圈 + 耗时 + 估算 token + **正在生成的正文末尾预览**（单行 \\r 覆盖，零闪烁）。
+    不打印完整正文，收尾仍统一渲染 markdown。"""
+    _F = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+    def __init__(self):
+        self.i = 0
+        self.on = False
+        self.start = None
+        self.chars = 0
+        self.tail = ""   # 当前行尾的正文预览
+
+    def tick(self, text: str = "") -> None:
+        if self.start is None:
+            self.start = time.time()
+        if text:
+            self.chars += len(text)
+            combined = self.tail + text
+            if "\n" in combined:
+                combined = combined.rsplit("\n", 1)[1]   # 只留最后一行
+            self.tail = combined
+        self.i += 1
+        frame = self._F[self.i % len(self._F)]
+        elapsed = int(time.time() - self.start)
+        toks = self.chars // 3   # 中英混排粗估 ~3 字符/token，仅作进度感
+        tok_s = f"~{toks / 1000:.1f}k tok" if toks >= 1000 else f"~{toks} tok"
+        head = f"生成中 {elapsed}s · {tok_s} · "
+        width = shutil.get_terminal_size((80, 24)).columns
+        avail = width - 2 - _dwidth(head) - 1   # 2=frame+空格，1=余量
+        preview = self.tail.strip()
+        if preview and avail > 6:
+            clipped = False
+            while _dwidth(preview) > avail - 1 and len(preview) > 1:
+                preview = preview[1:]; clipped = True   # 从左裁，保留最新文字
+            body = head + ("…" + preview if clipped else preview)
+        else:
+            body = head + "Ctrl-C 中断"
+        sys.stdout.write(f"\r\033[K{_C['c']}{frame}{_C['x']} {_C['d']}{body}{_C['x']}")
+        sys.stdout.flush()
+        self.on = True
+
+    def clear(self) -> None:
+        if self.on:
+            sys.stdout.write("\r\033[K")
+            sys.stdout.flush()
+            self.on = False
+            self.tail = ""   # 一段叙述/工具行后重置预览
+
+
+class _StreamPrinter:
+    """完整流式：边生成边打印正文（dim），收尾按视觉行数擦除最后一段再渲染 markdown。
+    仅在 tty + /stream on 时启用；任何异常/非 tty 由调用方回退到 spinner 路径。"""
+    def __init__(self):
+        self.block = ""   # 当前连续正文段（被工具行打断即提交清零）
+        self.on = False
+
+    def render(self, text: str = "") -> None:
+        if not text:
+            return
+        sys.stdout.write(f"{_C['d']}{text}{_C['x']}")
+        sys.stdout.flush()
+        self.block += text
+        self.on = True
+
+    def commit(self) -> None:
+        """被 narrate（工具行/提示）打断：保留已打印文本，重置当前段。"""
+        self.block = ""
+
+    @staticmethod
+    def _visual_lines(s: str, width: int) -> int:
+        n = 0
+        for seg in s.split("\n"):
+            w = _dwidth(seg)
+            n += max(1, -(-w // width)) if w else 1
+        return n
+
+    def rerender(self, final_text: str) -> None:
+        """擦除最后一段流式正文，改打印 markdown 渲染版。"""
+        from . import markdown
+        if self.on and self.block:
+            width = shutil.get_terminal_size((80, 24)).columns
+            lines = self._visual_lines(self.block, width)
+            sys.stdout.write("\r")
+            if lines > 1:
+                sys.stdout.write(f"\033[{lines - 1}A")
+            sys.stdout.write("\033[J")
+            sys.stdout.flush()
+        print(f"{_C['c']}●{_C['x']} " + markdown.render(final_text))

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1203,6 +1203,7 @@ SLASH_COMMANDS = [
     ("/compact", "压缩上下文；/compact auto on|off 控制自动压缩"),
     ("/init", "生成账户指令模板 AGENTS.md（长期打法/边界，自动注入）"),
     ("/raw", "切换 Markdown 渲染 / 原始流式输出"),
+    ("/stream", "开关完整流式（边生成边出字、收尾渲染 markdown；默认关）"),
     ("/auto-edit", "开关写操作自动放行（/auto-edit on|off；默认逐次审批）"),
     ("/clear", "清空当前对话上下文"),
     ("/exit", "退出 (亦可 /quit)"),
@@ -1293,6 +1294,47 @@ class _LiveSpinner:
             sys.stdout.flush()
             self.on = False
             self.tail = ""   # 一段叙述/工具行后重置预览
+
+
+class _StreamPrinter:
+    """完整流式：边生成边打印正文（dim），收尾按视觉行数擦除最后一段再渲染 markdown。
+    仅在 tty + /stream on 时启用；任何异常/非 tty 由调用方回退到 spinner 路径。"""
+    def __init__(self):
+        self.block = ""   # 当前连续正文段（被工具行打断即提交清零）
+        self.on = False
+
+    def render(self, text: str = "") -> None:
+        if not text:
+            return
+        sys.stdout.write(f"{_C['d']}{text}{_C['x']}")
+        sys.stdout.flush()
+        self.block += text
+        self.on = True
+
+    def commit(self) -> None:
+        """被 narrate（工具行/提示）打断：保留已打印文本，重置当前段。"""
+        self.block = ""
+
+    @staticmethod
+    def _visual_lines(s: str, width: int) -> int:
+        n = 0
+        for seg in s.split("\n"):
+            w = _dwidth(seg)
+            n += max(1, -(-w // width)) if w else 1
+        return n
+
+    def rerender(self, final_text: str) -> None:
+        """擦除最后一段流式正文，改打印 markdown 渲染版。"""
+        from . import markdown
+        if self.on and self.block:
+            width = shutil.get_terminal_size((80, 24)).columns
+            lines = self._visual_lines(self.block, width)
+            sys.stdout.write("\r")
+            if lines > 1:
+                sys.stdout.write(f"\033[{lines - 1}A")
+            sys.stdout.write("\033[J")
+            sys.stdout.flush()
+        print(f"{_C['c']}●{_C['x']} " + markdown.render(final_text))
 
 
 def _help_text() -> str:
@@ -1422,6 +1464,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         sid = sessions.new_id()
     ctx.session_id = sid
     render_md = not getattr(args, "raw", False)   # 默认 markdown 渲染
+    stream_live = bool(cfg.get_setting("stream_live", False))   # 完整流式（opt-in，/stream on）
 
     def _persist():
         try:
@@ -1506,6 +1549,14 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         if line == "/raw":
             render_md = not render_md
             print(ui.message("success", f"已切换为 {'原始流式' if not render_md else 'Markdown 渲染'} 输出。")); continue
+        if line in ("/stream", "/stream on", "/stream off"):
+            stream_live = (not stream_live) if line == "/stream" else line.endswith(" on")
+            cfg.set_setting("stream_live", stream_live)
+            if stream_live and not sys.stdout.isatty():
+                print(ui.message("warn", "完整流式需要交互终端；当前非 tty，仍用收尾渲染。"))
+            else:
+                print(ui.message("success", f"完整流式已{'开启（边生成边出字，收尾渲染 markdown）' if stream_live else '关闭（用 spinner+流式预览）'}。"))
+            continue
         if line in ("/auto-edit", "/auto-edit on", "/auto-edit off"):
             if line == "/auto-edit":
                 ctx.perm.accept_edits = not ctx.perm.accept_edits
@@ -1686,8 +1737,15 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             mcfg = cfg.get_model_config()
             provider = build_chain(mcfg, api_key, narrate=lambda s: print(s))
             ctx.provider = provider   # 供 dispatch_subagent 跑只读子 agent 用
-            if render_md:
-                # 缓冲 + spinner，收尾渲染 markdown
+            if render_md and stream_live and sys.stdout.isatty():
+                # 完整流式：边生成边打印正文，收尾擦除最后一段改渲染 markdown
+                sp = _StreamPrinter()
+                out = agent_loop.run_turn_stream(
+                    provider, ctx, messages, model=mcfg.get("model", ""),
+                    render=sp.render, narrate=lambda s: (sp.commit(), print(s)))
+                sp.rerender(out["text"])
+            elif render_md:
+                # 缓冲 + spinner（含流式正文预览），收尾渲染 markdown
                 spin = _LiveSpinner()
                 out = agent_loop.run_turn_stream(
                     provider, ctx, messages, model=mcfg.get("model", ""),

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import time
@@ -1194,6 +1195,7 @@ SLASH_COMMANDS = [
     ("/workspace", "项目理解：/workspace map|search|explain"),
     ("/patch", "结构化补丁：/patch make|validate|apply|tests"),
     ("/gitops", "Git 工作流：/gitops status|diff|stage|commit|tag"),
+    ("/diff", "看工作区改动的彩色 diff（/diff staged 看暂存区）"),
     ("/memory", "记忆：状态/最近巡检；/memory <词> 检索"),
     ("/plan", "进入/退出计划模式（只读，不写入）"),
     ("/approve", "批准并退出计划模式，继续执行"),
@@ -1238,8 +1240,14 @@ def _looks_like_code_task(query: str) -> bool:
     return engineering_context.should_include(query) or bool(_CODE_HINTS.search(query or ""))
 
 
+def _dwidth(s: str) -> int:
+    """终端显示宽度（CJK 全角算 2 格），用于状态行不换行截断。"""
+    return sum(2 if ord(c) > 0x2E7F else 1 for c in s)
+
+
 class _LiveSpinner:
-    """生成时的轻量转圈反馈：转圈 + 已耗时 + 估算输出 token + 中断提示（不打印正文，收尾渲染 markdown）。"""
+    """生成时的实时反馈：转圈 + 耗时 + 估算 token + **正在生成的正文末尾预览**（单行 \\r 覆盖，零闪烁）。
+    不打印完整正文，收尾仍统一渲染 markdown。"""
     _F = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
     def __init__(self):
@@ -1247,18 +1255,34 @@ class _LiveSpinner:
         self.on = False
         self.start = None
         self.chars = 0
+        self.tail = ""   # 当前行尾的正文预览
 
     def tick(self, text: str = "") -> None:
         if self.start is None:
             self.start = time.time()
-        self.chars += len(text or "")
+        if text:
+            self.chars += len(text)
+            combined = self.tail + text
+            if "\n" in combined:
+                combined = combined.rsplit("\n", 1)[1]   # 只留最后一行
+            self.tail = combined
         self.i += 1
         frame = self._F[self.i % len(self._F)]
         elapsed = int(time.time() - self.start)
         toks = self.chars // 3   # 中英混排粗估 ~3 字符/token，仅作进度感
-        tok_s = f" · ~{toks / 1000:.1f}k tok" if toks >= 1000 else (f" · ~{toks} tok" if toks else "")
-        # \033[K 清到行尾，避免上一帧更长状态残留
-        sys.stdout.write(f"\r\033[K{_C['c']}{frame}{_C['x']} {_C['d']}生成中 · {elapsed}s{tok_s} · Ctrl-C 中断{_C['x']}")
+        tok_s = f"~{toks / 1000:.1f}k tok" if toks >= 1000 else f"~{toks} tok"
+        head = f"生成中 {elapsed}s · {tok_s} · "
+        width = shutil.get_terminal_size((80, 24)).columns
+        avail = width - 2 - _dwidth(head) - 1   # 2=frame+空格，1=余量
+        preview = self.tail.strip()
+        if preview and avail > 6:
+            clipped = False
+            while _dwidth(preview) > avail - 1 and len(preview) > 1:
+                preview = preview[1:]; clipped = True   # 从左裁，保留最新文字
+            body = head + ("…" + preview if clipped else preview)
+        else:
+            body = head + "Ctrl-C 中断"
+        sys.stdout.write(f"\r\033[K{_C['c']}{frame}{_C['x']} {_C['d']}{body}{_C['x']}")
         sys.stdout.flush()
         self.on = True
 
@@ -1267,6 +1291,7 @@ class _LiveSpinner:
             sys.stdout.write("\r\033[K")
             sys.stdout.flush()
             self.on = False
+            self.tail = ""   # 一段叙述/工具行后重置预览
 
 
 def _help_text() -> str:
@@ -1495,6 +1520,19 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             enabled = line.endswith(" on")
             cfg.set_setting("auto_compact", enabled)
             print(ui.message("success", f"自动压缩已{'开启' if enabled else '关闭'}。手动压缩仍可用 /compact。"))
+            continue
+        if line == "/diff" or line == "/diff staged":
+            from . import git_workflow, panels as _panels
+            staged = line.endswith(" staged")
+            data = git_workflow.unified_diff(os.getcwd(), staged=staged)
+            if not data.get("ok"):
+                print(ui.message("warn", data.get("error", "无法取得 diff")))
+            elif not (data.get("patch") or "").strip():
+                print(ui.message("info", f"{'暂存区' if staged else '工作区'}没有改动。"))
+            else:
+                print(_panels.colorize_patch(data["patch"], color=sys.stdout.isatty()))
+                if data.get("truncated"):
+                    print(ui.message("muted", "（diff 较长已截断，完整看 git diff）"))
             continue
         if line == "/init":
             p = memory.init_agents(str(cfg.IVYEA_DIR / "AGENTS.md"))

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1337,10 +1337,31 @@ class _StreamPrinter:
         print(f"{_C['c']}●{_C['x']} " + markdown.render(final_text))
 
 
+_SLASH_GROUPS = [
+    ("模型 / 配置", ["/model", "/config", "/status", "/mcp"]),
+    ("代码 / 工程", ["/diff", "/workspace", "/patch", "/gitops", "/tools"]),
+    ("会话控制", ["/plan", "/approve", "/auto-edit", "/raw", "/stream", "/compact", "/cost", "/clear"]),
+    ("知识 / 记忆", ["/knowledge", "/skill", "/memory", "/init"]),
+    ("系统", ["/help", "/exit"]),
+]
+_SLASH_ALIASES = {"/h": "/help", "/?": "/help", "/q": "/exit", "/quit": "/exit"}
+
+
 def _help_text() -> str:
-    lines = [f"{_C['b']}斜杠命令{_C['x']}（输入 / 后按 Tab 可补全）："]
-    for cmd, desc in SLASH_COMMANDS:
-        lines.append(f"  {_C['c']}{cmd:<9}{_C['x']} {desc}")
+    desc = dict(SLASH_COMMANDS)
+    lines = [f"{_C['b']}斜杠命令{_C['x']}（输入 / 后按 Tab 可补全；别名 /h /q）："]
+    seen = set()
+    for title, cmds in _SLASH_GROUPS:
+        lines.append(f"{_C['d']}— {title} —{_C['x']}")
+        for cmd in cmds:
+            if cmd in desc:
+                lines.append(f"  {_C['c']}{cmd:<11}{_C['x']} {desc[cmd]}")
+                seen.add(cmd)
+    extra = [(c, d) for c, d in SLASH_COMMANDS if c not in seen]   # 兜底：未归类的也列出
+    if extra:
+        lines.append(f"{_C['d']}— 其它 —{_C['x']}")
+        for cmd, d in extra:
+            lines.append(f"  {_C['c']}{cmd:<11}{_C['x']} {d}")
     from . import commands as _cmds
     custom = _cmds.list_commands()
     if custom:
@@ -1521,6 +1542,8 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             return 0
         if not line:
             continue
+        if line in _SLASH_ALIASES:   # 别名归一（/h→/help、/q→/exit 等）
+            line = _SLASH_ALIASES[line]
         if line in ("/exit", "/quit"):
             print("再见。")
             return 0
@@ -2753,8 +2776,21 @@ from .cli_code import (  # noqa: E402
     _cmd_code, _cmd_codereview, _cmd_gitops, _cmd_patch, _cmd_task, _cmd_workspace)
 
 
+_CLI_GROUPS_EPILOG = """\
+常用命令分组（裸 `ivyea` 直接进对话）：
+  对话 / 模型   chat  model  config  doctor  onboard  serve
+  广告运营      patrol  diagnose  apply  lingxing  audit  action  listing  review  offer  competitor  weekly  alert
+  代码 / 工程   code  patch  codereview  workspace  gitops  task  shadow
+  知识 / 记忆   knowledge  skill  memory  retrieval  profile  scorecard  trace  eval
+  系统 / 其它   mcp  schedule  notify  policy  vision  image  self  runs
+
+`ivyea <命令> -h` 看子命令详情。"""
+
+
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="ivyea", description="Ivyea Agent — 亚马逊运营 CLI Agent")
+    p = argparse.ArgumentParser(prog="ivyea", description="Ivyea Agent — 亚马逊运营 CLI Agent",
+                                epilog=_CLI_GROUPS_EPILOG,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--version", action="version", version=f"ivyea-agent {__version__}")
     # 顶层便捷标志：裸 ivyea 进对话时也能用（见 main 转发）
     p.add_argument("--resume", nargs="?", const=True, help="裸 ivyea：续接会话（留空=最近）")

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1203,6 +1203,7 @@ SLASH_COMMANDS = [
     ("/compact", "压缩上下文；/compact auto on|off 控制自动压缩"),
     ("/init", "生成账户指令模板 AGENTS.md（长期打法/边界，自动注入）"),
     ("/raw", "切换 Markdown 渲染 / 原始流式输出"),
+    ("/auto-edit", "开关写操作自动放行（/auto-edit on|off；默认逐次审批）"),
     ("/clear", "清空当前对话上下文"),
     ("/exit", "退出 (亦可 /quit)"),
 ]
@@ -1452,10 +1453,11 @@ def _cmd_chat(args: argparse.Namespace) -> int:
 
     def _status() -> str:
         plan = "计划模式 · " if ctx.plan_mode else ""
+        auto = "⚡自动放行 · " if ctx.perm.accept_edits else ""
         cost = f"¥{meter.cost:.4f} · " if meter.turns else ""
         cx = f"ctx ~{_ui['ctx'] // 1000}k · " if _ui["ctx"] else ""
         turns = f"{meter.turns} 轮 · " if meter.turns else ""
-        return (f" ivyea · {_label()} · {plan}"
+        return (f" ivyea · {_label()} · {plan}{auto}"
                 f"{'真实写' if args.execute else 'dry-run'} · {turns}{cx}{cost}输入 / 看命令 ")
 
     ci = chat_input.ChatInput(SLASH_COMMANDS, _status)
@@ -1497,6 +1499,17 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         if line == "/raw":
             render_md = not render_md
             print(ui.message("success", f"已切换为 {'原始流式' if not render_md else 'Markdown 渲染'} 输出。")); continue
+        if line in ("/auto-edit", "/auto-edit on", "/auto-edit off"):
+            if line == "/auto-edit":
+                ctx.perm.accept_edits = not ctx.perm.accept_edits
+            else:
+                ctx.perm.accept_edits = line.endswith(" on")
+            if ctx.perm.accept_edits:
+                print(ui.message("warn", "⚡ 自动放行已开：本会话所有写操作不再逐次审批"
+                                         "（计划模式拦截、改前必读仍生效）。/auto-edit off 关闭。"))
+            else:
+                print(ui.message("success", "已关闭自动放行，恢复逐次人工审批。"))
+            continue
         if line == "/compact":
             ak = cfg.get_active_key()
             if not ak:

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1428,8 +1428,9 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             sessions.save(sid, messages, model=cfg.get_model_config().get("model", ""),
                           usage={"cost": meter.cost, "turns": meter.turns,
                                  "prompt": meter.prompt, "completion": meter.completion})
-        except Exception:
-            pass
+        except Exception as e:
+            from . import log
+            log.dbg("chat.persist", f"会话保存失败 sid={sid}: {e!r}")
 
     keyst = _model_key_label(cfg.load_settings())
     mode = "真实写" if args.execute else "dry-run"
@@ -1448,6 +1449,12 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         f"{_C['d']}/ 弹命令菜单 · ↑↓+Enter 选择 · 直接说需求 · /exit 退出{_C['x']}",
     ], width=64)
     print()
+
+    # 主脑健康探测（本地，不发网络）：凭据过期/未配时醒目提示并指明出路，避免“开箱即坏”。
+    _health = cfg.main_brain_health()
+    if not _health.get("ok"):
+        print(ui.message("warn", _health.get("hint", "主脑不可用，请用 /model 切换。")))
+        print()
 
     from . import chat_input
 

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -11,15 +11,15 @@ import argparse
 import getpass
 import json
 import os
-import re
 import shlex
-import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
 
 from . import __version__, config, ui
+# chat 展示层 helper 已拆到 chat_ui.py；re-export 保持 cli.X 引用与既有测试兼容。
+from .chat_ui import _is_amazon_domain, _looks_like_code_task, _LiveSpinner, _StreamPrinter
 
 
 def _ask(prompt: str, default: str = "") -> str:
@@ -1210,133 +1210,6 @@ SLASH_COMMANDS = [
 ]
 
 
-# 亚马逊广告域信号：命中任一则本轮按广告任务处理，注入内置知识/skill。
-_AMAZON_TERMS = (
-    "广告", "否词", "否定", "竞价", "出价", "bid", "预算", "budget", "acos", "acoas", "roas",
-    "tacos", "asin", "listing", "关键词", "搜索词", "投放", "活动", "campaign", "浪费词",
-    "转化", "点击", "曝光", "ctr", "cpc", "cvr", "店铺", "销量", "库存", "类目", "竞品",
-    "sp广告", "sb广告", "sd广告", "亚马逊", "amazon", "运营", "领星", "lingxing",
-    "sku", "review", "qa", "offer",
-)
-
-
-def _is_amazon_domain(query: str) -> bool:
-    """本轮是否带亚马逊广告/运营域信号。无信号的工程任务据此跳过内置知识注入。"""
-    q = (query or "").lower()
-    return any(t in q for t in _AMAZON_TERMS)
-
-
-# 代码/工程任务信号：源码文件后缀 + 代码语义词。比 engineering_context 的术语表更宽，
-# 用来兜住「给 calc.py 加 docstring」这类不含'优化/bug'但分明是写代码的请求。
-_CODE_HINTS = re.compile(
-    r"\.(py|js|ts|tsx|jsx|go|rs|java|kt|rb|php|cs|cpp|cc|hpp|sh|sql|ya?ml|toml|ini|css|html?|vue)\b"
-    r"|docstring|traceback|stack ?trace|函数|方法|变量|类型|形参|参数列表|报错|异常|栈|仓库|repo\b"
-    r"|分支|commit|merge|pull ?request|\bdef \b|\bclass \b|\bimport \b|编译|断点|单元测试|代码|脚本",
-    re.I,
-)
-
-
-def _looks_like_code_task(query: str) -> bool:
-    """本轮是否是写代码/工程任务（用于决定是否跳过亚马逊知识注入）。"""
-    from . import engineering_context
-    return engineering_context.should_include(query) or bool(_CODE_HINTS.search(query or ""))
-
-
-def _dwidth(s: str) -> int:
-    """终端显示宽度（CJK 全角算 2 格），用于状态行不换行截断。"""
-    return sum(2 if ord(c) > 0x2E7F else 1 for c in s)
-
-
-class _LiveSpinner:
-    """生成时的实时反馈：转圈 + 耗时 + 估算 token + **正在生成的正文末尾预览**（单行 \\r 覆盖，零闪烁）。
-    不打印完整正文，收尾仍统一渲染 markdown。"""
-    _F = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
-
-    def __init__(self):
-        self.i = 0
-        self.on = False
-        self.start = None
-        self.chars = 0
-        self.tail = ""   # 当前行尾的正文预览
-
-    def tick(self, text: str = "") -> None:
-        if self.start is None:
-            self.start = time.time()
-        if text:
-            self.chars += len(text)
-            combined = self.tail + text
-            if "\n" in combined:
-                combined = combined.rsplit("\n", 1)[1]   # 只留最后一行
-            self.tail = combined
-        self.i += 1
-        frame = self._F[self.i % len(self._F)]
-        elapsed = int(time.time() - self.start)
-        toks = self.chars // 3   # 中英混排粗估 ~3 字符/token，仅作进度感
-        tok_s = f"~{toks / 1000:.1f}k tok" if toks >= 1000 else f"~{toks} tok"
-        head = f"生成中 {elapsed}s · {tok_s} · "
-        width = shutil.get_terminal_size((80, 24)).columns
-        avail = width - 2 - _dwidth(head) - 1   # 2=frame+空格，1=余量
-        preview = self.tail.strip()
-        if preview and avail > 6:
-            clipped = False
-            while _dwidth(preview) > avail - 1 and len(preview) > 1:
-                preview = preview[1:]; clipped = True   # 从左裁，保留最新文字
-            body = head + ("…" + preview if clipped else preview)
-        else:
-            body = head + "Ctrl-C 中断"
-        sys.stdout.write(f"\r\033[K{_C['c']}{frame}{_C['x']} {_C['d']}{body}{_C['x']}")
-        sys.stdout.flush()
-        self.on = True
-
-    def clear(self) -> None:
-        if self.on:
-            sys.stdout.write("\r\033[K")
-            sys.stdout.flush()
-            self.on = False
-            self.tail = ""   # 一段叙述/工具行后重置预览
-
-
-class _StreamPrinter:
-    """完整流式：边生成边打印正文（dim），收尾按视觉行数擦除最后一段再渲染 markdown。
-    仅在 tty + /stream on 时启用；任何异常/非 tty 由调用方回退到 spinner 路径。"""
-    def __init__(self):
-        self.block = ""   # 当前连续正文段（被工具行打断即提交清零）
-        self.on = False
-
-    def render(self, text: str = "") -> None:
-        if not text:
-            return
-        sys.stdout.write(f"{_C['d']}{text}{_C['x']}")
-        sys.stdout.flush()
-        self.block += text
-        self.on = True
-
-    def commit(self) -> None:
-        """被 narrate（工具行/提示）打断：保留已打印文本，重置当前段。"""
-        self.block = ""
-
-    @staticmethod
-    def _visual_lines(s: str, width: int) -> int:
-        n = 0
-        for seg in s.split("\n"):
-            w = _dwidth(seg)
-            n += max(1, -(-w // width)) if w else 1
-        return n
-
-    def rerender(self, final_text: str) -> None:
-        """擦除最后一段流式正文，改打印 markdown 渲染版。"""
-        from . import markdown
-        if self.on and self.block:
-            width = shutil.get_terminal_size((80, 24)).columns
-            lines = self._visual_lines(self.block, width)
-            sys.stdout.write("\r")
-            if lines > 1:
-                sys.stdout.write(f"\033[{lines - 1}A")
-            sys.stdout.write("\033[J")
-            sys.stdout.flush()
-        print(f"{_C['c']}●{_C['x']} " + markdown.render(final_text))
-
-
 _SLASH_GROUPS = [
     ("模型 / 配置", ["/model", "/config", "/status", "/mcp"]),
     ("代码 / 工程", ["/diff", "/workspace", "/patch", "/gitops", "/tools"]),
@@ -1535,6 +1408,183 @@ def _cmd_chat(args: argparse.Namespace) -> int:
     from . import hooks as _hooks
     _hooks.fire("session_start", {"session_id": sid or "", "cwd": os.getcwd()})
 
+    # ── slash 命令注册表（替代旧的 25 分支 if 链；handler 返回 True=已处理→continue）──
+    def _sh_help(line):
+        print(_help_text()); return True
+
+    def _sh_clear(line):
+        nonlocal messages
+        messages = [_sys_msg()]
+        print(ui.message("success", "已清空对话上下文")); return True
+
+    def _sh_plan(line):
+        ctx.plan_mode = not ctx.plan_mode
+        messages[0] = _sys_msg()
+        print(ui.message("info", "已进入计划模式（只读，不写入；/approve 批准后执行）。") if ctx.plan_mode
+              else ui.message("success", "已退出计划模式。")); return True
+
+    def _sh_approve(line):
+        if ctx.plan_mode:
+            ctx.plan_mode = False
+            messages[0] = _sys_msg()
+            print(ui.message("success", "已批准，退出计划模式。说“继续/执行”让我落地计划。"))
+        else:
+            print(ui.message("warn", "当前不在计划模式。"))
+        return True
+
+    def _sh_cost(line):
+        lim = pricing.daily_limit()
+        tail = f" · 今日 ¥{pricing.today_spend():.4f}" + (f"/¥{lim:.2f} 上限" if lim > 0 else "（无上限，可 config set daily_cost_limit_cny）")
+        print((meter.summary() if meter.turns else "本会话还没有模型调用。") + tail); return True
+
+    def _sh_raw(line):
+        nonlocal render_md
+        render_md = not render_md
+        print(ui.message("success", f"已切换为 {'原始流式' if not render_md else 'Markdown 渲染'} 输出。")); return True
+
+    def _sh_stream(line):
+        nonlocal stream_live
+        stream_live = (not stream_live) if line == "/stream" else line.endswith(" on")
+        cfg.set_setting("stream_live", stream_live)
+        if stream_live and not sys.stdout.isatty():
+            print(ui.message("warn", "完整流式需要交互终端；当前非 tty，仍用收尾渲染。"))
+        else:
+            print(ui.message("success", f"完整流式已{'开启（边生成边出字，收尾渲染 markdown）' if stream_live else '关闭（用 spinner+流式预览）'}。"))
+        return True
+
+    def _sh_auto_edit(line):
+        if line == "/auto-edit":
+            ctx.perm.accept_edits = not ctx.perm.accept_edits
+        else:
+            ctx.perm.accept_edits = line.endswith(" on")
+        if ctx.perm.accept_edits:
+            print(ui.message("warn", "⚡ 自动放行已开：本会话所有写操作不再逐次审批"
+                                     "（计划模式拦截、改前必读仍生效）。/auto-edit off 关闭。"))
+        else:
+            print(ui.message("success", "已关闭自动放行，恢复逐次人工审批。"))
+        return True
+
+    def _sh_compact(line):
+        nonlocal messages
+        if line in ("/compact auto", "/compact auto status"):
+            state = "开启" if bool(cfg.get_setting("auto_compact", False)) else "关闭"
+            th = int(cfg.get_setting("compact_at_tokens", ctx_mod.DEFAULT_COMPACT_AT))
+            print(ui.message("info", f"自动压缩：{state} · 阈值 {th} prompt tokens")); return True
+        if line in ("/compact auto on", "/compact auto off"):
+            enabled = line.endswith(" on")
+            cfg.set_setting("auto_compact", enabled)
+            print(ui.message("success", f"自动压缩已{'开启' if enabled else '关闭'}。手动压缩仍可用 /compact。")); return True
+        ak = cfg.get_active_key()
+        if not ak:
+            print(ui.message("warn", "未配 key，无法压缩。")); return True
+        before = sum(len(str(m.get('content') or '')) for m in messages)
+        provider = from_settings(cfg.get_model_config(), ak)
+        messages, summary = ctx_mod.compact(messages, provider)
+        after = sum(len(str(m.get('content') or '')) for m in messages)
+        if summary:
+            memory.remember_summary(summary, sid)
+        _persist()
+        print(ui.message("success", f"已压缩上下文（约 {before}→{after} 字），摘要已入库。") if summary
+              else ui.message("info", "上下文较短，无需压缩。"))
+        return True
+
+    def _sh_diff(line):
+        from . import git_workflow, panels as _panels
+        staged = line.endswith(" staged")
+        data = git_workflow.unified_diff(os.getcwd(), staged=staged)
+        if not data.get("ok"):
+            print(ui.message("warn", data.get("error", "无法取得 diff")))
+        elif not (data.get("patch") or "").strip():
+            print(ui.message("info", f"{'暂存区' if staged else '工作区'}没有改动。"))
+        else:
+            print(_panels.colorize_patch(data["patch"], color=sys.stdout.isatty()))
+            if data.get("truncated"):
+                print(ui.message("muted", "（diff 较长已截断，完整看 git diff）"))
+        return True
+
+    def _sh_init(line):
+        nonlocal instructions
+        p = memory.init_agents(str(cfg.IVYEA_DIR / "AGENTS.md"))
+        if p[0]:
+            print(ui.message("success", f"已生成账户指令模板：{p[1]}"))
+            print(ui.message("info", "填好后重开对话即自动注入。"))
+        else:
+            print(ui.message("info", f"已存在：{p[1]}（未覆盖）。`ivyea config edit` 或直接编辑它。"))
+        instructions = memory.load_instructions(os.getcwd())
+        messages[0] = _sys_msg()
+        return True
+
+    def _sh_mcp(line):
+        servers = cfg.load_mcp().get("mcpServers", {})
+        print("MCP 服务器: " + (", ".join(servers) if servers else "(无，ivyea mcp add)")); return True
+
+    def _sh_knowledge(line):
+        from . import knowledge
+        q = line[10:].strip() if line.startswith("/knowledge ") else ""
+        if not q:
+            print("用法：/knowledge <关键词>，例如 /knowledge 否词")
+        else:
+            print(knowledge.render_search(q, limit=5))
+        return True
+
+    def _sh_skill(line):
+        from . import skills
+        q = line[7:].strip() if line.startswith("/skill ") else ""
+        print(skills.render_list() if not q else skills.render_search(q, limit=8)); return True
+
+    def _sh_embedded(line):
+        _run_embedded_cli(line); return True
+
+    def _sh_tools(line):
+        for t in agent_tools.TOOL_SCHEMAS:
+            f = t["function"]; print(f"  {f['name']} — {f['description']}")
+        return True
+
+    def _sh_memory(line):
+        from . import memory
+        q = line[7:].strip() if line.startswith("/memory ") else ""
+        if q:
+            hits = memory.search(q, limit=10)
+            print("\n".join(f"  · {h['text']}" for h in hits) or "（无匹配记忆）")
+        else:
+            st = memory.stats()
+            print(f"记忆：决策 {st['decisions']}（批准{st['approved']}/否决{st['rejected']}）· "
+                  f"巡检 {st['runs']} 次 · FTS5={'on' if st['fts'] else 'off(LIKE)'}")
+            for r in memory.recent_runs(limit=5):
+                import time as _t
+                print(f"  · {_t.strftime('%m-%d %H:%M', _t.localtime(r['ts']))} {r['asin']} "
+                      f"否{r['negatives']}/放{r['scale']}/降{r['reduce']}")
+            print(f"  {_C['d']}/memory <关键词> 检索；对话里也可让我 记住/回忆{_C['x']}")
+        return True
+
+    def _sh_status(line):
+        _print_config(); return True
+
+    def _sh_config(line):
+        _config_wizard(); return True
+
+    def _sh_model(line):
+        if line == "/model":
+            _model_picker(); return True
+        mid = line.split(None, 1)[1].strip()
+        m = __import__("ivyea_agent.models", fromlist=["by_id"]).by_id(mid)
+        if m:
+            cfg.apply_model(m)
+            print(f"已切换主脑: {m['label']}（{'已配 key' if cfg.get_active_key() else '未配 key，用 /model 配置'}）")
+        else:
+            print(ui.message("warn", f"未知模型 id：{mid}。用 /model 看清单。"))
+        return True
+
+    _SLASH_HANDLERS = {
+        "/help": _sh_help, "/": _sh_help, "/?": _sh_help,
+        "/clear": _sh_clear, "/plan": _sh_plan, "/approve": _sh_approve, "/cost": _sh_cost,
+        "/raw": _sh_raw, "/stream": _sh_stream, "/auto-edit": _sh_auto_edit, "/compact": _sh_compact,
+        "/diff": _sh_diff, "/init": _sh_init, "/mcp": _sh_mcp, "/knowledge": _sh_knowledge,
+        "/skill": _sh_skill, "/tools": _sh_tools, "/memory": _sh_memory, "/status": _sh_status,
+        "/config": _sh_config, "/model": _sh_model,
+        "/workspace": _sh_embedded, "/patch": _sh_embedded, "/gitops": _sh_embedded,
+    }
+
     while True:
         line = ci.read("❯ ")
         if line is chat_input.EXIT:
@@ -1547,158 +1597,10 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         if line in ("/exit", "/quit"):
             print("再见。")
             return 0
-        if line in ("/help", "/", "/?"):
-            print(_help_text()); continue
-        if line == "/clear":
-            messages = [_sys_msg()]
-            print(ui.message("success", "已清空对话上下文")); continue
-        if line == "/plan":
-            ctx.plan_mode = not ctx.plan_mode
-            messages[0] = _sys_msg()
-            print(ui.message("info", "已进入计划模式（只读，不写入；/approve 批准后执行）。") if ctx.plan_mode
-                  else ui.message("success", "已退出计划模式。")); continue
-        if line == "/approve":
-            if ctx.plan_mode:
-                ctx.plan_mode = False
-                messages[0] = _sys_msg()
-                print(ui.message("success", "已批准，退出计划模式。说“继续/执行”让我落地计划。"))
-            else:
-                print(ui.message("warn", "当前不在计划模式。"))
-            continue
-        if line == "/cost":
-            lim = pricing.daily_limit()
-            tail = f" · 今日 ¥{pricing.today_spend():.4f}" + (f"/¥{lim:.2f} 上限" if lim > 0 else "（无上限，可 config set daily_cost_limit_cny）")
-            print((meter.summary() if meter.turns else "本会话还没有模型调用。") + tail); continue
-        if line == "/raw":
-            render_md = not render_md
-            print(ui.message("success", f"已切换为 {'原始流式' if not render_md else 'Markdown 渲染'} 输出。")); continue
-        if line in ("/stream", "/stream on", "/stream off"):
-            stream_live = (not stream_live) if line == "/stream" else line.endswith(" on")
-            cfg.set_setting("stream_live", stream_live)
-            if stream_live and not sys.stdout.isatty():
-                print(ui.message("warn", "完整流式需要交互终端；当前非 tty，仍用收尾渲染。"))
-            else:
-                print(ui.message("success", f"完整流式已{'开启（边生成边出字，收尾渲染 markdown）' if stream_live else '关闭（用 spinner+流式预览）'}。"))
-            continue
-        if line in ("/auto-edit", "/auto-edit on", "/auto-edit off"):
-            if line == "/auto-edit":
-                ctx.perm.accept_edits = not ctx.perm.accept_edits
-            else:
-                ctx.perm.accept_edits = line.endswith(" on")
-            if ctx.perm.accept_edits:
-                print(ui.message("warn", "⚡ 自动放行已开：本会话所有写操作不再逐次审批"
-                                         "（计划模式拦截、改前必读仍生效）。/auto-edit off 关闭。"))
-            else:
-                print(ui.message("success", "已关闭自动放行，恢复逐次人工审批。"))
-            continue
-        if line == "/compact":
-            ak = cfg.get_active_key()
-            if not ak:
-                print(ui.message("warn", "未配 key，无法压缩。")); continue
-            before = sum(len(str(m.get('content') or '')) for m in messages)
-            provider = from_settings(cfg.get_model_config(), ak)
-            messages, summary = ctx_mod.compact(messages, provider)
-            after = sum(len(str(m.get('content') or '')) for m in messages)
-            if summary:
-                memory.remember_summary(summary, sid)
-            _persist()
-            print(ui.message("success", f"已压缩上下文（约 {before}→{after} 字），摘要已入库。") if summary
-                  else ui.message("info", "上下文较短，无需压缩。"))
-            continue
-        if line in ("/compact auto", "/compact auto status"):
-            state = "开启" if bool(cfg.get_setting("auto_compact", False)) else "关闭"
-            th = int(cfg.get_setting("compact_at_tokens", ctx_mod.DEFAULT_COMPACT_AT))
-            print(ui.message("info", f"自动压缩：{state} · 阈值 {th} prompt tokens"))
-            continue
-        if line in ("/compact auto on", "/compact auto off"):
-            enabled = line.endswith(" on")
-            cfg.set_setting("auto_compact", enabled)
-            print(ui.message("success", f"自动压缩已{'开启' if enabled else '关闭'}。手动压缩仍可用 /compact。"))
-            continue
-        if line == "/diff" or line == "/diff staged":
-            from . import git_workflow, panels as _panels
-            staged = line.endswith(" staged")
-            data = git_workflow.unified_diff(os.getcwd(), staged=staged)
-            if not data.get("ok"):
-                print(ui.message("warn", data.get("error", "无法取得 diff")))
-            elif not (data.get("patch") or "").strip():
-                print(ui.message("info", f"{'暂存区' if staged else '工作区'}没有改动。"))
-            else:
-                print(_panels.colorize_patch(data["patch"], color=sys.stdout.isatty()))
-                if data.get("truncated"):
-                    print(ui.message("muted", "（diff 较长已截断，完整看 git diff）"))
-            continue
-        if line == "/init":
-            p = memory.init_agents(str(cfg.IVYEA_DIR / "AGENTS.md"))
-            if p[0]:
-                print(ui.message("success", f"已生成账户指令模板：{p[1]}"))
-                print(ui.message("info", "填好后重开对话即自动注入。"))
-            else:
-                print(ui.message("info", f"已存在：{p[1]}（未覆盖）。`ivyea config edit` 或直接编辑它。"))
-            instructions = memory.load_instructions(os.getcwd())
-            messages[0] = _sys_msg()
-            continue
-        if line == "/mcp":
-            servers = cfg.load_mcp().get("mcpServers", {})
-            print("MCP 服务器: " + (", ".join(servers) if servers else "(无，ivyea mcp add)")); continue
-        if line == "/knowledge" or line.startswith("/knowledge "):
-            from . import knowledge
-            q = line[10:].strip() if line.startswith("/knowledge ") else ""
-            if not q:
-                print("用法：/knowledge <关键词>，例如 /knowledge 否词")
-            else:
-                print(knowledge.render_search(q, limit=5))
-            continue
-        if line == "/skill" or line.startswith("/skill "):
-            from . import skills
-            q = line[7:].strip() if line.startswith("/skill ") else ""
-            if not q:
-                print(skills.render_list())
-            else:
-                print(skills.render_search(q, limit=8))
-            continue
-        if (
-            line == "/workspace" or line.startswith("/workspace ")
-            or line == "/patch" or line.startswith("/patch ")
-            or line == "/gitops" or line.startswith("/gitops ")
-        ):
-            _run_embedded_cli(line)
-            continue
-        if line == "/tools":
-            for t in agent_tools.TOOL_SCHEMAS:
-                f = t["function"]; print(f"  {f['name']} — {f['description']}")
-            continue
-        if line == "/memory" or line.startswith("/memory "):
-            from . import memory
-            q = line[7:].strip() if line.startswith("/memory ") else ""
-            if q:
-                hits = memory.search(q, limit=10)
-                print("\n".join(f"  · {h['text']}" for h in hits) or "（无匹配记忆）")
-            else:
-                st = memory.stats()
-                print(f"记忆：决策 {st['decisions']}（批准{st['approved']}/否决{st['rejected']}）· "
-                      f"巡检 {st['runs']} 次 · FTS5={'on' if st['fts'] else 'off(LIKE)'}")
-                for r in memory.recent_runs(limit=5):
-                    import time as _t
-                    print(f"  · {_t.strftime('%m-%d %H:%M', _t.localtime(r['ts']))} {r['asin']} "
-                          f"否{r['negatives']}/放{r['scale']}/降{r['reduce']}")
-                print(f"  {_C['d']}/memory <关键词> 检索；对话里也可让我 记住/回忆{_C['x']}")
-            continue
-        if line == "/status":
-            _print_config(); continue
-        if line in ("/config", "/model"):
-            _model_picker() if line == "/model" else _config_wizard()
-            continue
-        if line.startswith("/model "):  # /model <id> 直接切
-            mid = line.split(None, 1)[1].strip()
-            m = __import__("ivyea_agent.models", fromlist=["by_id"]).by_id(mid)
-            if m:
-                cfg.apply_model(m)
-                print(f"已切换主脑: {m['label']}（{'已配 key' if cfg.get_active_key() else '未配 key，用 /model 配置'}）")
-            else:
-                print(ui.message("warn", f"未知模型 id：{mid}。用 /model 看清单。"))
-            continue
-        if line.startswith("/"):
+        _handler = _SLASH_HANDLERS.get(line.split()[0])
+        if _handler is not None:
+            _handler(line); continue
+        if line.startswith("/"):   # 自定义命令展开（展开后贯穿到模型轮）/ 未知命令
             from . import commands as _cmds
             _head = line.split()[0]
             _expanded = _cmds.expand(_head[1:], line[len(_head):].strip())

--- a/ivyea_agent/config.py
+++ b/ivyea_agent/config.py
@@ -136,6 +136,27 @@ def get_active_key() -> str:
     return ""
 
 
+def main_brain_health() -> dict[str, Any]:
+    """本地判断主脑可用性（不发网络请求）。返回 {ok, status, label, hint}。"""
+    s = load_settings()
+    auth = (s.get("auth_type") or "api_key").lower()
+    pid = str(s.get("provider_id") or s.get("provider") or "")
+    label = s.get("label") or pid or "主脑"
+    if auth in ("oauth_external", "oauth_device_code"):
+        from . import oauth_auth
+        st = oauth_auth.token_status(pid)
+        if st in ("not-authenticated", "expired"):
+            how = "已过期" if st == "expired" else "未认证"
+            return {"ok": False, "status": st, "label": label,
+                    "hint": f"主脑 {label} 凭据{how}：`ivyea model {pid} --login`（或 --device-code）"
+                            f"重新登录，或 /model 切换其它主脑。"}
+        return {"ok": True, "status": st, "label": label, "hint": ""}
+    if bool(get_active_key()):
+        return {"ok": True, "status": "key", "label": label, "hint": ""}
+    return {"ok": False, "status": "no-key", "label": label,
+            "hint": f"主脑 {label} 未配 key：/model 配置或切换其它主脑。"}
+
+
 def apply_model(entry: dict[str, Any], model: str = "", base_url: str = "") -> None:
     """把 models.py 的一个条目（或自定义）写入 settings。"""
     s = load_settings()

--- a/ivyea_agent/doctor.py
+++ b/ivyea_agent/doctor.py
@@ -67,11 +67,11 @@ def _data_dir() -> Check:
 def _model() -> Check:
     s = config.get_model_config()
     key_env = s.get("key_env") or ""
-    has_key = bool(config.get_active_key())
     detail = f"{s.get('label')} · {s.get('model')} · {key_env}"
-    if not has_key:
-        return Check("模型配置", "warn", detail + "，key 未配置", "运行 `ivyea model` 配置 API key")
-    return Check("模型配置", "ok", detail + "，key 已配置")
+    health = config.main_brain_health()   # 含 oauth 凭据过期判断
+    if not health.get("ok"):
+        return Check("模型配置", "warn", detail + f"，{health.get('status')}", health.get("hint", "运行 `ivyea model` 配置/切换"))
+    return Check("模型配置", "ok", detail + "，主脑可用")
 
 
 def _knowledge() -> Check:

--- a/ivyea_agent/engineering_context.py
+++ b/ivyea_agent/engineering_context.py
@@ -22,9 +22,12 @@ def should_include(query: str) -> bool:
     return bool(re.search(r"\b(test|release|deploy|install|upgrade|bug|fix|refactor|workspace|skill|patch)\b", q))
 
 
-def build(root: str | Path = ".", query: str = "", max_chars: int = 2200) -> str:
-    if not should_include(query):
-        return ""
+# 昂贵的 [workspace]+[skills] 段按 (root, git head, clean) 缓存——结构在同一提交/工作树
+# 状态下不变，避免每个代码轮都重跑 project_inspect 的文件遍历。[git] 段始终新鲜重算。
+_STATIC_CACHE: dict = {}
+
+
+def _static_sections(root: str | Path) -> list[str]:
     parts: list[str] = []
     try:
         inspected = workspace.project_inspect(root)
@@ -43,18 +46,6 @@ def build(root: str | Path = ".", query: str = "", max_chars: int = 2200) -> str
             parts.append("suggested_commands: " + ", ".join(str(c) for c in commands[:6]))
     except (OSError, ValueError, RuntimeError, KeyError, TypeError) as e:
         parts.append(f"[workspace] unavailable: {e}")
-
-    try:
-        st = git_workflow.status(root)
-        if st.get("ok"):
-            changes = st.get("changes") or []
-            parts.append("[git]")
-            parts.append(f"branch={st.get('branch')} head={st.get('head')} clean={st.get('clean')}")
-            if changes:
-                parts.append("changes: " + ", ".join(str(c) for c in changes[:10]))
-    except (OSError, ValueError, RuntimeError, KeyError, TypeError) as e:
-        parts.append(f"[git] unavailable: {e}")
-
     try:
         rows = skills.status()
         warn = [r for r in rows if not r.get("ok")]
@@ -64,6 +55,33 @@ def build(root: str | Path = ".", query: str = "", max_chars: int = 2200) -> str
             parts.append("warnings: " + ", ".join(f"{r['id']}:{','.join(r['issues'][:2])}" for r in warn[:6]))
     except (OSError, ValueError, RuntimeError, KeyError, TypeError) as e:
         parts.append(f"[skills] unavailable: {e}")
+    return parts
+
+
+def build(root: str | Path = ".", query: str = "", max_chars: int = 2200) -> str:
+    if not should_include(query):
+        return ""
+    try:
+        st = git_workflow.status(root)
+    except (OSError, ValueError, RuntimeError, KeyError, TypeError):
+        st = {}
+
+    key = (str(Path(root).resolve()), st.get("head"), st.get("clean")) if st.get("ok") else None
+    if key is not None and key in _STATIC_CACHE:
+        parts = list(_STATIC_CACHE[key])
+    else:
+        parts = _static_sections(root)
+        if key is not None:
+            if len(_STATIC_CACHE) > 32:
+                _STATIC_CACHE.clear()
+            _STATIC_CACHE[key] = list(parts)
+
+    if st.get("ok"):   # [git] 段始终新鲜
+        changes = st.get("changes") or []
+        parts.append("[git]")
+        parts.append(f"branch={st.get('branch')} head={st.get('head')} clean={st.get('clean')}")
+        if changes:
+            parts.append("changes: " + ", ".join(str(c) for c in changes[:10]))
 
     text = "\n".join(parts).strip()
     if len(text) > max_chars:

--- a/ivyea_agent/git_workflow.py
+++ b/ivyea_agent/git_workflow.py
@@ -76,6 +76,20 @@ def diff_summary(root: str | Path = ".", staged: bool = False, max_files: int = 
     return {"ok": True, "root": str(r), "staged": staged, "stat": stat, "files": files}
 
 
+def unified_diff(root: str | Path = ".", staged: bool = False, max_lines: int = 500) -> dict[str, Any]:
+    """工作区(或 staged)的统一 diff 原文，供 /diff 上色展示。"""
+    r = repo_root(root)
+    if not r:
+        return {"ok": False, "error": "不是 Git 仓库"}
+    args = ["diff"] + (["--cached"] if staged else [])
+    _, patch = _run_git(r, args)
+    lines = patch.splitlines()
+    truncated = len(lines) > max_lines
+    if truncated:
+        patch = "\n".join(lines[:max_lines])
+    return {"ok": True, "root": str(r), "staged": staged, "patch": patch, "truncated": truncated}
+
+
 def workflows(root: str | Path = ".") -> list[dict[str, str]]:
     r = repo_root(root) or Path(root).expanduser().resolve()
     wf_dir = r / ".github" / "workflows"

--- a/ivyea_agent/log.py
+++ b/ivyea_agent/log.py
@@ -1,0 +1,34 @@
+"""极轻量 debug 日志：仅在 IVYEA_DEBUG 环境变量或 config debug=true 时落盘，否则 no-op。
+
+给那些过去 `except ...: pass` 静默吞错的地方一个去处——平时零开销/零噪声，
+排障时 `IVYEA_DEBUG=1 ivyea ...` 即可在 ~/.ivyea/logs/agent.log 看到真实失败。
+"""
+from __future__ import annotations
+
+import os
+import time
+
+
+def enabled() -> bool:
+    if os.environ.get("IVYEA_DEBUG"):
+        return True
+    try:
+        from . import config
+        return bool(config.get_setting("debug", False))
+    except Exception:
+        return False
+
+
+def dbg(scope: str, msg: str) -> None:
+    """记一条 debug 日志（仅在开启时）。绝不抛出，绝不影响主流程。"""
+    if not enabled():
+        return
+    try:
+        from . import config
+        d = config.IVYEA_DIR / "logs"
+        d.mkdir(parents=True, exist_ok=True)
+        line = f"{time.strftime('%Y-%m-%d %H:%M:%S')} [{scope}] {msg}\n"
+        with (d / "agent.log").open("a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception:
+        pass

--- a/ivyea_agent/memory.py
+++ b/ivyea_agent/memory.py
@@ -192,8 +192,9 @@ def load_instructions(cwd: str = "", limit: int = 6000) -> str:
                 t = p.read_text(encoding="utf-8").strip()
                 if t:
                     parts.append(f"# {p.name}\n{t}")
-        except Exception:
-            pass
+        except Exception as e:
+            from . import log
+            log.dbg("memory.instructions", f"读取 {p} 失败: {e!r}")
     return "\n\n".join(parts)[:limit]
 
 

--- a/ivyea_agent/panels.py
+++ b/ivyea_agent/panels.py
@@ -43,6 +43,27 @@ def render_todos(todos: list, *, color: bool = True) -> str:
     return "\n".join(lines)
 
 
+def colorize_patch(patch: str, *, color: bool = True) -> str:
+    """给一段 git 统一 diff 文本上色（绿增/红删/dim hunk头/青文件头）。用于 /diff 等。"""
+    if not patch.strip():
+        return ""
+    out = []
+    for ln in patch.splitlines():
+        if not color:
+            out.append(ln)
+        elif ln.startswith("diff --git") or ln.startswith(("+++", "---")):
+            out.append(f"{_CYAN}{ln}{_X}")
+        elif ln.startswith("@@"):
+            out.append(f"{_DIM}{ln}{_X}")
+        elif ln.startswith("+"):
+            out.append(f"{_GREEN}{ln}{_X}")
+        elif ln.startswith("-"):
+            out.append(f"{_RED}{ln}{_X}")
+        else:
+            out.append(ln)
+    return "\n".join(out)
+
+
 def render_diff(old: str, new: str, path: str = "", *, color: bool = True, context: int = 2) -> str:
     """old→new 的彩色统一 diff（红删/绿增）。"""
     if old == new:

--- a/ivyea_agent/permission.py
+++ b/ivyea_agent/permission.py
@@ -19,6 +19,7 @@ class PermissionState:
     """一次会话/一次 apply 内的审批状态。"""
     session_allow: set = field(default_factory=set)   # 本会话已"允许此类"的动作 kind
     aborted: bool = False
+    accept_edits: bool = False                         # opt-in：本会话所有写操作自动放行（/auto-edit on）
 
 
 def preview(a: Action) -> str:
@@ -43,7 +44,7 @@ def request(a: Action, state: PermissionState,
     会就地处理「本会话都允许此类」与「改一下」(改幅度/否定匹配)。"""
     if state.aborted:
         return ABORT
-    if a.kind in state.session_allow:
+    if state.accept_edits or a.kind in state.session_allow:
         return APPROVE
 
     options = [("approve", "批准本次"), ("session", "本会话同类都批准"),
@@ -74,7 +75,7 @@ def request_intent(intent: dict, preview_text: str, state: PermissionState,
     if state.aborted:
         return ABORT
     op_type = intent.get("op_type", "")
-    if op_type in state.session_allow:
+    if state.accept_edits or op_type in state.session_allow:
         return APPROVE
     has_edit = edit_fn is not None
     options = [("approve", "批准本次"), ("session", "本会话同类都批准"), ("deny", "拒绝")]

--- a/ivyea_agent/policy.py
+++ b/ivyea_agent/policy.py
@@ -129,6 +129,33 @@ def check_command(command: str) -> tuple[bool, str]:
     return True, ""
 
 
+# 明确只读、无副作用的命令头（用于自动放行，省去逐次审批）。
+_READONLY_HEADS = {
+    "ls", "cat", "pwd", "head", "tail", "wc", "which", "echo", "printf", "date", "tree",
+    "stat", "file", "du", "df", "whoami", "hostname", "uname", "basename", "dirname",
+    "realpath", "nl", "sort", "uniq", "cut", "grep", "rg", "env", "printenv",
+}
+# git 的恒只读子命令（branch/tag/remote/stash/config 有写形式，故排除）。
+_READONLY_GIT = {
+    "status", "diff", "log", "show", "ls-files", "rev-parse", "describe",
+    "blame", "shortlog", "cat-file", "name-rev", "whatchanged",
+}
+# 任一写/链式元字符出现就不自动放行（重定向/管道/串联/命令替换）。
+_WRITE_META_RE = re.compile(r"[>|;&`<]|\$\(")
+
+
+def is_readonly_command(command: str) -> bool:
+    """是否为明确只读、可自动放行的 shell 命令（保守：含任何写/链式元字符即否）。"""
+    cmd = _norm_cmd(command)
+    if not cmd or _WRITE_META_RE.search(cmd):
+        return False
+    parts = cmd.split()
+    head = parts[0]
+    if head == "git":
+        return len(parts) >= 2 and parts[1] in _READONLY_GIT
+    return head in _READONLY_HEADS
+
+
 def assess_command(command: str) -> dict[str, Any]:
     """Return allow/deny and a coarse risk level for a shell command."""
     cmd = _norm_cmd(command)

--- a/ivyea_agent/tools_general.py
+++ b/ivyea_agent/tools_general.py
@@ -50,14 +50,16 @@ def _disp(p) -> str:
         return str(p)
 
 
-def _read_nudge(ctx, paths) -> str:
-    """改前必读软护栏：列出本会话未 read_file 过的目标文件，返回温和提示行（不阻断）。"""
+def _require_read(ctx, paths) -> str:
+    """改前必读硬护栏（对标 Claude Code）：本会话未 read_file 过的已存在目标文件，
+    直接挡回让模型先读。返回空串=放行；非空=应直接 return 的错误信息。"""
     read = getattr(ctx, "read_paths", None) or set()
     unread = [p for p in paths if str(p) not in read and Path(p).exists()]
     if not unread:
         return ""
     names = "、".join(_disp(p) for p in unread)
-    return f"⚠ 本会话未读过 {names}，建议先 read_file 核对再改\n"
+    return (f"已拦截：本会话还没 read_file 过 {names}，不能盲改。"
+            f"请先 read_file 看真实内容、确认 old 唯一匹配，再重试本次编辑。")
 
 
 def _gate(ctx, kind: str, preview: str) -> tuple[bool, str]:
@@ -268,8 +270,11 @@ def t_code_apply_patch(args: dict, ctx) -> str:
     validation = patcher.validate_spec(spec, root=root)
     if not validation.get("ok"):
         return _truncate(patcher.render_validation(validation))
-    # 2) 构造彩色 diff 预览 + 改前必读提示
+    # 2) 改前必读硬护栏 + 构造彩色 diff 预览
     abs_paths = [str((Path(root) / o.get("path", "")).resolve()) for o in ops if isinstance(o, dict) and o.get("path")]
+    blocked = _require_read(ctx, abs_paths)
+    if blocked:
+        return blocked
     n = len([o for o in ops if isinstance(o, dict)])
     lines = [f"应用结构化补丁（{n} 处）并跑测试："]
     for o in ops:
@@ -280,7 +285,7 @@ def t_code_apply_patch(args: dict, ctx) -> str:
             lines.append(panels.render_diff(o.get("old", ""), o.get("new", ""), str(o.get("path", ""))))
         except Exception:
             pass
-    preview = _read_nudge(ctx, abs_paths) + "\n".join(lines)
+    preview = "\n".join(lines)
     # 3) 一次审批
     ok, msg = _gate(ctx, "code_apply_patch", preview)
     if not ok:
@@ -518,7 +523,10 @@ def t_edit_file(args: dict, ctx) -> str:
         return "未找到要替换的原文（old 不匹配）。"
     if cnt > 1:
         return f"原文出现 {cnt} 次，不唯一；请提供更长的 old 以唯一定位。"
-    preview = _read_nudge(ctx, [str(p)]) + f"编辑 {_disp(p)}：替换 1 处\n" + panels.render_diff(old, new, p.name)
+    blocked = _require_read(ctx, [str(p)])
+    if blocked:
+        return blocked
+    preview = f"编辑 {_disp(p)}：替换 1 处\n" + panels.render_diff(old, new, p.name)
     ok, msg = _gate(ctx, "edit_file", preview)
     if not ok:
         return msg

--- a/ivyea_agent/tools_general.py
+++ b/ivyea_agent/tools_general.py
@@ -41,6 +41,21 @@ def _dangerous_command(command: str) -> str:
     return ""
 
 
+def _with_line_numbers(text: str, start: int = 1) -> str:
+    """cat -n 式给每行加行号（仅供模型定位/引用；edit 的 old 不要带行号）。"""
+    lines = text.split("\n")
+    width = max(4, len(str(start + len(lines) - 1)))
+    return "\n".join(f"{start + i:>{width}}\t{ln}" for i, ln in enumerate(lines))
+
+
+_LINE_NO_RE = re.compile(r"^\s*\d+\t", re.M)
+
+
+def _strip_line_no(text: str) -> str:
+    """去掉每行前导的 `行号\\t`（兜底模型误把 read_file 的行号粘进 old）。"""
+    return _LINE_NO_RE.sub("", text)
+
+
 def _disp(p) -> str:
     """审批预览用的友好路径：在 cwd 下显示相对路径，否则原样。仅展示用，写入仍用绝对路径。"""
     try:
@@ -95,7 +110,7 @@ def t_read_file(args: dict, ctx) -> str:
     offset = args.get("offset")
     limit = args.get("limit")
     if offset is None and limit is None:
-        return _truncate(text)
+        return _truncate(_with_line_numbers(text, 1))
     # 行区间读取：offset 从 1 开始；大文件只取一段，避免被迫用 run_command 分段读。
     lines = text.splitlines()
     total = len(lines)
@@ -103,7 +118,7 @@ def t_read_file(args: dict, ctx) -> str:
     if start > total:
         return f"（{p.name} 共 {total} 行，offset={start} 超出范围）"
     end = total if limit is None else min(total, start + max(1, int(limit)) - 1)
-    body = "\n".join(lines[start - 1:end])
+    body = _with_line_numbers("\n".join(lines[start - 1:end]), start)
     return f"（{p.name} 第 {start}–{end} 行，共 {total} 行）\n" + _truncate(body)
 
 
@@ -225,6 +240,36 @@ def t_grep(args: dict, ctx) -> str:
     if not hits:
         return f"无匹配（扫描 {scanned} 文件）：{pattern}"
     return f"命中 {len(hits)} 处（扫描 {scanned} 文件）：\n" + _truncate("\n".join(hits))
+
+
+def t_glob(args: dict, ctx) -> str:
+    """按文件名 glob 模式找文件（如 **/*.py）。只读、ignore-aware（复用 workspace.iter_files）。"""
+    import fnmatch
+    from . import workspace
+    pattern = (args.get("pattern") or "").strip()
+    if not pattern:
+        return "pattern 为空。"
+    base = args.get("path")
+    root = Path(os.path.expanduser(base)).resolve() if base else Path(_ws_root(ctx))
+    ok, msg = policy.check_path(root, "read")
+    if not ok:
+        return msg
+    max_n = min(int(args.get("max_results") or 100), 500)
+    # fnmatch 的 * 本就跨 /，把 **/ 归一为空、** 归一为 * 即可正确支持 **/*.py 这类（含根目录）。
+    norm = pattern.replace("**/", "").replace("**", "*")
+    hits: list[str] = []
+    for path in workspace.iter_files(root):
+        try:
+            rel = path.relative_to(root).as_posix()
+        except ValueError:
+            rel = path.name
+        if fnmatch.fnmatch(rel, norm) or fnmatch.fnmatch(path.name, pattern):
+            hits.append(rel)
+            if len(hits) >= max_n:
+                break
+    if not hits:
+        return f"没有匹配 {pattern} 的文件。"
+    return f"匹配 {len(hits)} 个文件：\n" + _truncate("\n".join(sorted(hits)))
 
 
 def t_code_search(args: dict, ctx) -> str:
@@ -519,8 +564,11 @@ def t_edit_file(args: dict, ctx) -> str:
     except Exception as e:  # noqa: BLE001
         return f"读取失败：{e}"
     cnt = text.count(old)
+    if cnt == 0 and _LINE_NO_RE.search(old):
+        old = _strip_line_no(old)   # 容错：模型把 read_file 的行号粘进了 old
+        cnt = text.count(old)
     if cnt == 0:
-        return "未找到要替换的原文（old 不匹配）。"
+        return "未找到要替换的原文（old 不匹配）。注意 old 用文件真实内容，不要带 read_file 的行号。"
     if cnt > 1:
         return f"原文出现 {cnt} 次，不唯一；请提供更长的 old 以唯一定位。"
     blocked = _require_read(ctx, [str(p)])
@@ -567,10 +615,11 @@ def _make_preexec(timeout: int):
     return _apply
 
 
-def _run(cmd, args, ctx, kind: str, preview: str) -> str:
-    ok, msg = _gate(ctx, kind, preview)
-    if not ok:
-        return msg
+def _run(cmd, args, ctx, kind: str, preview: str, *, auto_ok: bool = False) -> str:
+    if not auto_ok:   # 只读命令(auto_ok)免审批，也可在计划模式下跑（本就只读）
+        ok, msg = _gate(ctx, kind, preview)
+        if not ok:
+            return msg
     workdir = getattr(ctx, "workspace", "") or os.getcwd()
     timeout = int(args.get("timeout") or _EXEC_TIMEOUT)
     try:
@@ -608,7 +657,8 @@ def t_run_command(args: dict, ctx) -> str:
         return f"安全策略拒绝高风险命令：{blocked}"
     import os as _os
     shell = ["cmd", "/c", command] if _os.name == "nt" else ["bash", "-lc", command]
-    return _run(shell, args, ctx, "run_command", "运行命令：" + _truncate(command, 400))
+    auto_ok = policy.is_readonly_command(command)   # 只读命令自动放行，省去逐次审批
+    return _run(shell, args, ctx, "run_command", "运行命令：" + _truncate(command, 400), auto_ok=auto_ok)
 
 
 def t_todo_write(args: dict, ctx) -> str:
@@ -694,7 +744,8 @@ def _fn(name, desc, props, required=()):
 
 
 GENERAL_TOOL_SCHEMAS = [
-    _fn("read_file", "读取本地文本文件内容（只读，自动放行）。大文件用 offset/limit 读行区间，别用 run_command 分段读。",
+    _fn("read_file", "读取本地文本文件内容（只读，自动放行）。返回带行号（行号\\t内容，仅供定位/引用，"
+        "edit_file 的 old 用真实内容不要带行号）。大文件用 offset/limit 读行区间，别用 run_command 分段读。",
         {"path": {"type": "string", "description": "文件路径，支持 ~"},
          "offset": {"type": "integer", "description": "起始行号（从 1 开始）；读大文件某段时填"},
          "limit": {"type": "integer", "description": "最多读多少行；配合 offset 读区间"}}, ["path"]),
@@ -703,7 +754,8 @@ GENERAL_TOOL_SCHEMAS = [
     _fn("write_file", "新建或整体重写文件（写操作，一次调用即审批落盘）。改已有文件的某一处别用它，用 edit_file。",
         {"path": {"type": "string"}, "content": {"type": "string"}}, ["path", "content"]),
     _fn("edit_file", "改单个文件的某一处：唯一字符串替换 old→new（写操作，一次调用即审批落盘）。"
-        "old 必须在文件中唯一出现。单处改动首选它；跨多文件/多处或要顺带跑测试用 code_apply_patch。",
+        "old 用文件真实内容（不要带 read_file 的行号前缀）且必须唯一出现。"
+        "单处改动首选它；跨多文件/多处或要顺带跑测试用 code_apply_patch。",
         {"path": {"type": "string"}, "old": {"type": "string"}, "new": {"type": "string"}},
         ["path", "old", "new"]),
     _fn("run_python", "在沙箱(限工作目录/超时)运行 Python 代码取 stdout（执行，会弹审批）。可用 pandas/openpyxl 等。",
@@ -718,6 +770,11 @@ GENERAL_TOOL_SCHEMAS = [
         {"pattern": {"type": "string", "description": "正则表达式"},
          "glob": {"type": "string", "description": "可选：只搜匹配此 glob 的文件，如 *.py"},
          "max_results": {"type": "integer", "description": "最多命中条数，默认 80"}}, ["pattern"]),
+    _fn("glob", "按文件名 glob 模式找文件（如 **/*.py、src/**/*.ts）。只读，自动放行。"
+        "想按文件名/路径定位文件用它；想按内容搜用 grep。",
+        {"pattern": {"type": "string", "description": "glob 模式，如 **/*.py"},
+         "path": {"type": "string", "description": "起始目录，默认工作目录"},
+         "max_results": {"type": "integer", "description": "最多返回条数，默认 100"}}, ["pattern"]),
     _fn("code_search", "按符号/路径/预览检索代码库里最相关的文件（索引搜索）。只读。适合“这功能在哪实现的”。",
         {"query": {"type": "string"}, "limit": {"type": "integer"}}, ["query"]),
     _fn("code_symbols", "列出/搜索代码库里的函数/类等符号定义位置。只读。",
@@ -779,7 +836,7 @@ GENERAL_DISPATCH = {
     "write_file": t_write_file, "edit_file": t_edit_file,
     "run_python": t_run_python, "run_command": t_run_command,
     "web_fetch": t_web_fetch, "web_search": t_web_search,
-    "grep": t_grep, "code_search": t_code_search,
+    "grep": t_grep, "glob": t_glob, "code_search": t_code_search,
     "code_symbols": t_code_symbols, "code_impact": t_code_impact,
     "code_apply_patch": t_code_apply_patch, "run_tests": t_run_tests, "code_repair": t_code_repair,
     "mcp_list_tools": t_mcp_list_tools, "mcp_call_tool": t_mcp_call_tool,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ivyea-agent"
-version = "1.0.29"
+version = "1.0.30"
 description = "Ivyea Agent — 自托管的亚马逊运营 CLI Agent（对话式 + 多模型 + 领星广告读写审批 + 通用工具 + 记忆）"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_code_edit_tools.py
+++ b/tests/test_code_edit_tools.py
@@ -12,11 +12,16 @@ def _repo(tmp_path):
     return tmp_path
 
 
+def _read_first(ctx, root):
+    dispatch("read_file", {"path": str(root / "pkg" / "calc.py")}, ctx)  # 满足改前必读硬护栏
+
+
 def test_apply_patch_denied_does_not_write(tmp_path, monkeypatch):
     # 一次性语义：先校验通过 → 弹审批；用户拒绝则不落盘。
     root = _repo(tmp_path)
     monkeypatch.setattr(permission, "request_intent", lambda *a, **k: permission.DENY)
     ctx = ToolContext(workspace=str(root))
+    _read_first(ctx, root)
     out = dispatch("code_apply_patch", {"ops": [
         {"path": "pkg/calc.py", "old": "return a + b\n", "new": "return a + b + 0\n"}]}, ctx)
     assert "跳过" in out or "deny" in out.lower()
@@ -28,10 +33,21 @@ def test_apply_patch_approve_writes(tmp_path, monkeypatch):
     root = _repo(tmp_path)
     monkeypatch.setattr(permission, "request_intent", lambda *a, **k: permission.APPROVE)
     ctx = ToolContext(workspace=str(root), execute=True)
+    _read_first(ctx, root)
     out = dispatch("code_apply_patch", {"ops": [
         {"path": "pkg/calc.py", "old": "return a + b\n", "new": "return a + b + 0\n"}]}, ctx)
     assert "应用" in out or "applied" in out.lower() or "execute" in out.lower()
     assert (root / "pkg" / "calc.py").read_text(encoding="utf-8").endswith("return a + b + 0\n")
+
+
+def test_apply_patch_blocked_without_prior_read(tmp_path):
+    # 改前必读硬护栏：未读过目标文件 → 挡回，不落盘、不弹审批。
+    root = _repo(tmp_path)
+    ctx = ToolContext(workspace=str(root))
+    out = dispatch("code_apply_patch", {"ops": [
+        {"path": "pkg/calc.py", "old": "return a + b\n", "new": "return a + b + 0\n"}]}, ctx)
+    assert "已拦截" in out and "read_file" in out
+    assert (root / "pkg" / "calc.py").read_text(encoding="utf-8").endswith("return a + b\n")
 
 
 def test_apply_patch_invalid_returns_without_approval(tmp_path, monkeypatch):
@@ -50,6 +66,7 @@ def test_apply_patch_invalid_returns_without_approval(tmp_path, monkeypatch):
 def test_apply_patch_blocked_in_plan_mode(tmp_path):
     root = _repo(tmp_path)
     ctx = ToolContext(workspace=str(root), plan_mode=True)
+    _read_first(ctx, root)
     out = dispatch("code_apply_patch", {"ops": [
         {"path": "pkg/calc.py", "old": "return a + b\n", "new": "x\n"}]}, ctx)
     assert "计划模式" in out

--- a/tests/test_phase_a.py
+++ b/tests/test_phase_a.py
@@ -1,0 +1,108 @@
+"""Phase A：read_file 行号 + edit 容错、glob、accept-edits、只读命令自动放行。"""
+from __future__ import annotations
+
+from ivyea_agent import permission, policy
+from ivyea_agent import tools_general as tg
+from ivyea_agent.agent_tools import ToolContext, dispatch
+
+
+def _ctx(tmp_path, allow=()):
+    if policy.POLICY_FILE.exists():
+        policy.POLICY_FILE.unlink()
+    c = ToolContext(workspace=str(tmp_path))
+    for k in allow:
+        c.perm.session_allow.add(k)
+    return c
+
+
+# ── A1 行号 + edit 容错 ──
+def test_read_file_has_line_numbers(tmp_path):
+    f = tmp_path / "m.py"
+    f.write_text("import os\n\ndef foo():\n    return 1\n", encoding="utf-8")
+    out = tg.t_read_file({"path": str(f)}, _ctx(tmp_path))
+    assert "\t" in out and "1\timport os" in out
+    assert "3\tdef foo():" in out
+
+
+def test_read_file_range_line_numbers_offset(tmp_path):
+    f = tmp_path / "m.py"
+    f.write_text("\n".join(f"line{i}" for i in range(1, 11)) + "\n", encoding="utf-8")
+    out = tg.t_read_file({"path": str(f), "offset": 4, "limit": 2}, _ctx(tmp_path))
+    assert "4\tline4" in out and "5\tline5" in out and "line6" not in out
+
+
+def test_edit_tolerates_pasted_line_numbers(tmp_path):
+    f = tmp_path / "m.py"
+    f.write_text("a = 1\nb = 2\n", encoding="utf-8")
+    ctx = _ctx(tmp_path, allow=["edit_file"])
+    tg.t_read_file({"path": str(f)}, ctx)
+    # 模型误把行号粘进 old
+    r = tg.t_edit_file({"path": str(f), "old": "   2\tb = 2", "new": "b = 20"}, ctx)
+    assert "已编辑" in r and f.read_text() == "a = 1\nb = 20\n"
+
+
+# ── A2 glob ──
+def test_glob_finds_files(tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "a.py").write_text("x", encoding="utf-8")
+    (tmp_path / "b.py").write_text("y", encoding="utf-8")
+    (tmp_path / "c.txt").write_text("z", encoding="utf-8")
+    out = dispatch("glob", {"pattern": "**/*.py"}, _ctx(tmp_path))
+    assert "a.py" in out and "b.py" in out and "c.txt" not in out
+
+
+# ── A3 accept-edits ──
+def test_accept_edits_auto_approves_write(tmp_path):
+    f = tmp_path / "e.txt"
+    f.write_text("v=1", encoding="utf-8")
+    ctx = _ctx(tmp_path)
+    ctx.perm.accept_edits = True
+    tg.t_read_file({"path": str(f)}, ctx)        # 满足改前必读
+    r = tg.t_edit_file({"path": str(f), "old": "v=1", "new": "v=2"}, ctx)
+    assert "已编辑" in r and f.read_text() == "v=2"
+
+
+def test_accept_edits_still_blocked_in_plan_mode(tmp_path):
+    f = tmp_path / "e.txt"
+    f.write_text("v=1", encoding="utf-8")
+    ctx = _ctx(tmp_path)
+    ctx.perm.accept_edits = True
+    ctx.plan_mode = True
+    tg.t_read_file({"path": str(f)}, ctx)
+    r = tg.t_edit_file({"path": str(f), "old": "v=1", "new": "v=2"}, ctx)
+    assert "计划模式" in r and f.read_text() == "v=1"
+
+
+def test_accept_edits_still_requires_prior_read(tmp_path):
+    f = tmp_path / "e.txt"
+    f.write_text("v=1", encoding="utf-8")
+    ctx = _ctx(tmp_path)
+    ctx.perm.accept_edits = True   # 没读过 → 仍挡回
+    r = tg.t_edit_file({"path": str(f), "old": "v=1", "new": "v=2"}, ctx)
+    assert "已拦截" in r and f.read_text() == "v=1"
+
+
+# ── A4 只读命令自动放行 ──
+def test_is_readonly_command():
+    assert policy.is_readonly_command("ls -la")
+    assert policy.is_readonly_command("git status")
+    assert policy.is_readonly_command("git diff HEAD~1")
+    assert not policy.is_readonly_command("rm -rf x")
+    assert not policy.is_readonly_command("echo hi > f")      # 重定向
+    assert not policy.is_readonly_command("ls && rm x")        # 串联
+    assert not policy.is_readonly_command("cat a | tee b")     # 管道
+    assert not policy.is_readonly_command("git commit -m x")   # 写子命令
+
+
+def test_run_command_readonly_auto_runs(tmp_path):
+    (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+    ctx = _ctx(tmp_path)   # 没有任何 session_allow / 审批
+    out = tg.t_run_command({"command": "ls"}, ctx)
+    assert "a.txt" in out and "退出码 0" in out
+
+
+def test_run_command_write_still_gated_in_plan_mode(tmp_path):
+    ctx = _ctx(tmp_path)
+    ctx.plan_mode = True
+    out = tg.t_run_command({"command": "touch newfile"}, ctx)  # 非只读 → 计划模式拦
+    assert "计划模式" in out and not (tmp_path / "newfile").exists()

--- a/tests/test_phase_b.py
+++ b/tests/test_phase_b.py
@@ -1,0 +1,73 @@
+"""Phase B：主脑健康探测、debug 日志、engineering_context 缓存。"""
+from __future__ import annotations
+
+import importlib
+
+
+# ── B1 主脑健康（本地判断，不发网络）──
+def test_main_brain_health_oauth_expired(ivyea_home, monkeypatch):
+    from ivyea_agent import config, oauth_auth
+    monkeypatch.setattr(config, "load_settings",
+                        lambda: {"auth_type": "oauth_external", "provider_id": "openai-codex", "label": "Codex"})
+    monkeypatch.setattr(oauth_auth, "token_status", lambda pid: "expired")
+    h = config.main_brain_health()
+    assert h["ok"] is False and h["status"] == "expired" and "Codex" in h["hint"]
+
+
+def test_main_brain_health_api_key_ok(ivyea_home, monkeypatch):
+    from ivyea_agent import config
+    monkeypatch.setattr(config, "load_settings", lambda: {"auth_type": "api_key", "label": "DeepSeek"})
+    monkeypatch.setattr(config, "get_active_key", lambda: "sk-xxx")
+    assert config.main_brain_health()["ok"] is True
+
+
+# ── B2 debug 日志开关 ──
+def test_log_dbg_writes_only_when_enabled(ivyea_home, monkeypatch):
+    from ivyea_agent import config, log
+    importlib.reload(log)
+    logfile = config.IVYEA_DIR / "logs" / "agent.log"
+    # 关闭：不写
+    monkeypatch.delenv("IVYEA_DEBUG", raising=False)
+    monkeypatch.setattr(log, "enabled", lambda: False)
+    log.dbg("test", "should-not-write")
+    assert not logfile.exists()
+    # 开启：落盘
+    monkeypatch.setattr(log, "enabled", lambda: True)
+    log.dbg("test", "hello-debug")
+    assert logfile.exists() and "hello-debug" in logfile.read_text(encoding="utf-8")
+
+
+# ── B3 engineering_context 缓存 ──
+def test_engineering_context_caches_inspect(monkeypatch, tmp_path):
+    from ivyea_agent import engineering_context as ec
+    ec._STATIC_CACHE.clear()
+    calls = {"n": 0}
+
+    def fake_inspect(root):
+        calls["n"] += 1
+        return {"entrypoints": [], "tests": ["t_x.py"], "configs": [], "suggested_commands": []}
+
+    monkeypatch.setattr(ec.workspace, "project_inspect", fake_inspect)
+    monkeypatch.setattr(ec.skills, "status", lambda: [])
+    monkeypatch.setattr(ec.git_workflow, "status",
+                        lambda root: {"ok": True, "branch": "main", "head": "abc123", "clean": True, "changes": []})
+    q = "重构这个 python 模块"   # should_include=True
+    a = ec.build(str(tmp_path), q)
+    b = ec.build(str(tmp_path), q)
+    assert "tests: t_x.py" in a and a == b
+    assert calls["n"] == 1   # 第二次走缓存，project_inspect 只调一次
+
+
+def test_engineering_context_cache_invalidates_on_head_change(monkeypatch, tmp_path):
+    from ivyea_agent import engineering_context as ec
+    ec._STATIC_CACHE.clear()
+    calls = {"n": 0}
+    monkeypatch.setattr(ec.workspace, "project_inspect",
+                        lambda root: (calls.__setitem__("n", calls["n"] + 1) or {"entrypoints": [], "tests": [], "configs": [], "suggested_commands": []}))
+    monkeypatch.setattr(ec.skills, "status", lambda: [])
+    heads = iter(["h1", "h2"])
+    monkeypatch.setattr(ec.git_workflow, "status",
+                        lambda root: {"ok": True, "branch": "main", "head": next(heads), "clean": True, "changes": []})
+    ec.build(str(tmp_path), "修复 bug")
+    ec.build(str(tmp_path), "修复 bug")
+    assert calls["n"] == 2   # head 变 → 缓存失效，重算

--- a/tests/test_phase_c.py
+++ b/tests/test_phase_c.py
@@ -1,0 +1,36 @@
+"""Phase C：persona 开场、完整流式 _StreamPrinter 视觉行数计算。"""
+from __future__ import annotations
+
+from ivyea_agent import agent_loop
+from ivyea_agent.cli import _StreamPrinter
+
+
+def test_persona_opening_is_dual_role():
+    sp = agent_loop.SYSTEM_PROMPT
+    assert "编码" in sp[:120] or "工程" in sp[:120]   # 代码成为一等公民
+    assert "亚马逊运营" in sp[:120]                     # 运营仍在
+
+
+def test_stream_visual_lines_ascii_wrap():
+    # 宽 10：'a'*25 → 3 行；空串 → 1 行；含换行分别算
+    f = _StreamPrinter._visual_lines
+    assert f("a" * 25, 10) == 3
+    assert f("", 10) == 1
+    assert f("abc\ndef", 10) == 2
+    assert f("a" * 10, 10) == 1
+    assert f("a" * 11, 10) == 2
+
+
+def test_stream_visual_lines_cjk_double_width():
+    f = _StreamPrinter._visual_lines
+    # 中文每字宽 2：5 个中文 = 宽 10 → 正好 1 行；6 个 = 宽 12 → 2 行（宽 10）
+    assert f("你好世界吗", 10) == 1
+    assert f("你好世界吗啊", 10) == 2
+
+
+def test_stream_block_resets_on_commit():
+    sp = _StreamPrinter()
+    sp.block = "some streamed text"
+    sp.on = True
+    sp.commit()
+    assert sp.block == ""   # 工具行打断后重置当前段

--- a/tests/test_phase_d.py
+++ b/tests/test_phase_d.py
@@ -1,0 +1,32 @@
+"""Phase D：help 分组 + 别名（不删命令）。"""
+from __future__ import annotations
+
+import re
+
+from ivyea_agent import cli
+
+
+def _strip(s):
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def test_aliases_map_to_canonical():
+    assert cli._SLASH_ALIASES["/h"] == "/help"
+    assert cli._SLASH_ALIASES["/q"] == "/exit"
+
+
+def test_help_lists_every_slash_command():
+    txt = _strip(cli._help_text())
+    for cmd, _desc in cli.SLASH_COMMANDS:
+        assert cmd in txt, f"/help 漏了 {cmd}"
+
+
+def test_help_has_group_titles():
+    txt = _strip(cli._help_text())
+    for title, _ in cli._SLASH_GROUPS:
+        assert title in txt
+
+
+def test_cli_epilog_groups_present():
+    p = cli.build_parser()
+    assert "广告运营" in (p.epilog or "") and "代码 / 工程" in (p.epilog or "")

--- a/tests/test_tools_general.py
+++ b/tests/test_tools_general.py
@@ -53,8 +53,17 @@ def test_edit_unique(tmp_path):
     f = tmp_path / "e.txt"
     f.write_text("bid 1.00 done", encoding="utf-8")
     ctx = _ctx(tmp_path, allow=["edit_file"])
+    tg.t_read_file({"path": str(f)}, ctx)   # 改前必读硬护栏：先读再编辑
     r = tg.t_edit_file({"path": str(f), "old": "1.00", "new": "0.85"}, ctx)
     assert "已编辑" in r and f.read_text() == "bid 0.85 done"
+
+
+def test_edit_blocked_without_prior_read(tmp_path):
+    f = tmp_path / "e.txt"
+    f.write_text("bid 1.00 done", encoding="utf-8")
+    ctx = _ctx(tmp_path, allow=["edit_file"])
+    r = tg.t_edit_file({"path": str(f), "old": "1.00", "new": "0.85"}, ctx)
+    assert "已拦截" in r and "read_file" in r and f.read_text() == "bid 1.00 done"  # 未读→挡回，未改
 
 
 def test_edit_nonunique_refused(tmp_path):


### PR DESCRIPTION
接 v1.0.29（P0–P2），完成实跑+读码后的完整优化 roadmap（P3 + 11 项 A–D）。

## P3 写代码体验
改前必读硬护栏、/diff 命令、spinner 流式正文预览

## Phase A 写代码 quick wins
- read_file 带行号 + edit_file 容错（误带行号自动去除重试）
- glob 工具（ignore-aware）
- accept-edits opt-in 放行开关（/auto-edit，默认关，状态栏 ⚡）
- 只读 shell 命令自动放行（policy 白名单）

## Phase B 健壮性
- 主脑健康探测 + 入口降级（治“活跃主脑是已废 Codex 却开箱即坏”）
- 轻量 debug 日志（IVYEA_DEBUG）接管静默吞错
- engineering_context 会话缓存（按 git head/clean）

## Phase C 体验对齐
- persona 双一等（运营 + 编码都是一等本职）
- 完整 markdown 流式（/stream，opt-in，边出字+收尾重绘）

## Phase D 治本
- 拆 chat_ui.py（god-file 瘦身）
- slash 命令注册表（25 分支 if 链 → dict dispatch）
- help 分组 + 别名（/h /q，零删除命令）

## 质量门
ruff 干净；475 单测全过（+23）；各 Phase pty 端到端实跑（含自写终端模拟器验证流式擦除重绘、注册表 12 命令行为零漂移）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)