### PR TITLE
feat(chat): 默认改回滚动缓冲区 + 视觉对标 Claude(指令带/流式/markdown/上下文条/自动压缩)

### DIFF
--- a/ivyea_agent/chat_input.py
+++ b/ivyea_agent/chat_input.py
@@ -19,10 +19,12 @@ EXIT = object()  # 哨兵：用户在框内 Ctrl+C/Ctrl+D 退出
 
 class ChatInput:
     def __init__(self, slash_commands: list, status_fn: Callable[[], str],
-                 mode_cycle_fn: Callable[[], str] | None = None):
+                 mode_cycle_fn: Callable[[], str] | None = None,
+                 mode_label_fn: Callable[[], str] | None = None):
         self.slash = slash_commands
         self.status_fn = status_fn
         self.mode_cycle_fn = mode_cycle_fn   # shift+tab 循环模式：普通→自动接受→计划；返回新模式名
+        self.mode_label_fn = mode_label_fn   # ()->当前模式文字，显示在输入框上边线右端（对标 Claude）
         self._app_factory = None      # 带框 Application（每次新建）
         self._session = None          # 普通 PromptSession 兜底
         self._mode = "plain"
@@ -92,6 +94,8 @@ class ChatInput:
             "frame.border": "ansicyan",
             "hint": "ansibrightblack",
             "prompt": "ansicyan bold",
+            "mode": "ansicyan bold",                      # 输入框边线右端的模式标签
+
             "auto-suggestion": "ansibrightblack",        # 历史建议的灰字 ghost text
             "completion-menu": "#d1d5db",
             "completion-menu.completion": "#d1d5db",
@@ -104,15 +108,27 @@ class ChatInput:
             "bottom-toolbar.text": "ansibrightblack",
         }
 
-    @staticmethod
-    def _rounded_frame(body):
-        """圆角边框（╭╮╰╯），与欢迎框/Claude·Codex 风格统一；ptk 自带 Frame 是方角。"""
+    def _rounded_frame(self, body):
+        """圆角边框（╭╮╰╯），与欢迎框/Claude·Codex 风格统一；ptk 自带 Frame 是方角。
+        顶边线右端嵌当前模式标签（⏸ 计划模式 / ⚡ 自动接受编辑），对标 Claude 边线标签。"""
         from prompt_toolkit.layout.containers import HSplit, VSplit, Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
 
         def fill(char, width=None, height=None):
             return Window(char=char, style="class:frame.border", width=width, height=height)
 
-        top = VSplit([fill("╭", 1, 1), fill("─", height=1), fill("╮", 1, 1)], height=1)
+        def _label():
+            m = (self.mode_label_fn() if self.mode_label_fn else "") or ""
+            if not m:
+                return [("class:frame.border", "──")]
+            return [("class:frame.border", "─ "), ("class:mode", m), ("class:frame.border", " ─")]
+
+        top = VSplit([
+            fill("╭", 1, 1),
+            fill("─", height=1),                                              # 左侧铺满
+            Window(FormattedTextControl(_label), height=1, dont_extend_width=True),
+            fill("╮", 1, 1),
+        ], height=1)
         mid = VSplit([fill("│", 1), body, fill("│", 1)])
         bot = VSplit([fill("╰", 1, 1), fill("─", height=1), fill("╯", 1, 1)], height=1)
         return HSplit([top, mid, bot])
@@ -159,6 +175,16 @@ class ChatInput:
             else:
                 buf.cursor_right()
 
+        @kb.add("tab")              # Tab：优先接受 ghost 建议，否则走斜杠补全菜单
+        def _(event):
+            buf = ta.buffer
+            if buf.complete_state:
+                buf.complete_next()
+            elif buf.suggestion and buf.suggestion.text:
+                buf.insert_text(buf.suggestion.text)
+            elif buf.text.startswith("/"):
+                buf.start_completion(select_first=True)
+
         @kb.add("c-c")
         @kb.add("c-d")
         def _(event):
@@ -183,13 +209,27 @@ class ChatInput:
 
     @staticmethod
     def _echo_submitted(text: str) -> None:
+        """把刚提交的指令回显成 Claude 风格：`>` + 淡灰整行背景带，视觉上独立出来。"""
         if not text.strip():
             return
-        marker = "❯" if os.environ.get("NO_COLOR") else "\033[36m❯\033[0m"
         lines = text.split("\n")
-        # 首行带 ❯ 提示，多行输入的续行缩进 2 格与正文对齐
-        body = f"{marker} {lines[0]}" + "".join(f"\n  {ln}" for ln in lines[1:])
-        sys.stdout.write(body + "\n")
+        if os.environ.get("NO_COLOR"):
+            body = "".join((f"> {ln}\n" if i == 0 else f"  {ln}\n") for i, ln in enumerate(lines))
+            sys.stdout.write("\n" + body + "\n"); sys.stdout.flush(); return
+        try:
+            from prompt_toolkit.utils import get_cwidth
+            dw = lambda s: sum(get_cwidth(c) for c in s)   # noqa: E731
+        except Exception:
+            dw = len
+        import shutil
+        width = max(20, shutil.get_terminal_size((80, 24)).columns)
+        BG, MK, FG, X = "\033[48;5;236m", "\033[38;5;45m", "\033[38;5;252m", "\033[0m"
+        sys.stdout.write("\n")   # 与上文留一空行
+        for i, ln in enumerate(lines):
+            head = f"{MK}> {FG}" if i == 0 else f"{FG}  "   # 首行 > 标记，续行缩进对齐
+            pad = " " * max(0, width - 2 - dw(ln))
+            sys.stdout.write(f"{BG}{head}{ln}{pad}{X}\n")
+        sys.stdout.write("\n")   # 指令带与回答之间留白
         sys.stdout.flush()
 
     def read(self, plain_prompt: str = "❯ ") -> object:

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -19,16 +19,17 @@ import threading
 import time
 from typing import Callable
 
-_FALSY = ("0", "false", "off", "no")
+_TRUTHY = ("1", "true", "on", "yes")
 _SPIN = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 
 def tui_enabled() -> bool:
-    """是否走全屏 TUI。默认开；`IVYEA_TUI=0/false/off/no` 退回行式 CLI。
-    非 TTY / prompt_toolkit 不可用时也自动回退，保证任何环境可用。"""
-    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+    """是否走全屏 TUI（alt-screen）。默认**关**——走行式（正常滚动缓冲区），
+    这样鼠标滚轮/框选复制原生可用（对标 Claude Code）。仅 `IVYEA_TUI=1/true/on/yes`
+    才进全屏 TUI（opt-in）。非 TTY / prompt_toolkit 不可用时也回退到行式。"""
+    if os.environ.get("IVYEA_TUI", "").strip().lower() not in _TRUTHY:
         return False
-    if os.environ.get("IVYEA_TUI", "").strip().lower() in _FALSY:
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return False
     try:
         import prompt_toolkit  # noqa: F401

--- a/ivyea_agent/chat_ui.py
+++ b/ivyea_agent/chat_ui.py
@@ -137,4 +137,4 @@ class _StreamPrinter:
                 sys.stdout.write(f"\033[{lines - 1}A")
             sys.stdout.write("\033[J")
             sys.stdout.flush()
-        print(f"{_C['c']}●{_C['x']} " + markdown.render(final_text))
+        print(f"\n{_C['c']}●{_C['x']} " + markdown.render(final_text))   # 回答前留一空行，呼吸感

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1430,14 +1430,26 @@ def _cmd_chat(args: argparse.Namespace) -> int:
 
     from . import chat_input
 
+    def _ctx_bar() -> str:
+        """上下文用量进度条：ctx ▓▓░░░░ 22%（45k/96k）。分母=自动压缩阈值——到 100% 即压缩回落，
+        对标 Claude 的"距压缩还剩多少"。优先用 provider 真实 prompt_tokens，不回报时回退本地估算。"""
+        used = _ui["ctx"] or ctx_mod.estimate_tokens(messages)
+        if not used:
+            return ""
+        limit = int(cfg.get_setting("compact_at_tokens", ctx_mod.DEFAULT_COMPACT_AT))
+        pct = min(100, round(used * 100 / max(1, limit)))
+        n = 10
+        filled = min(n, round(pct * n / 100))
+        bar = "▓" * filled + "░" * (n - filled)
+        return f"ctx {bar} {pct}%（{used // 1000}k/{limit // 1000}k）· "
+
     def _status() -> str:
         plan = "计划模式 · " if ctx.plan_mode else ""
         auto = "⚡自动放行 · " if ctx.perm.accept_edits else ""
         cost = f"¥{meter.cost:.4f} · " if meter.turns else ""
-        cx = f"ctx ~{_ui['ctx'] // 1000}k · " if _ui["ctx"] else ""
         turns = f"{meter.turns} 轮 · " if meter.turns else ""
         return (f" ivyea · {_label()} · {plan}{auto}"
-                f"{'真实写' if args.execute else 'dry-run'} · {turns}{cx}{cost}shift+tab 切模式 ")
+                f"{'真实写' if args.execute else 'dry-run'} · {turns}{_ctx_bar()}{cost}shift+tab 切模式 ")
 
     def _cycle_mode() -> str:
         """Shift+Tab 循环：普通 → 自动接受编辑 → 计划模式 → 普通。返回新模式名。"""
@@ -1532,7 +1544,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
     def _sh_compact(line):
         nonlocal messages
         if line in ("/compact auto", "/compact auto status"):
-            state = "开启" if bool(cfg.get_setting("auto_compact", False)) else "关闭"
+            state = "开启" if bool(cfg.get_setting("auto_compact", ctx_mod.DEFAULT_AUTO_COMPACT)) else "关闭"
             th = int(cfg.get_setting("compact_at_tokens", ctx_mod.DEFAULT_COMPACT_AT))
             print(ui.message("info", f"自动压缩：{state} · 阈值 {th} prompt tokens")); return True
         if line in ("/compact auto on", "/compact auto off"):
@@ -1815,7 +1827,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
                     provider, ctx, messages, model=mcfg.get("model", ""),
                     render=spin.tick, narrate=lambda s: (spin.clear(), print(s)))
                 spin.clear()
-                print(f"{_C['c']}●{_C['x']} " + markdown.render(out["text"]))
+                print(f"\n{_C['c']}●{_C['x']} " + markdown.render(out["text"]))   # 回答前留一空行
             else:
                 print(f"{_C['c']}●{_C['x']} ", end="", flush=True)
                 out = agent_loop.run_turn_stream(provider, ctx, messages, model=mcfg.get("model", ""))

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1386,7 +1386,8 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         sid = sessions.new_id()
     ctx.session_id = sid
     render_md = not getattr(args, "raw", False)   # 默认 markdown 渲染
-    stream_live = bool(cfg.get_setting("stream_live", False))   # 完整流式（opt-in，/stream on）
+    # 完整流式默认开（tty 下逐字出字、收尾重排 markdown，对标 Claude）；/stream 可切、可持久化覆盖
+    stream_live = bool(cfg.get_setting("stream_live", True))
 
     def _persist():
         try:
@@ -1449,7 +1450,15 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         messages[0] = _sys_msg()   # 计划模式影响 system prompt
         return label
 
-    ci = chat_input.ChatInput(SLASH_COMMANDS, _status, mode_cycle_fn=_cycle_mode)
+    def _mode_label() -> str:      # 输入框上边线右端显示的当前模式（对标 Claude）
+        if ctx.plan_mode:
+            return "⏸ 计划模式"
+        if ctx.perm.accept_edits:
+            return "⚡ 自动接受编辑"
+        return ""
+
+    ci = chat_input.ChatInput(SLASH_COMMANDS, _status, mode_cycle_fn=_cycle_mode,
+                              mode_label_fn=_mode_label)
     from . import hooks as _hooks
     _hooks.fire("session_start", {"session_id": sid or "", "cwd": os.getcwd()})
 
@@ -1703,14 +1712,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         out["blocked"] = False
         return out
 
-    def _mode_label() -> str:    # 输入框上边线右端显示的当前模式（对标 Claude）
-        if ctx.plan_mode:
-            return "⏸ 计划模式"
-        if ctx.perm.accept_edits:
-            return "⚡ 自动接受编辑"
-        return ""
-
-    if _tui_on:                  # 全屏 TUI（默认；IVYEA_TUI=0 走下面的行式循环）
+    if _tui_on:                  # 全屏 TUI（opt-in：IVYEA_TUI=1；默认走下面的行式循环）
         return _chat_tui.run(_status, SLASH_COMMANDS, turn_fn=_execute_turn,
                              render_markdown=markdown.render,
                              plan_intent_fn=_plan_mode_intent,

--- a/ivyea_agent/context.py
+++ b/ivyea_agent/context.py
@@ -10,10 +10,10 @@ from typing import Optional
 
 from . import config
 
-# 默认只提示，不自动压缩。真正需要节省上下文时由用户执行 /compact。
-# 对支持更长上下文的模型，96K 仍保留一定余量；小上下文模型可自行 config set compact_at_tokens。
+# 默认主动自动压缩（对标 Claude Code）：prompt tokens 越过软阈值即在轮后压缩历史，
+# 压缩时给提示。/compact auto off 可关。小上下文模型可 config set compact_at_tokens 调低。
 DEFAULT_COMPACT_AT = 96000
-DEFAULT_AUTO_COMPACT = False
+DEFAULT_AUTO_COMPACT = True
 # 轮内硬上限：无论是否开自动压缩，估算 token 越过它就强制压缩以防请求溢出报错。
 # 这是“防崩”而非“省钱”，所以默认开启、阈值取得很高，正常长任务不会触发。
 DEFAULT_HARD_CEILING = 200000

--- a/ivyea_agent/markdown.py
+++ b/ivyea_agent/markdown.py
@@ -92,11 +92,23 @@ def _render(md: str) -> str:
             out.extend(_render_table(table_buf))
             table_buf.clear()
 
+    def _blank():
+        if out and out[-1] != "":
+            out.append("")
+
     for ln in lines:
         fence = re.match(r"^\s*```(\w*)", ln)
         if fence:
             _flush_table()
-            in_code = not in_code
+            if not in_code:                       # 代码块开：上方留白 + 语言标注框头
+                lang = fence.group(1)
+                _blank()
+                out.append(f"{_DIM}╭─{(' ' + lang) if lang else ''}{_X}")
+                in_code = True
+            else:                                 # 代码块关：框尾 + 下方留白
+                out.append(f"{_DIM}╰─{_X}")
+                out.append("")
+                in_code = False
             continue
         if in_code:
             out.append(f"{_CODE_BAR} {_CODE}{ln}{_X}")
@@ -109,8 +121,13 @@ def _render(md: str) -> str:
         if h:
             level = len(h.group(1))
             color = (_CY, _MG, _YE, _GR, _GR, _GR)[min(level - 1, 5)]
-            prefix = "" if level == 1 else _DIM + "#" * level + " " + _X
-            out.append(f"{prefix}{_B}{color}{_inline(h.group(2))}{_X}")
+            _blank()                              # 标题上方留白，呼吸感
+            title = _inline(h.group(2))
+            if level == 1:                        # 一级标题：不留 #，加同色下划色条
+                out.append(f"{_B}{color}{title}{_X}")
+                out.append(f"{_DIM}{color}{'─' * min(48, max(4, _vis_len(h.group(2))))}{_X}")
+            else:
+                out.append(f"{_DIM}{'#' * level} {_X}{_B}{color}{title}{_X}")
             continue
         if re.match(r"^\s*([-*_])\1{2,}\s*$", ln):
             out.append(f"{_DIM}{'─' * 48}{_X}")

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -13,23 +13,25 @@ def _plain(s: str) -> str:
     return re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", s)
 
 
-def test_tui_default_on_tty_and_opt_out(monkeypatch):
+def test_tui_default_off_and_opt_in(monkeypatch):
     import types
     monkeypatch.setattr(chat_tui.sys, "stdin", types.SimpleNamespace(isatty=lambda: True))
     monkeypatch.setattr(chat_tui.sys, "stdout", types.SimpleNamespace(isatty=lambda: True))
     monkeypatch.delenv("IVYEA_TUI", raising=False)
-    assert chat_tui.tui_enabled() is True                 # TTY 下默认开
-    for off in ("0", "false", "Off", "NO"):
-        monkeypatch.setenv("IVYEA_TUI", off)
-        assert chat_tui.tui_enabled() is False            # IVYEA_TUI=0 退回行式
+    assert chat_tui.tui_enabled() is False                # 默认走行式（正常滚动缓冲区）
+    for on in ("1", "true", "On", "YES"):
+        monkeypatch.setenv("IVYEA_TUI", on)
+        assert chat_tui.tui_enabled() is True             # IVYEA_TUI=1 才进全屏 TUI（opt-in）
+    monkeypatch.setenv("IVYEA_TUI", "0")
+    assert chat_tui.tui_enabled() is False
 
 
 def test_tui_disabled_when_not_tty(monkeypatch):
     import types
     monkeypatch.setattr(chat_tui.sys, "stdin", types.SimpleNamespace(isatty=lambda: False))
     monkeypatch.setattr(chat_tui.sys, "stdout", types.SimpleNamespace(isatty=lambda: True))
-    monkeypatch.delenv("IVYEA_TUI", raising=False)
-    assert chat_tui.tui_enabled() is False                # 非 TTY 自动回退
+    monkeypatch.setenv("IVYEA_TUI", "1")                  # 即便 opt-in，非 TTY 也回退行式
+    assert chat_tui.tui_enabled() is False
 
 
 def _run_headless(keys: str, status="  ivyea · GPT-5.5 · dry-run "):

--- a/tests/test_context_sessions.py
+++ b/tests/test_context_sessions.py
@@ -13,11 +13,13 @@ class _FakeProvider:
 
 def test_should_compact_threshold(ivyea_home):
     from ivyea_agent import config, context
-    assert context.should_compact(120000) is False
-    assert context.should_warn_compact(120000) is True
+    assert context.DEFAULT_AUTO_COMPACT is True           # 默认主动压缩（对标 Claude）
+    config.set_setting("auto_compact", False)
+    assert context.should_compact(120000) is False        # 关时不自动压
+    assert context.should_warn_compact(120000) is True    # 但仍会提示手动 /compact
     config.set_setting("auto_compact", True)
-    assert context.should_compact(120000) is True
-    assert context.should_compact(100) is False
+    assert context.should_compact(120000) is True         # 开时越过阈值即压
+    assert context.should_compact(100) is False           # 未过阈值不压
 
 
 def test_compact_replaces_history_no_tool_pairs(ivyea_home):

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -131,7 +131,8 @@ def test_chat_input_echo_indents_multiline(capsys, monkeypatch):
     ChatInput._echo_submitted("第一行\n第二行")
     ChatInput._echo_submitted("   ")                      # 纯空白不回显
     out = capsys.readouterr().out
-    assert out == "❯ 第一行\n  第二行\n"                  # 续行缩进 2 格、空白被跳过
+    # Claude 风格：> 标记 + 续行缩进 2 格，上下留白；NO_COLOR 无背景带
+    assert out == "\n> 第一行\n  第二行\n\n"
 
 
 def test_ui_icons_fallback_to_ascii_on_non_utf8(monkeypatch):


### PR DESCRIPTION
根因:全屏 alt-screen 无 scrollback→滚轮滚不动、丢原生复制。改回行式(正常缓冲区)做默认,全屏TUI留 IVYEA_TUI=1 opt-in。并对标 Claude:逐字流式默认、用户指令 > 淡灰带、markdown 标题/代码块框线、输入框边线模式标签、Tab补全、上下文进度条、自动压缩默认开、回答留白。真机验证,509全绿。🤖 Generated with [Claude Code](https://claude.com/claude-code)