### PR TITLE
fix(tui): banner回归+去重复指令+输入框成框

### DIFF
--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -66,7 +66,8 @@ class ChatTUI:
                  slash_commands: list | None = None,
                  plan_intent_fn: Callable[[str], str] | None = None,
                  set_plan_mode: Callable[[bool], str] | None = None,
-                 cycle_mode: Callable[[], str] | None = None):
+                 cycle_mode: Callable[[], str] | None = None,
+                 intro: str | None = None):
         self.status_fn = status_fn
         self.turn_fn = turn_fn
         self._md = render_markdown or (lambda s: s)
@@ -75,7 +76,7 @@ class ChatTUI:
         self._set_plan = set_plan_mode        # (on)->msg 或 None
         self._cycle = cycle_mode              # ()->label 或 None
         self.instruction = ""
-        self.blocks: list[str] = []          # 已定稿 block（可含 ANSI）
+        self.blocks: list[str] = [intro] if intro else []   # banner+欢迎框作首块
         self.live: str | None = None         # 当前流式助手文本（未定稿）
         self.running = False
         self.cancel_requested = False        # Esc/Ctrl-C 请求中断当前轮
@@ -216,8 +217,7 @@ class ChatTUI:
         return [("class:ftr", " " + base)]
 
     def _start_turn(self, line: str) -> None:
-        self.instruction = line
-        self.blocks.append(f"\033[36m❯\033[0m {line}")
+        self.instruction = line               # 头部固定显示当前指令；不再在 transcript 里重复回显
         self.scroll = 0
         self.running = True
         self.cancel_requested = False
@@ -289,8 +289,9 @@ class ChatTUI:
             Window(FormattedTextControl(self._header), height=1, style="class:hdr"),
             Window(height=1, char="─", style="class:rule"),
             Window(FormattedTextControl(self._body_ansi), wrap_lines=True),   # transcript
-            ta,                                                              # 输入框（紧贴 transcript 下方）
-            Window(height=1, char="─", style="class:rule"),                  # 分隔线
+            Window(height=1, char="─", style="class:rule"),                  # 输入框上边线
+            ta,                                                              # 输入框（上下有线，像个框）
+            Window(height=1, char="─", style="class:rule"),                  # 输入框下边线
             Window(FormattedTextControl(self._footer), height=1),            # 状态栏（最底部）
         ])
         kb = KeyBindings()
@@ -394,11 +395,13 @@ def run(status_fn: Callable[[], str], slash_commands: list,
         render_markdown: Callable[[str], str] | None = None,
         plan_intent_fn: Callable[[str], str] | None = None,
         set_plan_mode: Callable[[bool], str] | None = None,
-        cycle_mode: Callable[[], str] | None = None) -> int:
+        cycle_mode: Callable[[], str] | None = None,
+        intro: str | None = None) -> int:
     """启动 TUI 会话。turn_fn(line, render, narrate)->dict 跑真正一轮。"""
     tui = ChatTUI(status_fn=status_fn, turn_fn=turn_fn or (lambda *a, **k: {"text": ""}),
                   render_markdown=render_markdown, slash_commands=slash_commands,
-                  plan_intent_fn=plan_intent_fn, set_plan_mode=set_plan_mode, cycle_mode=cycle_mode)
+                  plan_intent_fn=plan_intent_fn, set_plan_mode=set_plan_mode, cycle_mode=cycle_mode,
+                  intro=intro)
     from . import tui as _tui_mod
     _tui_mod.set_active_selector(tui._approve)   # 工具线程的审批 marshal 回本 app
     try:

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1309,18 +1309,23 @@ def _plan_mode_intent(line: str) -> str | None:
     return None
 
 
-def _print_welcome_box(lines: list, width: int = 58) -> None:
-    """Claude Code 风格圆角欢迎框（按显示宽度对齐中英文混排）。"""
+def _welcome_box_str(lines: list, width: int = 58) -> str:
+    """Claude Code 风格圆角欢迎框（按显示宽度对齐中英文混排），返回字符串。"""
     try:
         from prompt_toolkit.utils import get_cwidth
     except Exception:
         def get_cwidth(ch): return 1
     inner, cy, x = width - 2, _C["c"], _C["x"]
-    print(f"{cy}╭{'─' * inner}╮{x}")
+    out = [f"{cy}╭{'─' * inner}╮{x}"]
     for ln in lines:
         w = sum(get_cwidth(ch) for ch in _strip_ansi(ln))
-        print(f"{cy}│{x} {ln}{' ' * max(0, inner - 1 - w)}{cy}│{x}")
-    print(f"{cy}╰{'─' * inner}╯{x}")
+        out.append(f"{cy}│{x} {ln}{' ' * max(0, inner - 1 - w)}{cy}│{x}")
+    out.append(f"{cy}╰{'─' * inner}╯{x}")
+    return "\n".join(out)
+
+
+def _print_welcome_box(lines: list, width: int = 58) -> None:
+    print(_welcome_box_str(lines, width))
 
 
 def _cmd_chat(args: argparse.Namespace) -> int:
@@ -1401,20 +1406,26 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         _n_mcp = len(cfg.load_mcp().get("mcpServers", {}))
     except Exception:
         _n_tools = _n_skills = _n_mcp = 0
-    print(f"{_C['c']}{_C['b']}{_BANNER}{_C['x']}")
-    _print_welcome_box([
+    _welcome_lines = [
         f"{_C['c']}✻{_C['x']} {_C['b']}亚马逊运营 Agent{_C['x']} · 规则引擎+LLM复核+审核制执行 · 自托管",
         f"{_C['d']}主脑 {_label()}（{keyst}）· 执行 {mode}{_C['x']}",
         f"{_C['d']}{_n_tools} 工具 · {_n_skills} skills · {_n_mcp} MCP · 会话 {(sid or '新')[:8]}{_C['x']}",
         f"{_C['d']}/ 命令 · ↑↓+Enter 选择 · Alt+Enter 换行 · /exit 退出{_C['x']}",
-    ], width=64)
-    print()
-
-    # 主脑健康探测（本地，不发网络）：凭据过期/未配时醒目提示并指明出路，避免“开箱即坏”。
+    ]
+    from . import chat_tui as _chat_tui
+    _tui_on = _chat_tui.tui_enabled()
     _health = cfg.main_brain_health()
-    if not _health.get("ok"):
-        print(ui.message("warn", _health.get("hint", "主脑不可用，请用 /model 切换。")))
+    _health_msg = "" if _health.get("ok") else ui.message("warn", _health.get("hint", "主脑不可用，请用 /model 切换。"))
+    # TUI 模式：banner+欢迎框作为 transcript 首块（打印会被 alt-screen 清掉）；行式则直接打印。
+    _intro = f"{_C['c']}{_C['b']}{_BANNER}{_C['x']}\n" + _welcome_box_str(_welcome_lines, width=64)
+    if _health_msg:
+        _intro += "\n" + _health_msg
+    if not _tui_on:
+        print(f"{_C['c']}{_C['b']}{_BANNER}{_C['x']}")
+        _print_welcome_box(_welcome_lines, width=64)
         print()
+        if _health_msg:
+            print(_health_msg + "\n")
 
     from . import chat_input
 
@@ -1692,13 +1703,12 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         out["blocked"] = False
         return out
 
-    from . import chat_tui
-    if chat_tui.tui_enabled():   # IVYEA_TUI=1 全屏 TUI（分阶段构建）；否则走下面的行式循环
-        return chat_tui.run(_status, SLASH_COMMANDS, turn_fn=_execute_turn,
-                            render_markdown=markdown.render,
-                            plan_intent_fn=_plan_mode_intent,
-                            set_plan_mode=_set_plan_mode_msg,
-                            cycle_mode=_cycle_mode)
+    if _tui_on:                  # 全屏 TUI（默认；IVYEA_TUI=0 走下面的行式循环）
+        return _chat_tui.run(_status, SLASH_COMMANDS, turn_fn=_execute_turn,
+                             render_markdown=markdown.render,
+                             plan_intent_fn=_plan_mode_intent,
+                             set_plan_mode=_set_plan_mode_msg,
+                             cycle_mode=_cycle_mode, intro=_intro)
 
     while True:
         line = ci.read("❯ ")

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -59,9 +59,8 @@ def _run_headless(keys: str, status="  ivyea · GPT-5.5 · dry-run "):
 def test_skeleton_sticky_header_and_clean_exit():
     rc, vis = _run_headless("排查任务\r/exit\r")
     assert rc == 0                                   # /exit 干净退出
-    assert "当前指令：排查任务" in vis               # sticky 头部显示最近指令
+    assert "当前指令：排查任务" in vis               # sticky 头部显示最近指令（不再 transcript 重复回显）
     assert "GPT-5.5" in vis                          # footer 显示 status
-    assert "❯ 排查任务" in vis                       # transcript 回显
 
 
 def test_skeleton_ctrl_c_exits():
@@ -90,7 +89,7 @@ def test_turn_streams_and_interleaves_tool_lines():
     assert tui.instruction == "改 greet.py"          # sticky 头部指令
     assert tui.live is None                           # 流式已定稿
     plain = _plain("\n".join(tui.blocks))
-    assert "❯ 改 greet.py" in plain                   # 用户回显
+    assert tui.instruction == "改 greet.py"           # 指令在头部（不再 transcript 回显）
     assert "你好" in plain and "，世界" in plain      # 两段流式文本
     # Claude 式交错：文本 → 工具行 → 继续文本
     assert plain.index("你好") < plain.index("⏺ 读取文件") < plain.index("，世界")
@@ -148,7 +147,8 @@ def test_tui_queue_auto_continues():
     tui.queued = ["第二条"]
     tui._finish({"text": "第一条 done"})    # 结束首轮 → 自动跑排队的下一条
     _wait_idle(tui)
-    assert "❯ 第二条" in _plain("\n".join(tui.blocks))
+    assert tui.instruction == "第二条"                       # 队列已自动继续到第二条
+    assert "答:第二条" in _plain("\n".join(tui.blocks))      # 第二条的回复已渲染
 
 
 # ---- P3 审批 marshal 到 TUI ----


### PR DESCRIPTION
banner/信息框作 transcript 首块;去 transcript 重复指令回显(头部已置顶);输入框上下加线成框。真机验证,508 全绿。🤖 Generated with [Claude Code](https://claude.com/claude-code)