### PR TITLE
fix(tui): 输入框移到分隔线上方，状态栏置底

### DIFF
--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -288,10 +288,10 @@ class ChatTUI:
         root = HSplit([
             Window(FormattedTextControl(self._header), height=1, style="class:hdr"),
             Window(height=1, char="─", style="class:rule"),
-            Window(FormattedTextControl(self._body_ansi), wrap_lines=True),
-            Window(height=1, char="─", style="class:rule"),
-            Window(FormattedTextControl(self._footer), height=1),
-            ta,
+            Window(FormattedTextControl(self._body_ansi), wrap_lines=True),   # transcript
+            ta,                                                              # 输入框（紧贴 transcript 下方）
+            Window(height=1, char="─", style="class:rule"),                  # 分隔线
+            Window(FormattedTextControl(self._footer), height=1),            # 状态栏（最底部）
         ])
         kb = KeyBindings()
 


### PR DESCRIPTION
原布局输入框掉在状态栏下方最底部。改为 transcript→输入框→分隔线→状态栏。真机验证顺序正确，508 测试全绿。🤖 Generated with [Claude Code](https://claude.com/claude-code)