### PR TITLE
feat(tui): 全屏 TUI 聊天界面（对标 Claude Code，IVYEA_TUI=1 opt-in）

### DIFF
--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -224,10 +224,15 @@ def run_turn(provider: LLMProvider, ctx: ToolContext, messages: list,
 
 def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
                     max_steps: int | None = None, narrate: Callable[[str], None] = print,
-                    render: Callable[[str], None] = None, model: str = "") -> dict:
+                    render: Callable[[str], None] = None, model: str = "",
+                    cancel_check: Callable[[], bool] | None = None) -> dict:
     """流式跑一轮：token 边出边渲染、工具实时叙述、累计用量。
-    返回 {text, usage}（usage 为本轮各步累加）。render(token) 逐字输出助手文本。"""
+    返回 {text, usage}（usage 为本轮各步累加）。render(token) 逐字输出助手文本。
+
+    cancel_check：TUI 忙碌时请求中断的钩子；在步/流/工具边界返回 True 则抛
+    KeyboardInterrupt，交给上层保留会话并恢复输入。默认无操作，行式循环不受影响。"""
     render = render or (lambda s: print(s, end="", flush=True))
+    cancel_check = cancel_check or (lambda: False)
     total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "prompt_cache_hit_tokens": 0}
 
     def _accum(u: dict) -> None:
@@ -241,11 +246,15 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
     max_steps = _resolve_max_steps(max_steps, "chat_max_tool_steps")
     status = TurnStatus(max_steps=max_steps)
     for step_idx in range(max_steps):
+        if cancel_check():
+            raise KeyboardInterrupt
         _maybe_compact(messages, provider, step_idx, narrate)
         status.before_model_step(step_idx, narrate)
         final = {"content": "", "tool_calls": [], "usage": {}}
         printed_any = False
         for ev in provider.stream_chat(messages, tools=TOOL_SCHEMAS):
+            if cancel_check():
+                raise KeyboardInterrupt
             if ev["type"] == "text":
                 printed_any = True
                 render(ev["text"])
@@ -259,6 +268,8 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
             content = final.get("content", "") or ""
             messages.append({"role": "assistant", "content": content})
             return {"text": content, "usage": total_usage}
+        if cancel_check():
+            raise KeyboardInterrupt
         _append_tool_call_msg(messages, final.get("content"), tool_calls)
         _dispatch_tool_calls(ctx, messages, status, tool_calls, step_idx, max_steps, narrate)
     text = _finalize_limit(ctx, messages, status, max_steps, extra_payload={"usage": total_usage})

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -1,18 +1,25 @@
 """全屏 TUI 聊天界面（对标 Claude Code）。
 
-分阶段构建（见计划）。P0：骨架——固定头部（当前指令置顶）+ 可滚动 transcript
-+ 常驻底部输入框，能渲染与干净退出。完整对话闭环、流式、审批在后续阶段接入。
+分阶段构建（见计划）。
+- P0：骨架（头部/transcript/输入）。
+- P1：核心闭环——提交回显 + sticky 头部 + 后台线程跑一轮 + 助手文本/工具行
+  线程安全 marshal 进 transcript + 状态行 spinner + 贴底跟随/上滚查看。
 
-启用：TTY + IVYEA_TUI=1（opt-in）。非 TTY / 未开 / 依赖缺失时 `tui_enabled()`
-返回 False，调用方回退到现有行式 CLI。
+启用：TTY + IVYEA_TUI=1（opt-in）。非 TTY / 未开 / 依赖缺失 → tui_enabled()
+False，调用方回退现有行式 CLI。审批/补全/中断等见后续阶段。
 """
 from __future__ import annotations
 
 import os
+import re
+import shutil
 import sys
+import threading
+import time
 from typing import Callable
 
 _TRUTHY = ("1", "true", "on", "yes")
+_SPIN = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 
 def tui_enabled() -> bool:
@@ -28,78 +35,190 @@ def tui_enabled() -> bool:
     return True
 
 
-def _style():
-    from prompt_toolkit.styles import Style
-    return Style.from_dict({
-        "hdr": "bold ansicyan",
-        "rule": "ansibrightblack",
-        "ftr": "noreverse ansibrightblack",
-        "prompt": "ansicyan bold",
-        "wip": "ansibrightblack",
-    })
+def _visual_lines(text: str, width: int) -> list[str]:
+    """把（可能含 ANSI 的）文本按显示宽度粗略拆成物理行，用于贴底裁剪。"""
+    from prompt_toolkit.utils import get_cwidth
+    out: list[str] = []
+    for logical in text.split("\n"):
+        plain = re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", logical)
+        if get_cwidth(plain) <= width or width <= 0:
+            out.append(logical)
+            continue
+        # 超宽行按显示宽度切（保留原行；仅用于行数估算，颜色可能在切点断，够用）
+        cur, w = "", 0
+        for ch in logical:
+            cw = get_cwidth(ch) if not ch.startswith("\x1b") else 0
+            if w + cw > width:
+                out.append(cur); cur, w = ch, cw
+            else:
+                cur += ch; w += cw
+        out.append(cur)
+    return out
 
 
-def run(status_fn: Callable[[], str], slash_commands: list) -> int:
-    """P0 骨架 TUI。返回退出码（供 _cmd_chat 直接 return）。
+class ChatTUI:
+    """一次 TUI 会话的状态与渲染。turn_fn(line, render, narrate)->dict 跑真正一轮。"""
 
-    后续阶段会把 transcript 模型、后台跑轮、流式 marshal、审批浮层挂进来；
-    P0 只验证全屏外壳（头部/transcript/输入）能渲染并干净退出。
-    """
-    from prompt_toolkit.application import Application
-    from prompt_toolkit.layout import Layout
-    from prompt_toolkit.layout.containers import HSplit, Window
-    from prompt_toolkit.layout.controls import FormattedTextControl
-    from prompt_toolkit.widgets import TextArea
-    from prompt_toolkit.key_binding import KeyBindings
+    def __init__(self, *, status_fn: Callable[[], str], turn_fn: Callable[..., dict],
+                 render_markdown: Callable[[str], str] | None = None):
+        self.status_fn = status_fn
+        self.turn_fn = turn_fn
+        self._md = render_markdown or (lambda s: s)
+        self.instruction = ""
+        self.blocks: list[str] = []          # 已定稿 block（可含 ANSI）
+        self.live: str | None = None         # 当前流式助手文本（未定稿）
+        self.running = False
+        self.scroll = 0                       # 距底部的物理行数；0=贴底跟随
+        self.started = 0.0
+        self.app = None
 
-    state = {
-        "instruction": "",
-        "lines": ["（P0 骨架：完整对话将在后续阶段接入。输入 /exit 退出。）"],
-    }
-
-    def header_text():
-        instr = state["instruction"] or "（还没有指令）"
-        return [("class:hdr", f" ▶ 当前指令：{instr}")]
-
-    def body_text():
-        return [("class:wip", "\n".join(state["lines"]))]
-
-    def footer_text():
-        return [("class:ftr", " " + (status_fn() or ""))]
-
-    ta = TextArea(prompt=[("class:prompt", "❯ ")], multiline=False, height=1)
-    root = HSplit([
-        Window(FormattedTextControl(header_text), height=1, style="class:hdr"),
-        Window(height=1, char="─", style="class:rule"),
-        Window(FormattedTextControl(body_text), wrap_lines=True),   # transcript（P1 起可滚动）
-        Window(height=1, char="─", style="class:rule"),
-        Window(FormattedTextControl(footer_text), height=1, style="class:ftr"),
-        ta,
-    ])
-
-    kb = KeyBindings()
-
-    @kb.add("c-c")
-    @kb.add("c-d")
-    def _(event):
-        event.app.exit(result=0)
-
-    @kb.add("enter")
-    def _(event):
-        text = ta.text.strip()
-        ta.text = ""
-        if text in ("/exit", "/quit"):
-            event.app.exit(result=0)
+    # ---- 供后台线程调用的输出回调（线程安全：仅追加 + invalidate）----
+    def render(self, token: str = "") -> None:
+        if not token:
             return
-        if text:
-            state["instruction"] = text
-            state["lines"].append(f"❯ {text}")
-            state["lines"].append("（P0：对话闭环尚未接入，见 P1）")
+        self.live = (self.live or "") + token
+        self._invalidate()
 
-    app = Application(
-        layout=Layout(root, focused_element=ta),
-        key_bindings=kb, style=_style(),
-        full_screen=True, mouse_support=True,
-    )
-    app.run()
+    def narrate(self, text: str = "") -> None:
+        text = str(text or "")
+        if not text.strip():
+            return
+        self._commit_live()          # 工具行/提示打断当前流式文本，先定稿
+        self.blocks.append(text)
+        self._invalidate()
+
+    def _commit_live(self) -> None:
+        if self.live is not None:
+            body = self.live.strip()
+            if body:
+                self.blocks.append("● " + self._md(body))   # 文本段收尾渲染 markdown
+            self.live = None
+
+    def _invalidate(self) -> None:
+        app = self.app
+        if app is not None:
+            try:
+                app.invalidate()
+            except Exception:
+                pass
+
+    def _body_ansi(self):
+        from prompt_toolkit.formatted_text import ANSI
+        parts = list(self.blocks)
+        if self.live is not None:
+            parts.append("\033[2m" + self.live + "\033[0m")   # 流式中 dim 显示原文
+        text = "\n\n".join(p for p in parts if p) or "（开始对话吧。输入 /exit 退出。）"
+        width = shutil.get_terminal_size((100, 30)).columns
+        rows = shutil.get_terminal_size((100, 30)).lines
+        avail = max(3, rows - 5)                  # 头部+两条分隔+footer+输入 约 5 行
+        lines = _visual_lines(text, width)
+        if len(lines) > avail:
+            end = len(lines) - self.scroll
+            end = max(avail, min(end, len(lines)))
+            lines = lines[end - avail:end]
+        return ANSI("\n".join(lines))
+
+    def _header(self):
+        instr = self.instruction or "（还没有指令）"
+        tail = "  ⟳ 运行中" if self.running else ""
+        return [("class:hdr", f" ▶ 当前指令：{instr}{tail}")]
+
+    def _footer(self):
+        base = self.status_fn() or ""
+        if self.running:
+            frame = _SPIN[int((time.time() - self.started) * 10) % len(_SPIN)]
+            secs = int(time.time() - self.started)
+            return [("class:run", f" {frame} 生成中 {secs}s · Esc 稍后接入中断"), ("class:ftr", " · " + base)]
+        return [("class:ftr", " " + base)]
+
+    def _start_turn(self, line: str) -> None:
+        self.instruction = line
+        self.blocks.append(f"\033[36m❯\033[0m {line}")
+        self.scroll = 0
+        self.running = True
+        self.started = time.time()
+
+        def _worker():
+            try:
+                out = self.turn_fn(line, self.render, self.narrate)
+            except Exception as e:   # noqa: BLE001
+                out = {"text": "", "error": str(e)}
+            self._finish(out)
+
+        threading.Thread(target=_worker, daemon=True).start()
+        self._invalidate()
+
+    def _finish(self, out: dict) -> None:
+        self._commit_live()
+        err = out.get("error")
+        if err:
+            self.blocks.append(f"\033[31m✗ 出错：{err}\033[0m")
+        self.running = False
+        self.scroll = 0
+        self._invalidate()
+
+    def build_app(self):
+        from prompt_toolkit.application import Application
+        from prompt_toolkit.layout import Layout
+        from prompt_toolkit.layout.containers import HSplit, Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
+        from prompt_toolkit.widgets import TextArea
+        from prompt_toolkit.key_binding import KeyBindings
+        from prompt_toolkit.styles import Style
+
+        ta = TextArea(prompt=[("class:prompt", "❯ ")], multiline=False, height=1)
+        root = HSplit([
+            Window(FormattedTextControl(self._header), height=1, style="class:hdr"),
+            Window(height=1, char="─", style="class:rule"),
+            Window(FormattedTextControl(self._body_ansi), wrap_lines=True),
+            Window(height=1, char="─", style="class:rule"),
+            Window(FormattedTextControl(self._footer), height=1),
+            ta,
+        ])
+        kb = KeyBindings()
+
+        @kb.add("c-c")
+        @kb.add("c-d")
+        def _(event):
+            event.app.exit(result=0)
+
+        @kb.add("enter")
+        def _(event):
+            if self.running:      # P1：运行中先忽略输入（中断/排队见 P2）
+                return
+            text = ta.text.strip()
+            ta.text = ""
+            if text in ("/exit", "/quit"):
+                event.app.exit(result=0)
+                return
+            if text:
+                self._start_turn(text)
+
+        @kb.add("pageup")
+        def _(event):
+            self.scroll += 5
+
+        @kb.add("pagedown")
+        def _(event):
+            self.scroll = max(0, self.scroll - 5)
+
+        style = Style.from_dict({
+            "hdr": "bold ansicyan", "rule": "ansibrightblack",
+            "ftr": "noreverse ansibrightblack", "run": "ansiyellow",
+            "prompt": "ansicyan bold",
+        })
+        self.app = Application(
+            layout=Layout(root, focused_element=ta), key_bindings=kb, style=style,
+            full_screen=True, mouse_support=True, refresh_interval=0.2,
+        )
+        return self.app
+
+
+def run(status_fn: Callable[[], str], slash_commands: list,
+        turn_fn: Callable[..., dict] | None = None,
+        render_markdown: Callable[[str], str] | None = None) -> int:
+    """启动 TUI 会话。turn_fn(line, render, narrate)->dict 跑真正一轮。"""
+    tui = ChatTUI(status_fn=status_fn, turn_fn=turn_fn or (lambda *a, **k: {"text": ""}),
+                  render_markdown=render_markdown)
+    tui.build_app().run()
     return 0

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -60,10 +60,18 @@ class ChatTUI:
     """一次 TUI 会话的状态与渲染。turn_fn(line, render, narrate)->dict 跑真正一轮。"""
 
     def __init__(self, *, status_fn: Callable[[], str], turn_fn: Callable[..., dict],
-                 render_markdown: Callable[[str], str] | None = None):
+                 render_markdown: Callable[[str], str] | None = None,
+                 slash_commands: list | None = None,
+                 plan_intent_fn: Callable[[str], str] | None = None,
+                 set_plan_mode: Callable[[bool], str] | None = None,
+                 cycle_mode: Callable[[], str] | None = None):
         self.status_fn = status_fn
         self.turn_fn = turn_fn
         self._md = render_markdown or (lambda s: s)
+        self.slash_commands = slash_commands or []
+        self._plan_intent = plan_intent_fn or (lambda _t: None)
+        self._set_plan = set_plan_mode        # (on)->msg 或 None
+        self._cycle = cycle_mode              # ()->label 或 None
         self.instruction = ""
         self.blocks: list[str] = []          # 已定稿 block（可含 ANSI）
         self.live: str | None = None         # 当前流式助手文本（未定稿）
@@ -138,6 +146,39 @@ class ChatTUI:
             out.append(f"{mark}{i + 1}. {label}")
         out.append("\033[2m  ↑/↓ 选择 · Enter 确认 · 数字直选 · Ctrl-C 停止\033[0m")
         return out
+
+    def _completer(self):
+        from prompt_toolkit.completion import Completer, Completion
+        slash = self.slash_commands
+
+        class _C(Completer):
+            def get_completions(s, document, complete_event):
+                t = document.text_before_cursor
+                if not t.startswith("/"):
+                    return
+                for cmd, desc in slash:
+                    if cmd.startswith(t):
+                        yield Completion(cmd, start_position=-len(t), display=cmd, display_meta=desc)
+        return _C()
+
+    def _handle_submit(self, text: str) -> str:
+        """处理一条已提交文本。返回 'exit' / 'handled' / 'turn'。"""
+        if text in ("/exit", "/quit"):
+            return "exit"
+        if text == "/clear":
+            self.blocks = []
+            self.live = None
+            self.scroll = 0
+            return "handled"
+        pi = self._plan_intent(text)                       # 自然语言进/出计划模式
+        if pi is not None:
+            if self._set_plan is not None:
+                self.blocks.append("\033[2m" + self._set_plan(pi == "enter") + "\033[0m")
+            return "handled"
+        if text.startswith("/"):                           # 其它斜杠命令：P5 再接全，先提示
+            self.blocks.append(f"\033[2m（{text}：该命令暂请退出 TUI 后在行式界面使用；完整接入见 P5）\033[0m")
+            return "handled"
+        return "turn"
 
     def _body_ansi(self):
         from prompt_toolkit.formatted_text import ANSI
@@ -228,7 +269,18 @@ class ChatTUI:
 
         approving = Condition(lambda: self.pending is not None)
 
-        ta = TextArea(prompt=[("class:prompt", "❯ ")], multiline=False, height=1)
+        from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+        history = None
+        try:
+            from prompt_toolkit.history import FileHistory
+            from . import config as _cfg
+            _cfg.ensure_dirs()
+            history = FileHistory(str(_cfg.IVYEA_DIR / "chat_history"))
+        except Exception:
+            history = None
+        ta = TextArea(prompt=[("class:prompt", "❯ ")], multiline=False, height=1,
+                      completer=self._completer(), complete_while_typing=True,
+                      auto_suggest=AutoSuggestFromHistory(), history=history)
         root = HSplit([
             Window(FormattedTextControl(self._header), height=1, style="class:hdr"),
             Window(height=1, char="─", style="class:rule"),
@@ -275,10 +327,21 @@ class ChatTUI:
                 self.blocks.append(f"\033[2m⋯ 已排队：{text}\033[0m")
                 self._invalidate()
                 return
-            if text in ("/exit", "/quit"):
+            action = self._handle_submit(text)   # /exit /clear /plan / 计划模式 NL / 其它斜杠 / 普通轮
+            if action == "exit":
                 event.app.exit(result=0)
+            elif action == "handled":
+                self._invalidate()
+            else:
+                self._start_turn(text)
+
+        @kb.add("s-tab")                     # Shift+Tab：循环 普通/自动接受编辑/计划模式
+        def _(event):
+            if self.running or self.pending is not None or self._cycle is None:
                 return
-            self._start_turn(text)
+            label = self._cycle()
+            self.blocks.append(f"\033[2m⇄ 模式：{label}\033[0m")
+            self._invalidate()
 
         @kb.add("pageup")
         def _(event):
@@ -324,10 +387,14 @@ class ChatTUI:
 
 def run(status_fn: Callable[[], str], slash_commands: list,
         turn_fn: Callable[..., dict] | None = None,
-        render_markdown: Callable[[str], str] | None = None) -> int:
+        render_markdown: Callable[[str], str] | None = None,
+        plan_intent_fn: Callable[[str], str] | None = None,
+        set_plan_mode: Callable[[bool], str] | None = None,
+        cycle_mode: Callable[[], str] | None = None) -> int:
     """启动 TUI 会话。turn_fn(line, render, narrate)->dict 跑真正一轮。"""
     tui = ChatTUI(status_fn=status_fn, turn_fn=turn_fn or (lambda *a, **k: {"text": ""}),
-                  render_markdown=render_markdown)
+                  render_markdown=render_markdown, slash_commands=slash_commands,
+                  plan_intent_fn=plan_intent_fn, set_plan_mode=set_plan_mode, cycle_mode=cycle_mode)
     from . import tui as _tui_mod
     _tui_mod.set_active_selector(tui._approve)   # 工具线程的审批 marshal 回本 app
     try:

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -68,6 +68,8 @@ class ChatTUI:
         self.blocks: list[str] = []          # 已定稿 block（可含 ANSI）
         self.live: str | None = None         # 当前流式助手文本（未定稿）
         self.running = False
+        self.cancel_requested = False        # Esc/Ctrl-C 请求中断当前轮
+        self.queued: list[str] = []          # 运行中回车排队的后续指令
         self.scroll = 0                       # 距底部的物理行数；0=贴底跟随
         self.started = 0.0
         self.app = None
@@ -128,7 +130,9 @@ class ChatTUI:
         if self.running:
             frame = _SPIN[int((time.time() - self.started) * 10) % len(_SPIN)]
             secs = int(time.time() - self.started)
-            return [("class:run", f" {frame} 生成中 {secs}s · Esc 稍后接入中断"), ("class:ftr", " · " + base)]
+            q = f" · 已排队 {len(self.queued)}" if self.queued else ""
+            hint = " · 中断中…" if self.cancel_requested else " · Esc/Ctrl-C 中断 · 回车排队下一条"
+            return [("class:run", f" {frame} 生成中 {secs}s{hint}{q}"), ("class:ftr", " · " + base)]
         return [("class:ftr", " " + base)]
 
     def _start_turn(self, line: str) -> None:
@@ -136,11 +140,21 @@ class ChatTUI:
         self.blocks.append(f"\033[36m❯\033[0m {line}")
         self.scroll = 0
         self.running = True
+        self.cancel_requested = False
         self.started = time.time()
 
         def _worker():
             try:
-                out = self.turn_fn(line, self.render, self.narrate)
+                out = self.turn_fn(line, self.render, self.narrate,
+                                   cancel_check=lambda: self.cancel_requested)
+            except KeyboardInterrupt:
+                out = {"text": "", "cancelled": True}
+            except TypeError:
+                # turn_fn 不接受 cancel_check（如测试假函数）→ 退化重试
+                try:
+                    out = self.turn_fn(line, self.render, self.narrate)
+                except Exception as e:   # noqa: BLE001
+                    out = {"text": "", "error": str(e)}
             except Exception as e:   # noqa: BLE001
                 out = {"text": "", "error": str(e)}
             self._finish(out)
@@ -150,11 +164,19 @@ class ChatTUI:
 
     def _finish(self, out: dict) -> None:
         self._commit_live()
-        err = out.get("error")
-        if err:
-            self.blocks.append(f"\033[31m✗ 出错：{err}\033[0m")
+        if out.get("cancelled"):
+            self.blocks.append("\033[33m⛔ 已中断（会话已保留，可继续输入）\033[0m")
+        elif out.get("error"):
+            self.blocks.append(f"\033[31m✗ 出错：{out['error']}\033[0m")
         self.running = False
+        self.cancel_requested = False
         self.scroll = 0
+        # 处理运行中排队的后续指令：逐条自动继续
+        if self.queued:
+            nxt = self.queued.pop(0)
+            self._invalidate()
+            self._start_turn(nxt)
+            return
         self._invalidate()
 
     def build_app(self):
@@ -178,21 +200,40 @@ class ChatTUI:
         kb = KeyBindings()
 
         @kb.add("c-c")
+        def _(event):
+            if self.running:                 # 运行中：请求中断当前轮
+                self.cancel_requested = True
+            else:                            # 空闲：退出
+                event.app.exit(result=0)
+
         @kb.add("c-d")
         def _(event):
             event.app.exit(result=0)
 
+        @kb.add("escape", eager=True)
+        def _(event):
+            if self.running:                 # 运行中：Esc 也请求中断
+                self.cancel_requested = True
+
         @kb.add("enter")
         def _(event):
-            if self.running:      # P1：运行中先忽略输入（中断/排队见 P2）
-                return
             text = ta.text.strip()
             ta.text = ""
+            if not text:
+                return
+            if self.running:                 # 运行中：回车把指令排队，本轮结束后自动继续
+                if text in ("/exit", "/quit"):
+                    self.cancel_requested = True
+                    event.app.exit(result=0)
+                    return
+                self.queued.append(text)
+                self.blocks.append(f"\033[2m⋯ 已排队：{text}\033[0m")
+                self._invalidate()
+                return
             if text in ("/exit", "/quit"):
                 event.app.exit(result=0)
                 return
-            if text:
-                self._start_turn(text)
+            self._start_turn(text)
 
         @kb.add("pageup")
         def _(event):

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -242,6 +242,8 @@ class ChatTUI:
 
     def _finish(self, out: dict) -> None:
         self._commit_live()
+        if out.get("todos_panel"):           # 轮末计划面板（与行式对齐）
+            self.blocks.append(out["todos_panel"])
         if out.get("cancelled"):
             self.blocks.append("\033[33m⛔ 已中断（会话已保留，可继续输入）\033[0m")
         elif out.get("error"):

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -73,6 +73,10 @@ class ChatTUI:
         self.scroll = 0                       # 距底部的物理行数；0=贴底跟随
         self.started = 0.0
         self.app = None
+        # 审批（P3）：工具线程投递请求→主 app 渲染内联浮层→选定回填并唤醒
+        self.pending = None                  # {"title","body","options","idx"}
+        self._approval_ev = None
+        self._approval_result = None
 
     # ---- 供后台线程调用的输出回调（线程安全：仅追加 + invalidate）----
     def render(self, token: str = "") -> None:
@@ -104,11 +108,44 @@ class ChatTUI:
             except Exception:
                 pass
 
+    # ---- 审批（工具线程调用，阻塞等主 app 选定）----
+    def _approve(self, title: str, body: str, options: list, kind: str = "warn") -> str:
+        ev = threading.Event()
+        self._approval_ev = ev
+        self._approval_result = None
+        self.pending = {"title": title, "body": body, "options": options, "idx": 0}
+        self._invalidate()
+        ev.wait()                      # 阻塞工具线程，直到主 app 选定
+        return self._approval_result or (options[-1][0] if options else "")
+
+    def _confirm_approval(self, idx: int) -> None:
+        opts = self.pending["options"] if self.pending else []
+        if opts:
+            self._approval_result = opts[max(0, min(idx, len(opts) - 1))][0]
+        self.pending = None
+        if self._approval_ev is not None:
+            self._approval_ev.set()
+        self._invalidate()
+
+    def _approval_lines(self) -> list[str]:
+        p = self.pending
+        out = [f"\033[33m  ▌ {p['title']}\033[0m"]
+        for ln in str(p["body"]).splitlines():
+            out.append("    " + ln)
+        out.append("")
+        for i, (_k, label) in enumerate(p["options"]):
+            mark = "\033[36m ❯ \033[0m" if i == p["idx"] else "   "
+            out.append(f"{mark}{i + 1}. {label}")
+        out.append("\033[2m  ↑/↓ 选择 · Enter 确认 · 数字直选 · Ctrl-C 停止\033[0m")
+        return out
+
     def _body_ansi(self):
         from prompt_toolkit.formatted_text import ANSI
         parts = list(self.blocks)
         if self.live is not None:
             parts.append("\033[2m" + self.live + "\033[0m")   # 流式中 dim 显示原文
+        if self.pending is not None:
+            parts.append("\n".join(self._approval_lines()))   # 审批面板置于末尾
         text = "\n\n".join(p for p in parts if p) or "（开始对话吧。输入 /exit 退出。）"
         width = shutil.get_terminal_size((100, 30)).columns
         rows = shutil.get_terminal_size((100, 30)).lines
@@ -186,7 +223,10 @@ class ChatTUI:
         from prompt_toolkit.layout.controls import FormattedTextControl
         from prompt_toolkit.widgets import TextArea
         from prompt_toolkit.key_binding import KeyBindings
+        from prompt_toolkit.filters import Condition
         from prompt_toolkit.styles import Style
+
+        approving = Condition(lambda: self.pending is not None)
 
         ta = TextArea(prompt=[("class:prompt", "❯ ")], multiline=False, height=1)
         root = HSplit([
@@ -201,7 +241,9 @@ class ChatTUI:
 
         @kb.add("c-c")
         def _(event):
-            if self.running:                 # 运行中：请求中断当前轮
+            if self.pending is not None:     # 审批中：Ctrl-C = 选最后一项(约定=停止)
+                self._confirm_approval(len(self.pending["options"]) - 1)
+            elif self.running:               # 运行中：请求中断当前轮
                 self.cancel_requested = True
             else:                            # 空闲：退出
                 event.app.exit(result=0)
@@ -217,6 +259,9 @@ class ChatTUI:
 
         @kb.add("enter")
         def _(event):
+            if self.pending is not None:     # 审批中：回车确认当前选项（下方 filtered 处理，此处兜底）
+                self._confirm_approval(self.pending["idx"])
+                return
             text = ta.text.strip()
             ta.text = ""
             if not text:
@@ -243,6 +288,28 @@ class ChatTUI:
         def _(event):
             self.scroll = max(0, self.scroll - 5)
 
+        # 审批中：↑/↓ 移动选择，数字直选（仅 pending 时激活，不影响正常输入）
+        @kb.add("up", filter=approving)
+        def _(event):
+            n = len(self.pending["options"])
+            self.pending["idx"] = (self.pending["idx"] - 1) % n
+            self._invalidate()
+
+        @kb.add("down", filter=approving)
+        def _(event):
+            n = len(self.pending["options"])
+            self.pending["idx"] = (self.pending["idx"] + 1) % n
+            self._invalidate()
+
+        def _mk_digit(d):
+            def handler(event):
+                if self.pending and d - 1 < len(self.pending["options"]):
+                    self._confirm_approval(d - 1)
+            return handler
+
+        for _d in range(1, 10):
+            kb.add(str(_d), filter=approving)(_mk_digit(_d))
+
         style = Style.from_dict({
             "hdr": "bold ansicyan", "rule": "ansibrightblack",
             "ftr": "noreverse ansibrightblack", "run": "ansiyellow",
@@ -261,5 +328,10 @@ def run(status_fn: Callable[[], str], slash_commands: list,
     """启动 TUI 会话。turn_fn(line, render, narrate)->dict 跑真正一轮。"""
     tui = ChatTUI(status_fn=status_fn, turn_fn=turn_fn or (lambda *a, **k: {"text": ""}),
                   render_markdown=render_markdown)
-    tui.build_app().run()
+    from . import tui as _tui_mod
+    _tui_mod.set_active_selector(tui._approve)   # 工具线程的审批 marshal 回本 app
+    try:
+        tui.build_app().run()
+    finally:
+        _tui_mod.set_active_selector(None)
     return 0

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -1,0 +1,105 @@
+"""全屏 TUI 聊天界面（对标 Claude Code）。
+
+分阶段构建（见计划）。P0：骨架——固定头部（当前指令置顶）+ 可滚动 transcript
++ 常驻底部输入框，能渲染与干净退出。完整对话闭环、流式、审批在后续阶段接入。
+
+启用：TTY + IVYEA_TUI=1（opt-in）。非 TTY / 未开 / 依赖缺失时 `tui_enabled()`
+返回 False，调用方回退到现有行式 CLI。
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Callable
+
+_TRUTHY = ("1", "true", "on", "yes")
+
+
+def tui_enabled() -> bool:
+    """是否走全屏 TUI。默认关（opt-in），P5 再翻默认。"""
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return False
+    if os.environ.get("IVYEA_TUI", "").strip().lower() not in _TRUTHY:
+        return False
+    try:
+        import prompt_toolkit  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _style():
+    from prompt_toolkit.styles import Style
+    return Style.from_dict({
+        "hdr": "bold ansicyan",
+        "rule": "ansibrightblack",
+        "ftr": "noreverse ansibrightblack",
+        "prompt": "ansicyan bold",
+        "wip": "ansibrightblack",
+    })
+
+
+def run(status_fn: Callable[[], str], slash_commands: list) -> int:
+    """P0 骨架 TUI。返回退出码（供 _cmd_chat 直接 return）。
+
+    后续阶段会把 transcript 模型、后台跑轮、流式 marshal、审批浮层挂进来；
+    P0 只验证全屏外壳（头部/transcript/输入）能渲染并干净退出。
+    """
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.layout.containers import HSplit, Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    from prompt_toolkit.widgets import TextArea
+    from prompt_toolkit.key_binding import KeyBindings
+
+    state = {
+        "instruction": "",
+        "lines": ["（P0 骨架：完整对话将在后续阶段接入。输入 /exit 退出。）"],
+    }
+
+    def header_text():
+        instr = state["instruction"] or "（还没有指令）"
+        return [("class:hdr", f" ▶ 当前指令：{instr}")]
+
+    def body_text():
+        return [("class:wip", "\n".join(state["lines"]))]
+
+    def footer_text():
+        return [("class:ftr", " " + (status_fn() or ""))]
+
+    ta = TextArea(prompt=[("class:prompt", "❯ ")], multiline=False, height=1)
+    root = HSplit([
+        Window(FormattedTextControl(header_text), height=1, style="class:hdr"),
+        Window(height=1, char="─", style="class:rule"),
+        Window(FormattedTextControl(body_text), wrap_lines=True),   # transcript（P1 起可滚动）
+        Window(height=1, char="─", style="class:rule"),
+        Window(FormattedTextControl(footer_text), height=1, style="class:ftr"),
+        ta,
+    ])
+
+    kb = KeyBindings()
+
+    @kb.add("c-c")
+    @kb.add("c-d")
+    def _(event):
+        event.app.exit(result=0)
+
+    @kb.add("enter")
+    def _(event):
+        text = ta.text.strip()
+        ta.text = ""
+        if text in ("/exit", "/quit"):
+            event.app.exit(result=0)
+            return
+        if text:
+            state["instruction"] = text
+            state["lines"].append(f"❯ {text}")
+            state["lines"].append("（P0：对话闭环尚未接入，见 P1）")
+
+    app = Application(
+        layout=Layout(root, focused_element=ta),
+        key_bindings=kb, style=_style(),
+        full_screen=True, mouse_support=True,
+    )
+    app.run()
+    return 0

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1451,18 +1451,19 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         messages = [_sys_msg()]
         print(ui.message("success", "已清空对话上下文")); return True
 
-    def _set_plan_mode(on: bool) -> None:
-        """显式进/出计划模式（/plan 与自然语言共用）。已在目标状态则只提示。"""
+    def _set_plan_mode_msg(on: bool) -> str:
+        """进/出计划模式并返回提示消息（不打印）。/plan、NL、TUI 共用。"""
         if on == ctx.plan_mode:
-            print(ui.message("info", "已在计划模式。" if on else "当前不在计划模式。"))
-            return
+            return ui.message("info", "已在计划模式。" if on else "当前不在计划模式。")
         ctx.plan_mode = on
         messages[0] = _sys_msg()
         if on:
-            print(ui.message("info", "已进入计划模式（只读，不写入；说“退出计划模式”或 /approve 后执行）。"
-                                     "复杂任务建议先 /model 切更强主脑。"))
-        else:
-            print(ui.message("success", "已退出计划模式。"))
+            return ui.message("info", "已进入计划模式（只读，不写入；说“退出计划模式”或 /approve 后执行）。"
+                                      "复杂任务建议先 /model 切更强主脑。")
+        return ui.message("success", "已退出计划模式。")
+
+    def _set_plan_mode(on: bool) -> None:
+        print(_set_plan_mode_msg(on))
 
     def _sh_plan(line):
         _set_plan_mode(not ctx.plan_mode); return True
@@ -1691,7 +1692,10 @@ def _cmd_chat(args: argparse.Namespace) -> int:
     from . import chat_tui
     if chat_tui.tui_enabled():   # IVYEA_TUI=1 全屏 TUI（分阶段构建）；否则走下面的行式循环
         return chat_tui.run(_status, SLASH_COMMANDS, turn_fn=_execute_turn,
-                            render_markdown=markdown.render)
+                            render_markdown=markdown.render,
+                            plan_intent_fn=_plan_mode_intent,
+                            set_plan_mode=_set_plan_mode_msg,
+                            cycle_mode=_cycle_mode)
 
     while True:
         line = ci.read("❯ ")

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1681,6 +1681,9 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             pricing.add_spend(c)
         memory.index_turn("user", line, sid)
         memory.index_turn("assistant", out.get("text", ""), sid)
+        if ctx.todos:                        # 供 TUI 在轮末渲染计划面板（与行式对齐）
+            from . import panels as _panels
+            out["todos_panel"] = _panels.render_todos(ctx.todos, color=True)
         if ctx_mod.should_compact(int((out.get("usage") or {}).get("prompt_tokens") or 0)):
             messages, _s = ctx_mod.compact(messages, provider)
             if _s:

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1629,9 +1629,9 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         "/workspace": _sh_embedded, "/patch": _sh_embedded, "/gitops": _sh_embedded,
     }
 
-    def _execute_turn(line, render, narrate):
+    def _execute_turn(line, render, narrate, cancel_check=None):
         """跑一轮对话，输出经 render(token)/narrate(行) 注入 —— 供 TUI 复用（行式循环仍走下方原逻辑）。
-        返回 {text, usage, blocked}。会更新 messages/meter/记忆/上下文压缩。"""
+        cancel_check：运行中请求中断的钩子（TUI 用）。返回 {text, usage, blocked}。"""
         nonlocal messages
         api_key = cfg.get_active_key()
         cms = cfg.load_settings()
@@ -1673,7 +1673,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         provider = build_chain(mcfg, api_key, narrate=narrate)
         ctx.provider = provider
         out = agent_loop.run_turn_stream(provider, ctx, messages, model=mcfg.get("model", ""),
-                                         render=render, narrate=narrate)
+                                         render=render, narrate=narrate, cancel_check=cancel_check)
         c = meter.add(mcfg.get("model", ""), out.get("usage") or {})
         _ui["ctx"] = int((out.get("usage") or {}).get("prompt_tokens") or _ui["ctx"])
         if c:

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1629,6 +1629,10 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         "/workspace": _sh_embedded, "/patch": _sh_embedded, "/gitops": _sh_embedded,
     }
 
+    from . import chat_tui
+    if chat_tui.tui_enabled():   # IVYEA_TUI=1 全屏 TUI（分阶段构建）；否则走下面的行式循环
+        return chat_tui.run(_status, SLASH_COMMANDS)
+
     while True:
         line = ci.read("❯ ")
         if line is chat_input.EXIT:

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1629,9 +1629,69 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         "/workspace": _sh_embedded, "/patch": _sh_embedded, "/gitops": _sh_embedded,
     }
 
+    def _execute_turn(line, render, narrate):
+        """跑一轮对话，输出经 render(token)/narrate(行) 注入 —— 供 TUI 复用（行式循环仍走下方原逻辑）。
+        返回 {text, usage, blocked}。会更新 messages/meter/记忆/上下文压缩。"""
+        nonlocal messages
+        api_key = cfg.get_active_key()
+        cms = cfg.load_settings()
+        if (cms.get("kind") in ("native", "oauth", "login")
+                and cms.get("api_mode") not in ("gemini_native", "gemini_code_assist", "bedrock_converse", "copilot_chat_completions", "codex_responses")):
+            narrate(ui.message("warn", "当前 provider 需原生/OAuth transport，尚未接入。请用 /model 切换。"))
+            return {"text": "", "usage": {}, "blocked": True}
+        if _model_needs_key(cms) and not api_key:
+            narrate(ui.message("warn", f"未配置主脑模型 key（{cms.get('key_env')}）。用 /model 配置。"))
+            return {"text": "", "usage": {}, "blocked": True}
+        _lim = pricing.daily_limit()
+        if _lim > 0 and pricing.today_spend() >= _lim:
+            narrate(ui.message("warn", f"今日已花 ¥{pricing.today_spend():.2f} 达上限 ¥{_lim:.2f}，已暂停。"))
+            return {"text": "", "usage": {}, "blocked": True}
+        from . import engineering_context, knowledge, skills
+        ectx = engineering_context.build(os.getcwd(), line)
+        _inject = bool(getattr(ctx, "asin", "")) or _is_amazon_domain(line) or not _looks_like_code_task(line)
+        kctx, kids = knowledge.context_for_query(line, limit=3) if _inject else ("", [])
+        sctx, sids = skills.context_for_query(line, limit=2) if _inject else ("", [])
+        user_content = line
+        if ectx:
+            user_content += "\n\n[工程上下文]\n" + ectx
+            narrate(ui.stage("Code", "计划 → 读上下文 → 修改/生成补丁 → 测试 → 复查"))
+        if sctx:
+            user_content += ("\n\n[Ivyea Skill：本轮相关可复用流程]\n" + sctx
+                             + "\n\n要求：优先按 skill workflow 组织执行步骤；涉及事实依据时再结合知识库。")
+            narrate(ui.message("muted", "已注入 skill: " + ", ".join(sids)))
+        if kctx:
+            user_content += ("\n\n[Ivyea 内置亚马逊知识库：本轮相关摘录]\n" + kctx
+                             + "\n\n要求：使用这些知识时说明依据，若与用户账户记忆冲突，以用户账户记忆为准。")
+            narrate(ui.message("muted", "已注入知识卡: " + ", ".join(kids)))
+        import time as _tt
+        ctx.turn_id = _tt.strftime("%Y%m%d-%H%M%S")
+        from . import hooks as _hooks
+        _hooks.fire("user_prompt", {"prompt": line, "session_id": sid or "", "turn_id": ctx.turn_id})
+        messages[0] = _sys_msg()
+        messages.append({"role": "user", "content": user_content})
+        mcfg = cfg.get_model_config()
+        provider = build_chain(mcfg, api_key, narrate=narrate)
+        ctx.provider = provider
+        out = agent_loop.run_turn_stream(provider, ctx, messages, model=mcfg.get("model", ""),
+                                         render=render, narrate=narrate)
+        c = meter.add(mcfg.get("model", ""), out.get("usage") or {})
+        _ui["ctx"] = int((out.get("usage") or {}).get("prompt_tokens") or _ui["ctx"])
+        if c:
+            pricing.add_spend(c)
+        memory.index_turn("user", line, sid)
+        memory.index_turn("assistant", out.get("text", ""), sid)
+        if ctx_mod.should_compact(int((out.get("usage") or {}).get("prompt_tokens") or 0)):
+            messages, _s = ctx_mod.compact(messages, provider)
+            if _s:
+                memory.remember_summary(_s, sid)
+                narrate(ui.message("info", "上下文较长，已自动压缩并入库摘要以省 token"))
+        out["blocked"] = False
+        return out
+
     from . import chat_tui
     if chat_tui.tui_enabled():   # IVYEA_TUI=1 全屏 TUI（分阶段构建）；否则走下面的行式循环
-        return chat_tui.run(_status, SLASH_COMMANDS)
+        return chat_tui.run(_status, SLASH_COMMANDS, turn_fn=_execute_turn,
+                            render_markdown=markdown.render)
 
     while True:
         line = ci.read("❯ ")

--- a/ivyea_agent/tui.py
+++ b/ivyea_agent/tui.py
@@ -10,6 +10,15 @@ from typing import Callable, Optional
 
 from . import ui
 
+# 活动选择器：全屏 TUI 运行时挂上自己的审批路由(fn(title, body, options, kind)->key)，
+# 让工具线程里的审批不再自建嵌套 Application，而是 marshal 回主 app。默认 None。
+_ACTIVE_SELECTOR: Optional[Callable[[str, str, list, str], str]] = None
+
+
+def set_active_selector(fn: Optional[Callable[[str, str, list, str], str]]) -> None:
+    global _ACTIVE_SELECTOR
+    _ACTIVE_SELECTOR = fn
+
 
 def _default_input(prompt: str) -> str:
     try:
@@ -121,6 +130,11 @@ def select(title: str, body: str, options: list[tuple[str, str]], *,
     """
     if not options:
         return ""
+    if _ACTIVE_SELECTOR is not None:   # 全屏 TUI：路由到主 app 的内联审批，避免嵌套 Application
+        try:
+            return _ACTIVE_SELECTOR(title, body, options, kind)
+        except Exception:
+            pass   # 路由失败则回退下方常规路径
     reader = input_fn or _default_input
     if not sys.stdin.isatty():
         return _fallback(title, body, options, kind, reader)

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -84,10 +84,55 @@ def test_turn_streams_and_interleaves_tool_lines():
 
 
 def test_turn_error_surfaced():
-    def boom(line, render, narrate):
+    def boom(line, render, narrate, cancel_check=None):
         raise RuntimeError("炸了")
     tui = chat_tui.ChatTUI(status_fn=lambda: "s", turn_fn=boom, render_markdown=lambda s: s)
     tui._start_turn("x")
     _wait_idle(tui)
     assert tui.running is False
     assert "炸了" in _plain("\n".join(tui.blocks))
+
+
+# ---- P2 中断 + 排队 ----
+def test_run_turn_stream_cancel_check_raises():
+    from ivyea_agent import agent_loop, agent_tools
+
+    class _P:
+        def stream_chat(self, *a, **k):
+            yield {"type": "text", "text": "x"}
+
+    ctx = agent_tools.ToolContext(session_id="s")
+    ctx.turn_id = "t"
+    import pytest as _pt
+    with _pt.raises(KeyboardInterrupt):
+        agent_loop.run_turn_stream(_P(), ctx, [{"role": "user", "content": "hi"}],
+                                   cancel_check=lambda: True)
+
+
+def test_tui_interrupt_preserves_session():
+    import time
+    def slow(line, render, narrate, cancel_check=None):
+        for _ in range(200):
+            if cancel_check and cancel_check():
+                raise KeyboardInterrupt
+            time.sleep(0.005)
+        return {"text": "done"}
+    tui = chat_tui.ChatTUI(status_fn=lambda: "s", turn_fn=slow, render_markdown=lambda s: s)
+    tui._start_turn("长任务")
+    time.sleep(0.05)
+    tui.cancel_requested = True
+    _wait_idle(tui)
+    assert tui.running is False
+    assert "已中断" in _plain("\n".join(tui.blocks))
+
+
+def test_tui_queue_auto_continues():
+    def quick(line, render, narrate, cancel_check=None):
+        render(f"答:{line}")
+        return {"text": line}
+    tui = chat_tui.ChatTUI(status_fn=lambda: "s", turn_fn=quick, render_markdown=lambda s: s)
+    tui.running = True
+    tui.queued = ["第二条"]
+    tui._finish({"text": "第一条 done"})    # 结束首轮 → 自动跑排队的下一条
+    _wait_idle(tui)
+    assert "❯ 第二条" in _plain("\n".join(tui.blocks))

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -136,3 +136,63 @@ def test_tui_queue_auto_continues():
     tui._finish({"text": "第一条 done"})    # 结束首轮 → 自动跑排队的下一条
     _wait_idle(tui)
     assert "❯ 第二条" in _plain("\n".join(tui.blocks))
+
+
+# ---- P3 审批 marshal 到 TUI ----
+def test_approval_marshaled_from_tool_thread():
+    import threading
+    import time
+    from ivyea_agent import tui as tui_mod
+
+    tui = chat_tui.ChatTUI(status_fn=lambda: "s", turn_fn=lambda *a, **k: {"text": ""},
+                           render_markdown=lambda s: s)
+    tui_mod.set_active_selector(tui._approve)
+    res = {}
+
+    def worker():
+        res["r"] = tui_mod.select("需要确认写操作", "编辑 demo.py：替换 1 处",
+                                  [("approve", "批准本次"), ("deny", "拒绝"), ("abort", "全部停止")])
+
+    th = threading.Thread(target=worker)
+    th.start()
+    for _ in range(200):
+        if tui.pending:
+            break
+        time.sleep(0.005)
+    try:
+        assert tui.pending is not None
+        panel = _plain("\n".join(tui._approval_lines()))
+        assert "批准本次" in panel and "编辑 demo.py" in panel   # 选项 + diff 预览
+        tui._confirm_approval(0)                                  # 选“批准本次”
+        th.join(timeout=1)
+        assert res.get("r") == "approve"
+        assert tui.pending is None
+    finally:
+        tui_mod.set_active_selector(None)
+
+
+def test_approval_ctrl_c_picks_last_abort():
+    import threading
+    import time
+    from ivyea_agent import tui as tui_mod
+
+    tui = chat_tui.ChatTUI(status_fn=lambda: "s", turn_fn=lambda *a, **k: {"text": ""},
+                           render_markdown=lambda s: s)
+    tui_mod.set_active_selector(tui._approve)
+    res = {}
+
+    def worker():
+        res["r"] = tui_mod.select("t", "b", [("approve", "a"), ("deny", "d"), ("abort", "停止")])
+
+    th = threading.Thread(target=worker)
+    th.start()
+    for _ in range(200):
+        if tui.pending:
+            break
+        time.sleep(0.005)
+    try:
+        tui._confirm_approval(len(tui.pending["options"]) - 1)   # 模拟 Ctrl-C 选最后
+        th.join(timeout=1)
+        assert res.get("r") == "abort"
+    finally:
+        tui_mod.set_active_selector(None)

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -54,3 +54,40 @@ def test_skeleton_sticky_header_and_clean_exit():
 def test_skeleton_ctrl_c_exits():
     rc, _ = _run_headless("\x03")                    # Ctrl-C 退出
     assert rc == 0
+
+
+# ---- P1 核心闭环 ----
+def _wait_idle(tui, timeout=2.0):
+    import time
+    end = time.time() + timeout
+    while time.time() < end and tui.running:
+        time.sleep(0.02)
+
+
+def test_turn_streams_and_interleaves_tool_lines():
+    import time
+    def fake_turn(line, render, narrate):
+        render("你好"); narrate("⏺ 读取文件"); render("，世界")
+        return {"text": "你好，世界", "usage": {}, "blocked": False}
+
+    tui = chat_tui.ChatTUI(status_fn=lambda: "s", turn_fn=fake_turn, render_markdown=lambda s: s)
+    tui._start_turn("改 greet.py")
+    _wait_idle(tui)
+    assert tui.running is False
+    assert tui.instruction == "改 greet.py"          # sticky 头部指令
+    assert tui.live is None                           # 流式已定稿
+    plain = _plain("\n".join(tui.blocks))
+    assert "❯ 改 greet.py" in plain                   # 用户回显
+    assert "你好" in plain and "，世界" in plain      # 两段流式文本
+    # Claude 式交错：文本 → 工具行 → 继续文本
+    assert plain.index("你好") < plain.index("⏺ 读取文件") < plain.index("，世界")
+
+
+def test_turn_error_surfaced():
+    def boom(line, render, narrate):
+        raise RuntimeError("炸了")
+    tui = chat_tui.ChatTUI(status_fn=lambda: "s", turn_fn=boom, render_markdown=lambda s: s)
+    tui._start_turn("x")
+    _wait_idle(tui)
+    assert tui.running is False
+    assert "炸了" in _plain("\n".join(tui.blocks))

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -171,6 +171,34 @@ def test_approval_marshaled_from_tool_thread():
         tui_mod.set_active_selector(None)
 
 
+# ---- P4 输入对齐 ----
+def test_handle_submit_routes():
+    from ivyea_agent.cli import _plan_mode_intent
+    tui = chat_tui.ChatTUI(
+        status_fn=lambda: "s", turn_fn=lambda *a, **k: {"text": ""}, render_markdown=lambda s: s,
+        slash_commands=[("/exit", "退出"), ("/plan", "计划"), ("/model", "模型")],
+        plan_intent_fn=_plan_mode_intent,
+        set_plan_mode=lambda on: ("已进入计划模式" if on else "已退出计划模式"),
+        cycle_mode=lambda: "自动接受编辑",
+    )
+    assert tui._handle_submit("/exit") == "exit"
+    tui.blocks = ["x"]
+    assert tui._handle_submit("/clear") == "handled" and tui.blocks == []
+    assert tui._handle_submit("进入计划模式") == "handled"
+    assert "计划模式" in _plain("\n".join(tui.blocks))
+    assert tui._handle_submit("/model") == "handled"           # 其它 slash → P5 提示
+    assert "P5" in _plain("\n".join(tui.blocks))
+    assert tui._handle_submit("帮我分析广告") == "turn"        # 普通 → 跑一轮
+
+
+def test_completer_slash():
+    from prompt_toolkit.document import Document
+    tui = chat_tui.ChatTUI(status_fn=lambda: "s", turn_fn=lambda *a, **k: {"text": ""},
+                           render_markdown=lambda s: s, slash_commands=[("/exit", "退出"), ("/plan", "计划")])
+    cs = list(tui._completer().get_completions(Document("/e"), None))
+    assert [c.text for c in cs] == ["/exit"]
+
+
 def test_approval_ctrl_c_picks_last_abort():
     import threading
     import time

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -1,0 +1,56 @@
+"""全屏 TUI 聊天骨架（P0）。"""
+from __future__ import annotations
+
+import io
+import re
+
+import pytest
+
+from ivyea_agent import chat_tui
+
+
+def _plain(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", s)
+
+
+def test_tui_disabled_when_not_tty(monkeypatch):
+    # 测试环境非 TTY：无论 IVYEA_TUI 如何都应回退（返回 False）
+    monkeypatch.setenv("IVYEA_TUI", "1")
+    assert chat_tui.tui_enabled() is False
+
+
+def _run_headless(keys: str, status="  ivyea · GPT-5.5 · dry-run "):
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output.vt100 import Vt100_Output
+    from prompt_toolkit.data_structures import Size
+    import prompt_toolkit.application as ptkapp
+
+    buf = io.StringIO()
+    with create_pipe_input() as pinp:
+        orig = ptkapp.Application
+
+        def factory(*a, **k):
+            k.setdefault("input", pinp)
+            k.setdefault("output", Vt100_Output(buf, lambda: Size(rows=30, columns=100), term="xterm-256color"))
+            return orig(*a, **k)
+
+        ptkapp.Application = factory
+        try:
+            pinp.send_text(keys)
+            rc = chat_tui.run(lambda: status, [("/model", "x"), ("/exit", "退出")])
+        finally:
+            ptkapp.Application = orig
+    return rc, _plain(buf.getvalue())
+
+
+def test_skeleton_sticky_header_and_clean_exit():
+    rc, vis = _run_headless("排查任务\r/exit\r")
+    assert rc == 0                                   # /exit 干净退出
+    assert "当前指令：排查任务" in vis               # sticky 头部显示最近指令
+    assert "GPT-5.5" in vis                          # footer 显示 status
+    assert "❯ 排查任务" in vis                       # transcript 回显
+
+
+def test_skeleton_ctrl_c_exits():
+    rc, _ = _run_headless("\x03")                    # Ctrl-C 退出
+    assert rc == 0


### PR DESCRIPTION
## 全屏 TUI 聊天界面（对标 Claude Code，opt-in）

把 `ivyea chat` 可选重构成 prompt_toolkit 全屏 alt-screen TUI：**固定头部显示当前指令（滚动不丢）+ 常驻底部输入框 + 可滚动 transcript**。`IVYEA_TUI=1` 开启；非 TTY / 未开 / 依赖缺失 → 回退现有行式 CLI（默认仍行式，未翻默认）。

新模块 `ivyea_agent/chat_tui.py`。分 6 阶段：
- **P0** 骨架 + flag + 兜底
- **P1** sticky 头部 + 常驻输入 + 后台线程跑一轮 + 助手文本/工具行线程安全 marshal 进 transcript（根治此前的流式刷屏）
- **P2** Esc/Ctrl-C 中断（`run_turn_stream` 加回可选 `cancel_check`）+ 运行中回车排队
- **P3** 审批搬进 TUI 内联面板（`tui._ACTIVE_SELECTOR` 钩子，避免嵌套第二个 Application；diff 预览 + 方向键/数字选）
- **P4** slash 补全 + ↑↓历史 + autosuggest + 计划模式（/plan+NL）+ Shift+Tab 模式循环
- **P5** 轮末 todo 计划面板对齐

`cli` 抽出 `_execute_turn(line,render,narrate,cancel_check)` 供 TUI 复用，**行式循环不动（零回归）**。

验证：507 测试全绿 + 真机 pty(GPT-5.5) 全链路（sticky 头部/流式/工具行/todo 面板/edit_file 审批改文件/不刷屏）。

已知代价：alt-screen 丢终端原生 scrollback/框选复制（用 app 内 PgUp/PgDn）；`/model` 等复杂 slash 命令在 TUI 内暂提示"退出后用"（后续补）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
