### PR TITLE
feat: 对标 Claude Code 补齐6项能力 + 输入框钉底重构(常驻底部app+滚轮/复制)

### DIFF
--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -225,13 +225,16 @@ def run_turn(provider: LLMProvider, ctx: ToolContext, messages: list,
 def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
                     max_steps: int | None = None, narrate: Callable[[str], None] = print,
                     render: Callable[[str], None] = None, model: str = "",
-                    cancel_check: Callable[[], bool] | None = None) -> dict:
+                    cancel_check: Callable[[], bool] | None = None,
+                    render_reasoning: Callable[[str], None] = None) -> dict:
     """流式跑一轮：token 边出边渲染、工具实时叙述、累计用量。
     返回 {text, usage}（usage 为本轮各步累加）。render(token) 逐字输出助手文本。
 
-    cancel_check：TUI 忙碌时请求中断的钩子；在步/流/工具边界返回 True 则抛
-    KeyboardInterrupt，交给上层保留会话并恢复输入。默认无操作，行式循环不受影响。"""
+    render_reasoning(token)：支持思考的模型(deepseek-reasoner/codex/claude/gemini)的
+    思考流；默认无操作(不显示)。cancel_check：TUI 忙碌时请求中断的钩子；在步/流/工具边界
+    返回 True 则抛 KeyboardInterrupt，交给上层保留会话并恢复输入。"""
     render = render or (lambda s: print(s, end="", flush=True))
+    render_reasoning = render_reasoning or (lambda s: None)
     cancel_check = cancel_check or (lambda: False)
     total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "prompt_cache_hit_tokens": 0}
 
@@ -258,6 +261,8 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
             if ev["type"] == "text":
                 printed_any = True
                 render(ev["text"])
+            elif ev["type"] == "reasoning":
+                render_reasoning(ev.get("text") or "")
             elif ev["type"] == "final":
                 final = ev
         if printed_any:

--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -18,7 +18,7 @@ from .providers import LLMProvider
 
 SYSTEM_PROMPT = """你是 Ivyea Agent：既是资深亚马逊运营专家，也是合格的编码/工程助手——两类任务都是你的一等本职。按用户当前需求自然切换：运营就按运营流程走，写代码就按工程流程走。
 广告：run_patrol(巡检) → propose_actions(看动作) → execute_actions(逐条人工审批执行) → 必要时 rollback。
-通用：read_file/list_dir/web_fetch/web_search 读取信息；write_file/edit_file 产出文件；run_python(可用 pandas/openpyxl 读 Excel、算数)、run_command 执行——这些写/执行操作都会弹人工审批。
+通用：read_file/list_dir/web_fetch/web_search 读取信息；write_file/edit_file 产出文件；run_python(可用 pandas/openpyxl 读 Excel、算数)、run_command 执行——这些写/执行操作都会弹人工审批。长任务（dev server、watch、长构建等不会很快结束的命令）用 run_command 的 run_in_background=true 后台跑、立即拿 bash_id，再用 bash_output 轮询输出，别在前台干等。
 代码：先 grep(内容正则)/glob(按文件名找文件)/code_search(找相关文件)/code_symbols/code_impact 定位，再 read_file 看真实内容（改前必读，别瞎猜路径）。改代码按场景选一个写工具：改单个文件的某一处→edit_file(唯一 old→new)；新建或整体重写文件→write_file；跨多文件/多处关联改动或要顺带跑测试→code_apply_patch(一次提交全部 ops)。每个写工具都是一次调用即审批落盘——**一次逻辑改动只用一个工具，不要先 dry-run 再 execute、也不要同一处既 edit_file 又 code_apply_patch 重复弹审批**。改完测试失败用 run_tests/code_repair 闭环修复。
 委派：需要多角度/独立的调研，可用 dispatch_subagent 派只读子 agent 并行查清，避免主线被探索细节塞满。
 MCP：用户接了 MCP 服务器时，用 mcp_list_tools/mcp_list_resources/mcp_list_prompts 发现，mcp_read_resource/mcp_get_prompt 取内容，mcp_call_tool 调用工具（写类会审批）。

--- a/ivyea_agent/agent_tools.py
+++ b/ivyea_agent/agent_tools.py
@@ -526,7 +526,8 @@ _DISPATCH = {
 # 可安全并行的只读工具：纯文件系统/网络读，不弹审批、不写共享状态（DB/索引文件）。
 # 故意保守：DB 检索（knowledge/skill/recall）和会写索引文件的 code_search/symbols/impact
 # 不在此列，避免 SQLite 跨线程或索引文件写竞争。
-PARALLEL_SAFE = {"read_file", "list_dir", "web_fetch", "web_search", "grep", "glob", "code_search", "code_symbols"}
+PARALLEL_SAFE = {"read_file", "list_dir", "web_fetch", "web_search", "grep", "glob",
+                 "code_search", "code_symbols", "bash_output"}
 
 
 @dataclass

--- a/ivyea_agent/chat_input.py
+++ b/ivyea_agent/chat_input.py
@@ -16,6 +16,31 @@ from . import config
 
 EXIT = object()  # 哨兵：用户在框内 Ctrl+C/Ctrl+D 退出
 
+import re as _re
+_AT_RE = _re.compile(r"(?<!\S)@([^\s@]*)$")   # 光标前最后一个 @路径片段（用于补全）
+
+
+def _at_completions(frag: str):
+    """@文件引用的路径补全：按当前片段列出目录下匹配的文件/子目录。"""
+    from prompt_toolkit.completion import Completion
+    base = os.path.dirname(frag)
+    prefix = os.path.basename(frag)
+    listdir = base or "."
+    try:
+        entries = sorted(os.listdir(os.path.expanduser(listdir)))
+    except Exception:
+        return
+    for name in entries:
+        if name.startswith(".") and not prefix.startswith("."):
+            continue
+        if not name.startswith(prefix):
+            continue
+        full = os.path.join(base, name) if base else name
+        is_dir = os.path.isdir(os.path.expanduser(full))
+        disp = full + ("/" if is_dir else "")
+        yield Completion(disp, start_position=-len(frag), display=disp,
+                         display_meta="目录" if is_dir else "文件")
+
 
 class ChatInput:
     def __init__(self, slash_commands: list, status_fn: Callable[[], str],
@@ -38,6 +63,10 @@ class ChatInput:
         class _C(Completer):
             def get_completions(s, document, complete_event):
                 t = document.text_before_cursor
+                m = _AT_RE.search(t)             # @路径补全（@文件引用）
+                if m:
+                    yield from _at_completions(m.group(1))
+                    return
                 if not t.startswith("/"):
                     return
                 seen = set()

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -64,6 +64,73 @@ def _visual_lines(text: str, width: int) -> list[str]:
     return out
 
 
+def _ptprint(s: str) -> None:
+    """打印带 ANSI 的一段到滚动缓冲区。patch_stdout 下必须走 print_formatted_text(ANSI())，
+    直接 print 原始 ANSI 会被当字面量（显示成 ?[36m）。"""
+    from prompt_toolkit import print_formatted_text
+    from prompt_toolkit.formatted_text import ANSI
+    print_formatted_text(ANSI(s))
+
+
+class _ScrollEmitter:
+    """滚动缓冲区输出器（patch_stdout 安全、无光标 erase）。assistant 文本按块（空行边界）缓冲
+    → 渲染 markdown 打印；工具行/思考直接打印。对标 Claude/Ink：完成内容落到正常滚动缓冲区，
+    底部输入框由 app 常驻重绘。所有输出走 _ptprint（print_formatted_text(ANSI)）。"""
+    def __init__(self, render_markdown):
+        self._md = render_markdown or (lambda s: s)
+        self._buf = ""            # 当前 assistant 文本块缓冲
+        self._emitted = False     # 本轮是否已定稿过块（● 仅首块）
+        self._reason_buf = ""      # 思考缓冲（收尾/被打断时一次性 dim 打印）
+
+    def text(self, token: str) -> None:
+        self._buf += token
+        while "\n\n" in self._buf:
+            block, self._buf = self._buf.split("\n\n", 1)
+            self._emit(block)
+
+    def _emit(self, block: str) -> None:
+        if not block.strip():
+            return
+        self._flush_reason()
+        prefix = "\033[36m●\033[0m " if not self._emitted else ""
+        self._emitted = True
+        _ptprint(prefix + self._md(block.strip()))
+
+    def flush_text(self) -> None:
+        if self._buf.strip():
+            self._emit(self._buf)
+        self._buf = ""
+
+    def line(self, text: str) -> None:
+        """工具行 / stage / 提示：先把当前文本块定稿，再直接打印。"""
+        self.flush_text()
+        self._flush_reason()
+        _ptprint(text)
+
+    def echo(self, line: str) -> None:
+        """把用户指令回显成 Claude 风格灰底带（打到滚动缓冲区）。"""
+        import shutil
+        try:
+            from prompt_toolkit.utils import get_cwidth
+            dw = lambda s: sum(get_cwidth(c) for c in s)   # noqa: E731
+        except Exception:
+            dw = len
+        width = max(20, shutil.get_terminal_size((80, 24)).columns)
+        BG, MK, FG = "\033[48;5;236m", "\033[38;5;45m", "\033[38;5;252m"
+        for i, ln in enumerate(str(line).split("\n")):
+            head = f"{MK}> {FG}" if i == 0 else f"{FG}  "
+            pad = " " * max(0, width - 2 - dw(ln))
+            _ptprint(f"{BG}{head}{ln}{pad}\033[0m")
+
+    def reasoning(self, token: str) -> None:
+        self._reason_buf += token or ""
+
+    def _flush_reason(self) -> None:
+        if self._reason_buf.strip():
+            _ptprint("\033[2m✻ 思考\n" + self._reason_buf.strip() + "\033[0m")
+        self._reason_buf = ""
+
+
 class ChatTUI:
     """一次 TUI 会话的状态与渲染。turn_fn(line, render, narrate)->dict 跑真正一轮。"""
 
@@ -74,11 +141,16 @@ class ChatTUI:
                  set_plan_mode: Callable[[bool], str] | None = None,
                  cycle_mode: Callable[[], str] | None = None,
                  mode_label_fn: Callable[[], str] | None = None,
+                 slash_handlers: dict | None = None,
+                 scrollback: bool = False,
                  intro: str | None = None):
         self.status_fn = status_fn
         self.turn_fn = turn_fn
         self._md = render_markdown or (lambda s: s)
         self.slash_commands = slash_commands or []
+        self._slash_handlers = slash_handlers or {}   # {"/model": fn, ...} 全量斜杠命令
+        self.scrollback = scrollback                  # True=常驻底部 app+patch_stdout（默认体验）
+        self._emitter = _ScrollEmitter(self._md) if scrollback else None
         self._mode_label_fn = mode_label_fn   # ()->当前模式文字 或 None
         self._plan_intent = plan_intent_fn or (lambda _t: None)
         self._set_plan = set_plan_mode        # (on)->msg 或 None
@@ -101,13 +173,32 @@ class ChatTUI:
     def render(self, token: str = "") -> None:
         if not token:
             return
+        if self.scrollback:          # 打到正常滚动缓冲区上方（输入框由 app 常驻钉底）
+            self._emitter.text(token)
+            return
         self.live = (self.live or "") + token
         self._scroll_to_bottom()     # 新内容 → 贴底跟随
         self._invalidate()
 
+    def render_reasoning(self, token: str = "") -> None:
+        if self.scrollback and token:
+            self._emitter.reasoning(token)
+
+    def _emit_line(self, text: str) -> None:
+        """一次性提示行（排队/模式切换/斜杠提示）：滚动区 print，alt-screen 进 transcript。"""
+        if self.scrollback:
+            _ptprint(text)
+        else:
+            self.blocks.append(text)
+            self._scroll_to_bottom()
+            self._invalidate()
+
     def narrate(self, text: str = "") -> None:
         text = str(text or "")
         if not text.strip():
+            return
+        if self.scrollback:
+            self._emitter.line(text)
             return
         self._commit_live()          # 工具行/提示打断当前流式文本，先定稿
         self.blocks.append(text)
@@ -182,16 +273,46 @@ class ChatTUI:
             self.blocks = []
             self.live = None
             self._scroll_to_bottom()
+            if self.scrollback:
+                self._emit_line("\033[2m（已清空对话上下文）\033[0m")
             return "handled"
         pi = self._plan_intent(text)                       # 自然语言进/出计划模式
         if pi is not None:
             if self._set_plan is not None:
-                self.blocks.append("\033[2m" + self._set_plan(pi == "enter") + "\033[0m")
+                self._emit_line("\033[2m" + self._set_plan(pi == "enter") + "\033[0m")
             return "handled"
-        if text.startswith("/"):                           # 其它斜杠命令：P5 再接全，先提示
-            self.blocks.append(f"\033[2m（{text}：该命令暂请退出 TUI 后在行式界面使用；完整接入见 P5）\033[0m")
+        head = text.split()[0] if text.split() else text
+        handler = self._slash_handlers.get(head)           # 全量斜杠命令（/model /compact /rewind /paste …）
+        if handler is not None:
+            self._run_slash(handler, text)
             return "handled"
+        if text.startswith("/"):                           # 未识别的斜杠命令 → 当普通轮/展开交给 turn_fn
+            return "turn"
         return "turn"
+
+    def _run_slash(self, handler, text: str) -> None:
+        """执行斜杠命令：滚动区模式下挂起 app 到终端跑（handler 多为 print/可能交互），避免嵌套 app。
+        运行期临时清空审批 marshal——否则 handler 里的 tui.select 会被 marshal 到已挂起的主 app 造成死锁。"""
+        from . import tui as _tui_mod
+
+        def _call():
+            _tui_mod.set_active_selector(None)
+            try:
+                handler(text)
+            finally:
+                _tui_mod.set_active_selector(self._approve)
+
+        if self.scrollback:
+            try:
+                from prompt_toolkit.application import run_in_terminal
+                run_in_terminal(_call)
+                return
+            except Exception:
+                pass
+        try:
+            _call()
+        except Exception as e:   # noqa: BLE001
+            self._emit_line(f"\033[31m命令出错：{e}\033[0m")
 
     def _body_height(self) -> int:
         """transcript 可用物理行数（终端高 - 输入框上线/输入/下线/状态栏 4 行）。"""
@@ -240,47 +361,70 @@ class ChatTUI:
 
     def _footer(self):
         base = self.status_fn() or ""
-        if self.running:   # "生成中" 已移到 transcript 内容处；footer 只留控制提示 + 状态
+        if self.running:
             q = f" · 已排队 {len(self.queued)}" if self.queued else ""
             hint = "中断中…" if self.cancel_requested else "Esc/Ctrl-C 中断 · 回车排队下一条"
+            if self.scrollback:   # 滚动区模式：footer 是唯一的"生成中"指示（带转圈+耗时）
+                frame = _SPIN[int((time.time() - self.started) * 10) % len(_SPIN)]
+                secs = int(time.time() - self.started)
+                return [("class:run", f" {frame} 生成中 {secs}s · {hint}{q}"), ("class:ftr", " · " + base)]
             return [("class:run", f" {hint}{q}"), ("class:ftr", " · " + base)]
         return [("class:ftr", " " + base)]
 
     def _start_turn(self, line: str) -> None:
         self.instruction = line
-        self.blocks.append(f"\033[36m❯\033[0m {line}")   # 问题内联回显（正常 Q/A 流，滚动可见）
+        if self.scrollback:                              # 指令回显成 Claude 风格灰底带，打到滚动区
+            self._emitter.echo(line)
+        else:
+            self.blocks.append(f"\033[36m❯\033[0m {line}")   # 内联回显（alt-screen transcript）
         self._scroll_to_bottom()
         self.running = True
         self.cancel_requested = False
         self.started = time.time()
 
+        def _call(**extra):
+            return self.turn_fn(line, self.render, self.narrate, **extra)
+
         def _worker():
-            try:
-                out = self.turn_fn(line, self.render, self.narrate,
-                                   cancel_check=lambda: self.cancel_requested)
-            except KeyboardInterrupt:
-                out = {"text": "", "cancelled": True}
-            except TypeError:
-                # turn_fn 不接受 cancel_check（如测试假函数）→ 退化重试
+            # 逐步退化匹配 turn_fn 签名（测试假函数可能不接受新 kwargs）；每级都兜住中断/异常
+            for extra in ({"cancel_check": lambda: self.cancel_requested,
+                           "render_reasoning": self.render_reasoning},
+                          {"cancel_check": lambda: self.cancel_requested},
+                          {}):
                 try:
-                    out = self.turn_fn(line, self.render, self.narrate)
+                    out = _call(**extra)
+                except KeyboardInterrupt:
+                    out = {"text": "", "cancelled": True}
+                except TypeError:
+                    continue   # 签名不匹配 → 试更少的参数
                 except Exception as e:   # noqa: BLE001
                     out = {"text": "", "error": str(e)}
-            except Exception as e:   # noqa: BLE001
-                out = {"text": "", "error": str(e)}
-            self._finish(out)
+                self._finish(out)
+                return
+            self._finish({"text": "", "error": "turn_fn 签名不兼容"})
 
         threading.Thread(target=_worker, daemon=True).start()
         self._invalidate()
 
     def _finish(self, out: dict) -> None:
-        self._commit_live()
-        if out.get("todos_panel"):           # 轮末计划面板（与行式对齐）
-            self.blocks.append(out["todos_panel"])
-        if out.get("cancelled"):
-            self.blocks.append("\033[33m⛔ 已中断（会话已保留，可继续输入）\033[0m")
-        elif out.get("error"):
-            self.blocks.append(f"\033[31m✗ 出错：{out['error']}\033[0m")
+        if self.scrollback:
+            self._emitter.flush_text()               # 定稿最后一个文本块
+            self._emitter._flush_reason()
+            if out.get("todos_panel"):
+                _ptprint(out["todos_panel"])
+            if out.get("cancelled"):
+                _ptprint("\033[33m⛔ 已中断（会话已保留，可继续输入）\033[0m")
+            elif out.get("error"):
+                _ptprint(f"\033[31m✗ 出错：{out['error']}\033[0m")
+            self._emitter._emitted = False           # 下一轮重新从 ● 首块开始
+        else:
+            self._commit_live()
+            if out.get("todos_panel"):           # 轮末计划面板（与行式对齐）
+                self.blocks.append(out["todos_panel"])
+            if out.get("cancelled"):
+                self.blocks.append("\033[33m⛔ 已中断（会话已保留，可继续输入）\033[0m")
+            elif out.get("error"):
+                self.blocks.append(f"\033[31m✗ 出错：{out['error']}\033[0m")
         self.running = False
         self.cancel_requested = False
         self._scroll_to_bottom()
@@ -316,21 +460,37 @@ class ChatTUI:
         ta = TextArea(prompt=[("class:prompt", "❯ ")], multiline=False, height=1,
                       completer=self._completer(), complete_while_typing=True,
                       auto_suggest=AutoSuggestFromHistory(), history=history)
-        from prompt_toolkit.layout.containers import VSplit
-        # transcript：末屏裁剪(贴底) + 键盘滚动。无固定头部——问题/回答正常内联流。
-        self._body_window = Window(FormattedTextControl(self._body_ansi), wrap_lines=True)
+        from prompt_toolkit.layout.containers import VSplit, ConditionalContainer
+        from prompt_toolkit.formatted_text import ANSI
         # 输入框上边线：右端显示当前模式（计划模式/自动接受编辑），对标 Claude 边线上的标签
         top_border = VSplit([
             Window(height=1, char="─", style="class:rule"),                  # 左侧铺满的线
             Window(FormattedTextControl(self._mode_label), height=1, dont_extend_width=True),
         ])
-        root = HSplit([
-            self._body_window,                                               # transcript
-            top_border,                                                      # 输入框上边线（右端带模式）
-            ta,                                                              # 输入框
-            Window(height=1, char="─", style="class:rule"),                  # 输入框下边线
-            Window(FormattedTextControl(self._footer), height=1),            # 状态栏（最底部）
-        ])
+        # 审批面板（有 pending 时显示在输入框上方；两模式共用）
+        approval_win = ConditionalContainer(
+            Window(FormattedTextControl(lambda: ANSI("\n".join(self._approval_lines()))), wrap_lines=True),
+            filter=approving)
+        if self.scrollback:
+            # 常驻底部 app：无内部 transcript（输出经 patch_stdout 落到正常滚动缓冲区上方）
+            self._body_window = None
+            root = HSplit([
+                approval_win,
+                top_border,                                                  # 输入框上边线（右端带模式）
+                ta,                                                          # 输入框（钉底）
+                Window(height=1, char="─", style="class:rule"),             # 输入框下边线
+                Window(FormattedTextControl(self._footer), height=1),        # 状态栏（生成中也在）
+            ])
+        else:
+            # alt-screen：内部 transcript（末屏裁剪+贴底+键盘滚动；审批面板在 _body_ansi 末尾）
+            self._body_window = Window(FormattedTextControl(self._body_ansi), wrap_lines=True)
+            root = HSplit([
+                self._body_window,
+                top_border,
+                ta,
+                Window(height=1, char="─", style="class:rule"),
+                Window(FormattedTextControl(self._footer), height=1),
+            ])
         kb = KeyBindings()
 
         @kb.add("c-c")
@@ -366,7 +526,7 @@ class ChatTUI:
                     event.app.exit(result=0)
                     return
                 self.queued.append(text)
-                self.blocks.append(f"\033[2m⋯ 已排队：{text}\033[0m")
+                self._emit_line(f"\033[2m⋯ 已排队：{text}\033[0m")
                 self._invalidate()
                 return
             action = self._handle_submit(text)   # /exit /clear /plan / 计划模式 NL / 其它斜杠 / 普通轮
@@ -382,7 +542,7 @@ class ChatTUI:
             if self.running or self.pending is not None or self._cycle is None:
                 return
             label = self._cycle()
-            self.blocks.append(f"\033[2m⇄ 模式：{label}\033[0m")
+            self._emit_line(f"\033[2m⇄ 模式：{label}\033[0m")
             self._invalidate()
 
         # 键盘滚动 transcript（mouse_support=False 为了原生框选复制，滚动走键盘）。
@@ -443,10 +603,11 @@ class ChatTUI:
             "run": "ansiyellow", "prompt": "ansicyan bold",
             "mode": "ansicyan bold", "auto-suggestion": "ansibrightblack",
         })
-        # mouse_support=False：不抢鼠标，终端原生选中/复制可用；滚动走键盘(PgUp/PgDn/Ctrl-U/B/N)
+        # mouse_support=False：不抢鼠标，终端原生选中/复制可用。scrollback 模式 full_screen=False
+        # （常驻底部 app，输出经 patch_stdout 落滚动缓冲区）；alt-screen 模式 full_screen=True。
         self.app = Application(
             layout=Layout(root, focused_element=ta), key_bindings=kb, style=style,
-            full_screen=True, mouse_support=False, refresh_interval=0.3,
+            full_screen=not self.scrollback, mouse_support=False, refresh_interval=0.3,
         )
         return self.app
 
@@ -458,16 +619,27 @@ def run(status_fn: Callable[[], str], slash_commands: list,
         set_plan_mode: Callable[[bool], str] | None = None,
         cycle_mode: Callable[[], str] | None = None,
         mode_label_fn: Callable[[], str] | None = None,
+        slash_handlers: dict | None = None,
+        scrollback: bool = False,
         intro: str | None = None) -> int:
-    """启动 TUI 会话。turn_fn(line, render, narrate)->dict 跑真正一轮。"""
+    """启动 TUI 会话。scrollback=True → 常驻底部 app + 输出落正常滚动缓冲区（默认体验，
+    保留原生滚轮/复制）；False → alt-screen 全屏 TUI。turn_fn 跑真正一轮。"""
     tui = ChatTUI(status_fn=status_fn, turn_fn=turn_fn or (lambda *a, **k: {"text": ""}),
                   render_markdown=render_markdown, slash_commands=slash_commands,
                   plan_intent_fn=plan_intent_fn, set_plan_mode=set_plan_mode, cycle_mode=cycle_mode,
-                  mode_label_fn=mode_label_fn, intro=intro)
+                  mode_label_fn=mode_label_fn, slash_handlers=slash_handlers,
+                  scrollback=scrollback, intro=intro)
     from . import tui as _tui_mod
     _tui_mod.set_active_selector(tui._approve)   # 工具线程的审批 marshal 回本 app
+    if scrollback and intro:
+        _ptprint(intro)                          # banner/欢迎框打到滚动缓冲区（输入框在其下方钉底）
     try:
-        tui.build_app().run()
+        if scrollback:
+            from prompt_toolkit.patch_stdout import patch_stdout
+            with patch_stdout():                 # 让后台/工具线程的 print 落在输入框上方
+                tui.build_app().run()
+        else:
+            tui.build_app().run()
     finally:
         _tui_mod.set_active_selector(None)
     return 0

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -297,9 +297,15 @@ class ChatTUI:
 
         def _call():
             _tui_mod.set_active_selector(None)
+            # patch_stdout 会把 print 的原始 ANSI 转义成字面量；run_in_terminal 已挂起 app，
+            # 临时换回真实终端流让 handler 的原始 ANSI 上色 + 交互输入正常，用完还原。
+            saved = sys.stdout
             try:
+                if self.scrollback and sys.__stdout__ is not None:
+                    sys.stdout = sys.__stdout__
                 handler(text)
             finally:
+                sys.stdout = saved
                 _tui_mod.set_active_selector(self._approve)
 
         if self.scrollback:

--- a/ivyea_agent/chat_ui.py
+++ b/ivyea_agent/chat_ui.py
@@ -100,11 +100,13 @@ class _LiveSpinner:
 
 
 class _StreamPrinter:
-    """完整流式：边生成边打印正文（dim），收尾按视觉行数擦除最后一段再渲染 markdown。
-    仅在 tty + /stream on 时启用；任何异常/非 tty 由调用方回退到 spinner 路径。"""
+    """渐进式 markdown 流式：正文以 dim 逐字出字；每当一个块（空行分隔）完成，立即擦掉
+    该 dim 块、改打印其 markdown 渲染版（committed），继续流下一块——收尾只剩最后一块要转，
+    避免整段"原文→渲染"的大跳变。仅 tty + /stream 时启用；异常/非 tty 由调用方回退 spinner。"""
     def __init__(self):
-        self.block = ""   # 当前连续正文段（被工具行打断即提交清零）
+        self.block = ""       # 屏上底部当前未定稿的 dim 块
         self.on = False
+        self._emitted = False  # 本轮是否已定稿过块（决定 ● 前缀只加一次）
 
     def render(self, text: str = "") -> None:
         if not text:
@@ -113,9 +115,20 @@ class _StreamPrinter:
         sys.stdout.flush()
         self.block += text
         self.on = True
+        while "\n\n" in self.block:                # 完成的块即时转 markdown
+            completed, remainder = self.block.split("\n\n", 1)
+            self._erase(self.block)                # 擦掉屏上整块 dim（completed+remainder）
+            self._emit_md(completed)
+            self.block = remainder
+            if remainder:                          # 余下部分继续以 dim 挂在底部
+                sys.stdout.write(f"{_C['d']}{remainder}{_C['x']}")
+                sys.stdout.flush()
 
     def commit(self) -> None:
-        """被 narrate（工具行/提示）打断：保留已打印文本，重置当前段。"""
+        """被 narrate（工具行/提示）打断：把当前块定稿为 markdown 再让工具行打印其下。"""
+        if self.block.strip():
+            self._erase(self.block)
+            self._emit_md(self.block)
         self.block = ""
 
     @staticmethod
@@ -126,18 +139,31 @@ class _StreamPrinter:
             n += max(1, -(-w // width)) if w else 1
         return n
 
-    def rerender(self, final_text: str) -> None:
-        """擦除最后一段流式正文，改打印 markdown 渲染版。"""
+    def _erase(self, text: str) -> None:
+        if not (self.on and text):
+            return
+        width = shutil.get_terminal_size((80, 24)).columns
+        lines = self._visual_lines(text, width)
+        sys.stdout.write("\r")
+        if lines > 1:
+            sys.stdout.write(f"\033[{lines - 1}A")
+        sys.stdout.write("\033[J")
+        sys.stdout.flush()
+
+    def _emit_md(self, block: str) -> None:
         from . import markdown
-        if self.on and self.block:
-            width = shutil.get_terminal_size((80, 24)).columns
-            lines = self._visual_lines(self.block, width)
-            sys.stdout.write("\r")
-            if lines > 1:
-                sys.stdout.write(f"\033[{lines - 1}A")
-            sys.stdout.write("\033[J")
-            sys.stdout.flush()
-        print(f"\n{_C['c']}●{_C['x']} " + markdown.render(final_text))   # 回答前留一空行，呼吸感
+        prefix = f"{_C['c']}●{_C['x']} " if not self._emitted else ""   # ● 仅首个定稿块
+        self._emitted = True
+        print(prefix + markdown.render(block.strip()))
+
+    def rerender(self, final_text: str) -> None:
+        """轮末：把最后一个未定稿块转成 markdown；若整段无空行则此处一次性渲染。"""
+        if self.block.strip():
+            self._erase(self.block)
+            self._emit_md(self.block)
+        elif not self._emitted:                    # 从没定稿过（如空回复）→ 兜底渲染全文
+            print(f"{_C['c']}●{_C['x']} " + markdown.render(final_text))
+        self.block = ""
 
 
 class _ReasoningPrinter:

--- a/ivyea_agent/chat_ui.py
+++ b/ivyea_agent/chat_ui.py
@@ -138,3 +138,24 @@ class _StreamPrinter:
             sys.stdout.write("\033[J")
             sys.stdout.flush()
         print(f"\n{_C['c']}●{_C['x']} " + markdown.render(final_text))   # 回答前留一空行，呼吸感
+
+
+class _ReasoningPrinter:
+    """思考流（支持 reasoning 的模型）：dim 灰的 ✻ 思考 块，正文开始前收尾。"""
+    def __init__(self):
+        self.on = False
+
+    def render(self, text: str = "") -> None:
+        if not text:
+            return
+        if not self.on:
+            sys.stdout.write(f"\n{_C['d']}✻ 思考\n")
+            self.on = True
+        sys.stdout.write(f"{_C['d']}{text}{_C['x']}")
+        sys.stdout.flush()
+
+    def done(self) -> None:
+        if self.on:
+            sys.stdout.write(f"{_C['x']}\n")
+            sys.stdout.flush()
+            self.on = False

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1201,6 +1201,7 @@ SLASH_COMMANDS = [
     ("/approve", "批准并退出计划模式，继续执行"),
     ("/cost", "本会话 token 用量与成本估算"),
     ("/compact", "压缩上下文；/compact auto on|off 控制自动压缩"),
+    ("/rewind", "回退检查点：截断对话到某轮之前 + 恢复代码文件（对话+代码快照）"),
     ("/init", "生成账户指令模板 AGENTS.md（长期打法/边界，自动注入）"),
     ("/paste", "把剪贴板里的图片喂给多模态模型（也可直接 @图片路径）"),
     ("/raw", "切换 Markdown 渲染 / 原始流式输出"),
@@ -1351,6 +1352,17 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         ctx.asin = args.asin
     meter = pricing.UsageMeter()
     _ui = {"ctx": 0}                                        # 状态栏:上下文 token 估算
+    _checkpoints: list = []                                 # /rewind 检查点：每轮前的 {对话长度, 代码快照}
+
+    def _snapshot(line: str) -> None:
+        """turn 开始前记一个检查点（对话截断点 + git 代码快照），供 /rewind 回退。"""
+        from . import git_workflow as _gw
+        try:
+            cp = _gw.checkpoint(os.getcwd())
+        except Exception:
+            cp = None
+        _checkpoints.append({"n": len(_checkpoints) + 1, "msg_len": len(messages),
+                             "cp": cp, "label": (line or "")[:50]})
     instructions = memory.load_instructions(os.getcwd())   # USER.md/AGENTS.md 持久指令
     profile_key = getattr(args, "asin", None) or "default"
     profile_context = profiles.context_text(profiles.resolve(asin=getattr(args, "asin", "") or ""), label=profile_key)
@@ -1653,13 +1665,37 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             print(ui.message("warn", f"未知模型 id：{mid}。用 /model 看清单。"))
         return True
 
+    def _sh_rewind(line):
+        """回退检查点：截断对话到某轮之前 + 把代码文件恢复到该轮之前（对标 Claude /rewind）。"""
+        nonlocal messages
+        from . import git_workflow as _gw, tui as _tuisel
+        if not _checkpoints:
+            print(ui.message("info", "还没有可回退的检查点（本会话尚无对话轮）。")); return True
+        opts = [(str(i), f"#{c['n']} {c['label'] or '(无标签)'}") for i, c in enumerate(_checkpoints)]
+        opts = opts[::-1][:10] + [("cancel", "取消")]
+        sel = _tuisel.select("回退到哪一轮之前？", "会截断此后的对话，并把 tracked 代码文件恢复到该轮之前。", opts)
+        if sel in ("cancel", ""):
+            print(ui.message("muted", "已取消。")); return True
+        c = _checkpoints[int(sel)]
+        stat = _gw.checkpoint_diffstat(c.get("cp"), os.getcwd()) if c.get("cp") else ""
+        preview = stat or "（无 git 仓 / 无 tracked 文件改动，仅回退对话）"
+        if _tuisel.select("确认回退？", preview, [("yes", "确认回退"), ("no", "取消")]) != "yes":
+            print(ui.message("muted", "已取消。")); return True
+        del messages[c["msg_len"]:]                     # 截断对话
+        if c.get("cp"):
+            ok, msg = _gw.restore_checkpoint(c["cp"], os.getcwd())
+            print(ui.message("success" if ok else "warn", msg))
+        del _checkpoints[_checkpoints.index(c):]        # 丢弃此检查点及其后的
+        _persist()
+        print(ui.message("success", f"已回退到 #{c['n']} 之前（对话截断 + 文件恢复）。")); return True
+
     _SLASH_HANDLERS = {
         "/help": _sh_help, "/": _sh_help, "/?": _sh_help,
         "/clear": _sh_clear, "/plan": _sh_plan, "/approve": _sh_approve, "/cost": _sh_cost,
         "/raw": _sh_raw, "/stream": _sh_stream, "/auto-edit": _sh_auto_edit, "/compact": _sh_compact,
         "/diff": _sh_diff, "/init": _sh_init, "/mcp": _sh_mcp, "/knowledge": _sh_knowledge,
         "/skill": _sh_skill, "/tools": _sh_tools, "/memory": _sh_memory, "/status": _sh_status,
-        "/config": _sh_config, "/model": _sh_model,
+        "/config": _sh_config, "/model": _sh_model, "/rewind": _sh_rewind,
         "/workspace": _sh_embedded, "/patch": _sh_embedded, "/gitops": _sh_embedded,
     }
 
@@ -1705,6 +1741,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         from . import hooks as _hooks
         _hooks.fire("user_prompt", {"prompt": line, "session_id": sid or "", "turn_id": ctx.turn_id})
         messages[0] = _sys_msg()
+        _snapshot(line)   # /rewind 检查点（本轮之前的对话+代码状态）
         messages.append({"role": "user", "content": _mentions.build_user_content(user_content, _mention_imgs)})
         mcfg = cfg.get_model_config()
         provider = build_chain(mcfg, api_key, narrate=narrate)
@@ -1823,6 +1860,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         from . import hooks as _hooks
         _hooks.fire("user_prompt", {"prompt": line, "session_id": sid or "", "turn_id": ctx.turn_id})
         messages[0] = _sys_msg()   # 每轮刷新 system：注入真实当前日期，续接旧会话/跨天也不过时
+        _snapshot(line)   # /rewind 检查点（本轮之前的对话+代码状态）
         messages.append({"role": "user", "content": _mentions.build_user_content(user_content, _mention_imgs)})
         try:
             mcfg = cfg.get_model_config()

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1427,11 +1427,20 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         f"{_C['d']}/ 命令 · ↑↓+Enter 选择 · Alt+Enter 换行 · /exit 退出{_C['x']}",
     ]
     from . import chat_tui as _chat_tui
-    _tui_on = _chat_tui.tui_enabled()
-    # 滚动区常驻 app（IVYEA_LIVE=1，opt-in；P5 翻默认）。IVYEA_PLAIN=1 强制旧行式循环。
-    _live_on = (os.environ.get("IVYEA_LIVE", "").strip().lower() in ("1", "true", "on", "yes")
-                and sys.stdin.isatty() and sys.stdout.isatty()
-                and os.environ.get("IVYEA_PLAIN", "").strip().lower() not in ("1", "true", "on", "yes"))
+    _tui_on = _chat_tui.tui_enabled()   # IVYEA_TUI=1 → 全屏 alt-screen
+    # 常驻底部 app（滚动缓冲区）为**默认**：输入框钉底、生成中也在，保留原生滚轮/复制（对标
+    # Claude/Ink）。IVYEA_PLAIN=1 退回旧行式循环；非 TTY / prompt_toolkit 不可用也退回。
+    def _live_default() -> bool:
+        if _tui_on or not (sys.stdin.isatty() and sys.stdout.isatty()):
+            return False
+        if os.environ.get("IVYEA_PLAIN", "").strip().lower() in ("1", "true", "on", "yes"):
+            return False
+        try:
+            import prompt_toolkit  # noqa: F401
+        except Exception:
+            return False
+        return True
+    _live_on = _live_default()
     _health = cfg.main_brain_health()
     _health_msg = "" if _health.get("ok") else ui.message("warn", _health.get("hint", "主脑不可用，请用 /model 切换。"))
     # TUI 模式：banner+欢迎框作为 transcript 首块（打印会被 alt-screen 清掉）；行式则直接打印。

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from . import __version__, config, ui
 # chat 展示层 helper 已拆到 chat_ui.py；re-export 保持 cli.X 引用与既有测试兼容。
-from .chat_ui import _is_amazon_domain, _looks_like_code_task, _LiveSpinner, _StreamPrinter
+from .chat_ui import _is_amazon_domain, _looks_like_code_task, _LiveSpinner, _ReasoningPrinter, _StreamPrinter
 
 
 def _ask(prompt: str, default: str = "") -> str:
@@ -1828,19 +1828,26 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             mcfg = cfg.get_model_config()
             provider = build_chain(mcfg, api_key, narrate=lambda s: print(s))
             ctx.provider = provider   # 供 dispatch_subagent 跑只读子 agent 用
+            rp = _ReasoningPrinter()   # 思考流（reasoning 模型）：正文前 dim 显示 ✻ 思考
             if render_md and stream_live and sys.stdout.isatty():
                 # 完整流式：边生成边打印正文，收尾擦除最后一段改渲染 markdown
                 sp = _StreamPrinter()
                 out = agent_loop.run_turn_stream(
                     provider, ctx, messages, model=mcfg.get("model", ""),
-                    render=sp.render, narrate=lambda s: (sp.commit(), print(s)))
+                    render=lambda t: (rp.done(), sp.render(t)),
+                    render_reasoning=rp.render,
+                    narrate=lambda s: (rp.done(), sp.commit(), print(s)))
+                rp.done()
                 sp.rerender(out["text"])
             elif render_md:
                 # 缓冲 + spinner（含流式正文预览），收尾渲染 markdown
                 spin = _LiveSpinner()
                 out = agent_loop.run_turn_stream(
                     provider, ctx, messages, model=mcfg.get("model", ""),
-                    render=spin.tick, narrate=lambda s: (spin.clear(), print(s)))
+                    render=lambda t: (rp.done(), spin.tick(t)),
+                    render_reasoning=rp.render,
+                    narrate=lambda s: (rp.done(), spin.clear(), print(s)))
+                rp.done()
                 spin.clear()
                 print(f"\n{_C['c']}●{_C['x']} " + markdown.render(out["text"]))   # 回答前留一空行
             else:

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1202,6 +1202,7 @@ SLASH_COMMANDS = [
     ("/cost", "本会话 token 用量与成本估算"),
     ("/compact", "压缩上下文；/compact auto on|off 控制自动压缩"),
     ("/init", "生成账户指令模板 AGENTS.md（长期打法/边界，自动注入）"),
+    ("/paste", "把剪贴板里的图片喂给多模态模型（也可直接 @图片路径）"),
     ("/raw", "切换 Markdown 渲染 / 原始流式输出"),
     ("/stream", "开关完整流式（边生成边出字、收尾渲染 markdown；默认关）"),
     ("/auto-edit", "开关写操作自动放行（/auto-edit on|off；默认逐次审批）"),
@@ -1685,7 +1686,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         kctx, kids = knowledge.context_for_query(line, limit=3) if _inject else ("", [])
         sctx, sids = skills.context_for_query(line, limit=2) if _inject else ("", [])
         from . import mentions as _mentions        # @文件引用：把 @path 文本文件内联给模型
-        user_content, _mention_imgs = _mentions.expand(line, os.getcwd())
+        user_content, _mention_imgs = _mentions.expand(line, os.getcwd(), with_images=True)
         if _mention_imgs:
             narrate(ui.message("muted", "已引用图片: " + ", ".join(os.path.basename(p) for p in _mention_imgs)))
         if ectx:
@@ -1704,7 +1705,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         from . import hooks as _hooks
         _hooks.fire("user_prompt", {"prompt": line, "session_id": sid or "", "turn_id": ctx.turn_id})
         messages[0] = _sys_msg()
-        messages.append({"role": "user", "content": user_content})
+        messages.append({"role": "user", "content": _mentions.build_user_content(user_content, _mention_imgs)})
         mcfg = cfg.get_model_config()
         provider = build_chain(mcfg, api_key, narrate=narrate)
         ctx.provider = provider
@@ -1746,6 +1747,14 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         if line in ("/exit", "/quit"):
             print("再见。")
             return 0
+        if line.split()[0] == "/paste":   # 剪贴板图片：存临时文件后改写成 @路径，走正常多模态轮
+            from . import vision as _vision
+            _img = _vision.clipboard_image()
+            if not _img:
+                print(ui.message("warn", "剪贴板里没有图片（网页终端无法访问系统剪贴板；本地终端需 pngpaste/xclip/wl-paste）。")); continue
+            _rest = line[len("/paste"):].strip() or "这张图片里是什么？"
+            print(ui.message("muted", f"已取剪贴板图片 → {_img}"))
+            line = f"@{_img} {_rest}"   # 落到下面的模型轮，由 mentions 收成多模态附件
         _handler = _SLASH_HANDLERS.get(line.split()[0])
         if _handler is not None:
             _handler(line); continue
@@ -1792,7 +1801,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         kctx, kids = knowledge.context_for_query(line, limit=3) if _inject_domain else ("", [])
         sctx, sids = skills.context_for_query(line, limit=2) if _inject_domain else ("", [])
         from . import mentions as _mentions        # @文件引用：把 @path 文本文件内联给模型
-        user_content, _mention_imgs = _mentions.expand(line, os.getcwd())
+        user_content, _mention_imgs = _mentions.expand(line, os.getcwd(), with_images=True)
         if _mention_imgs:
             print(ui.message("muted", "已引用图片: " + ", ".join(os.path.basename(p) for p in _mention_imgs)))
         if ectx:
@@ -1814,7 +1823,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         from . import hooks as _hooks
         _hooks.fire("user_prompt", {"prompt": line, "session_id": sid or "", "turn_id": ctx.turn_id})
         messages[0] = _sys_msg()   # 每轮刷新 system：注入真实当前日期，续接旧会话/跨天也不过时
-        messages.append({"role": "user", "content": user_content})
+        messages.append({"role": "user", "content": _mentions.build_user_content(user_content, _mention_imgs)})
         try:
             mcfg = cfg.get_model_config()
             provider = build_chain(mcfg, api_key, narrate=lambda s: print(s))

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1428,13 +1428,17 @@ def _cmd_chat(args: argparse.Namespace) -> int:
     ]
     from . import chat_tui as _chat_tui
     _tui_on = _chat_tui.tui_enabled()
+    # 滚动区常驻 app（IVYEA_LIVE=1，opt-in；P5 翻默认）。IVYEA_PLAIN=1 强制旧行式循环。
+    _live_on = (os.environ.get("IVYEA_LIVE", "").strip().lower() in ("1", "true", "on", "yes")
+                and sys.stdin.isatty() and sys.stdout.isatty()
+                and os.environ.get("IVYEA_PLAIN", "").strip().lower() not in ("1", "true", "on", "yes"))
     _health = cfg.main_brain_health()
     _health_msg = "" if _health.get("ok") else ui.message("warn", _health.get("hint", "主脑不可用，请用 /model 切换。"))
     # TUI 模式：banner+欢迎框作为 transcript 首块（打印会被 alt-screen 清掉）；行式则直接打印。
     _intro = f"{_C['c']}{_C['b']}{_BANNER}{_C['x']}\n" + _welcome_box_str(_welcome_lines, width=64)
     if _health_msg:
         _intro += "\n" + _health_msg
-    if not _tui_on:
+    if not _tui_on and not _live_on:   # LIVE/alt-screen 由 chat_tui 打 intro，避免双 banner
         print(f"{_C['c']}{_C['b']}{_BANNER}{_C['x']}")
         _print_welcome_box(_welcome_lines, width=64)
         print()
@@ -1766,11 +1770,6 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         out["blocked"] = False
         return out
 
-    # 常驻底部 app（滚动缓冲区）：输入框钉底、生成中也在，保留原生滚轮/复制（对标 Claude/Ink）。
-    # 开发期 opt-in（IVYEA_LIVE=1），P5 验证后翻默认。IVYEA_PLAIN=1 强制旧行式循环。
-    _live_on = (os.environ.get("IVYEA_LIVE", "").strip().lower() in ("1", "true", "on", "yes")
-                and sys.stdin.isatty() and sys.stdout.isatty()
-                and os.environ.get("IVYEA_PLAIN", "").strip().lower() not in ("1", "true", "on", "yes"))
     if _tui_on or _live_on:      # 全屏 TUI（IVYEA_TUI=1）或滚动区常驻 app（IVYEA_LIVE=1）
         return _chat_tui.run(_status, SLASH_COMMANDS, turn_fn=_execute_turn,
                              render_markdown=markdown.render,

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1699,7 +1699,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         "/workspace": _sh_embedded, "/patch": _sh_embedded, "/gitops": _sh_embedded,
     }
 
-    def _execute_turn(line, render, narrate, cancel_check=None):
+    def _execute_turn(line, render, narrate, cancel_check=None, render_reasoning=None):
         """跑一轮对话，输出经 render(token)/narrate(行) 注入 —— 供 TUI 复用（行式循环仍走下方原逻辑）。
         cancel_check：运行中请求中断的钩子（TUI 用）。返回 {text, usage, blocked}。"""
         nonlocal messages
@@ -1747,7 +1747,8 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         provider = build_chain(mcfg, api_key, narrate=narrate)
         ctx.provider = provider
         out = agent_loop.run_turn_stream(provider, ctx, messages, model=mcfg.get("model", ""),
-                                         render=render, narrate=narrate, cancel_check=cancel_check)
+                                         render=render, narrate=narrate, cancel_check=cancel_check,
+                                         render_reasoning=render_reasoning)
         c = meter.add(mcfg.get("model", ""), out.get("usage") or {})
         _ui["ctx"] = int((out.get("usage") or {}).get("prompt_tokens") or _ui["ctx"])
         if c:
@@ -1765,12 +1766,18 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         out["blocked"] = False
         return out
 
-    if _tui_on:                  # 全屏 TUI（opt-in：IVYEA_TUI=1；默认走下面的行式循环）
+    # 常驻底部 app（滚动缓冲区）：输入框钉底、生成中也在，保留原生滚轮/复制（对标 Claude/Ink）。
+    # 开发期 opt-in（IVYEA_LIVE=1），P5 验证后翻默认。IVYEA_PLAIN=1 强制旧行式循环。
+    _live_on = (os.environ.get("IVYEA_LIVE", "").strip().lower() in ("1", "true", "on", "yes")
+                and sys.stdin.isatty() and sys.stdout.isatty()
+                and os.environ.get("IVYEA_PLAIN", "").strip().lower() not in ("1", "true", "on", "yes"))
+    if _tui_on or _live_on:      # 全屏 TUI（IVYEA_TUI=1）或滚动区常驻 app（IVYEA_LIVE=1）
         return _chat_tui.run(_status, SLASH_COMMANDS, turn_fn=_execute_turn,
                              render_markdown=markdown.render,
                              plan_intent_fn=_plan_mode_intent,
                              set_plan_mode=_set_plan_mode_msg,
-                             cycle_mode=_cycle_mode, mode_label_fn=_mode_label, intro=_intro)
+                             cycle_mode=_cycle_mode, mode_label_fn=_mode_label,
+                             slash_handlers=_SLASH_HANDLERS, scrollback=_live_on, intro=_intro)
 
     while True:
         line = ci.read("❯ ")

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1684,7 +1684,10 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         _inject = bool(getattr(ctx, "asin", "")) or _is_amazon_domain(line) or not _looks_like_code_task(line)
         kctx, kids = knowledge.context_for_query(line, limit=3) if _inject else ("", [])
         sctx, sids = skills.context_for_query(line, limit=2) if _inject else ("", [])
-        user_content = line
+        from . import mentions as _mentions        # @文件引用：把 @path 文本文件内联给模型
+        user_content, _mention_imgs = _mentions.expand(line, os.getcwd())
+        if _mention_imgs:
+            narrate(ui.message("muted", "已引用图片: " + ", ".join(os.path.basename(p) for p in _mention_imgs)))
         if ectx:
             user_content += "\n\n[工程上下文]\n" + ectx
             narrate(ui.stage("Code", "计划 → 读上下文 → 修改/生成补丁 → 测试 → 复查"))
@@ -1788,7 +1791,10 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         )
         kctx, kids = knowledge.context_for_query(line, limit=3) if _inject_domain else ("", [])
         sctx, sids = skills.context_for_query(line, limit=2) if _inject_domain else ("", [])
-        user_content = line
+        from . import mentions as _mentions        # @文件引用：把 @path 文本文件内联给模型
+        user_content, _mention_imgs = _mentions.expand(line, os.getcwd())
+        if _mention_imgs:
+            print(ui.message("muted", "已引用图片: " + ", ".join(os.path.basename(p) for p in _mention_imgs)))
         if ectx:
             user_content += "\n\n[工程上下文]\n" + ectx
             print(ui.stage("Code", "计划 → 读上下文 → 修改/生成补丁 → 测试 → 复查"))

--- a/ivyea_agent/git_workflow.py
+++ b/ivyea_agent/git_workflow.py
@@ -41,6 +41,46 @@ def repo_root(path: str | Path = ".") -> Path | None:
     return Path(out).resolve()
 
 
+def checkpoint(root: str | Path = ".") -> dict[str, str] | None:
+    """快照当前工作区（tracked 改动）为独立提交对象，**不动索引/工作区/stash 列表/分支历史**。
+    返回 {head, stash}（stash="" 表示快照时工作区已干净）；非 git 仓返回 None。供 /rewind 用。"""
+    r = repo_root(root)
+    if r is None:
+        return None
+    _, head = _run_git(r, ["rev-parse", "HEAD"])
+    code, stash = _run_git(r, ["stash", "create", "ivyea checkpoint"])
+    return {"head": head.strip(), "stash": stash.strip() if code == 0 else ""}
+
+
+def checkpoint_diffstat(cp: dict | None, root: str | Path = ".") -> str:
+    """预览：从检查点快照恢复会改动哪些 tracked 文件（git diff --stat）。"""
+    r = repo_root(root)
+    if r is None or not cp:
+        return ""
+    target = cp.get("stash") or cp.get("head")
+    if not target:
+        return ""
+    _, out = _run_git(r, ["diff", "--stat", target, "--", "."])
+    return out.strip()
+
+
+def restore_checkpoint(cp: dict | None, root: str | Path = ".") -> tuple[bool, str]:
+    """把 tracked 文件恢复到检查点快照（git checkout <ref> -- .）。返回 (ok, 说明)。
+    只动 tracked 文件、不碰用户分支历史；非 git 仓返回 (False, ...) 只回退对话。"""
+    r = repo_root(root)
+    if r is None:
+        return False, "不在 git 仓库，未改动文件（仅回退了对话）。"
+    if not cp:
+        return False, "无检查点。"
+    target = cp.get("stash") or cp.get("head")
+    if not target:
+        return False, "检查点无效。"
+    code, out = _run_git(r, ["checkout", target, "--", "."])
+    if code != 0:
+        return False, f"文件恢复失败：{out[:200]}"
+    return True, "已把 tracked 文件恢复到检查点。"
+
+
 def status(root: str | Path = ".") -> dict[str, Any]:
     r = repo_root(root)
     if not r:

--- a/ivyea_agent/mentions.py
+++ b/ivyea_agent/mentions.py
@@ -56,3 +56,20 @@ def expand(line: str, cwd: str, *, with_images: bool = False) -> tuple[str, list
     if inlined:
         processed = processed + "\n\n" + "\n\n".join(inlined)
     return processed, images
+
+
+def build_user_content(text: str, image_paths: list[str]):
+    """构造一条 user 消息的 content：无图返回纯文本 str；有图返回 OpenAI 多模态
+    list-content（[{type:text},{type:image_url,image_url:{url:data:...}}]）。
+    各 provider 适配器把 image_url 转成自身格式（codex/anthropic/gemini），
+    不支持多模态的 provider 会安全拍平只取文本。"""
+    if not image_paths:
+        return text
+    from . import image_audit
+    parts: list = [{"type": "text", "text": text}]
+    for p in image_paths:
+        try:
+            parts.append({"type": "image_url", "image_url": {"url": image_audit.data_url(p)}})
+        except Exception:
+            pass   # 单张编码失败(过大/损坏)跳过，不阻塞整轮
+    return parts

--- a/ivyea_agent/mentions.py
+++ b/ivyea_agent/mentions.py
@@ -1,0 +1,58 @@
+"""@文件引用：把用户输入里的 @path 展开成内联文件内容（文本）或图片附件（多模态）。
+
+对标 Claude Code / Codex 的 @文件：`@src/app.py 解释一下` 会把文件内容内联给模型，
+省去模型再调 read_file。返回 (处理后的文本, 图片路径列表)——图片走多模态附件（Phase 3）。
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+# 图片后缀走多模态附件（不内联文本）；其余按文本文件内联
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"}
+_MAX_LINES = 2000                                  # 单文件内联行数上限，防塞爆上下文
+_MENTION_RE = re.compile(r"(?<!\S)@([^\s@]+)")     # 行首或空白后的 @路径
+
+
+def _resolve(cwd: str, raw: str) -> Path:
+    p = Path(os.path.expanduser(raw))
+    return p if p.is_absolute() else Path(cwd) / p
+
+
+def expand(line: str, cwd: str, *, with_images: bool = False) -> tuple[str, list[str]]:
+    """展开 @path 引用：
+    - 存在的文本文件 → 正文保留 `@path`，文件内容附到末尾（超 2000 行截断）。
+    - 图片文件 → with_images 时收进 images 列表（多模态）；否则原样保留。
+    - 路径不存在 → 原样保留 @path（可能只是普通 @提及）。
+    返回 (处理后的文本, 图片路径列表)。
+    """
+    images: list[str] = []
+    inlined: list[str] = []
+
+    def _sub(m: re.Match) -> str:
+        raw = m.group(1).rstrip(".,;:!?)），。；：！？")   # 容忍句末标点
+        if not raw:
+            return m.group(0)
+        p = _resolve(cwd, raw)
+        if not p.is_file():
+            return m.group(0)                              # 不存在 → 原样
+        if p.suffix.lower() in IMAGE_EXTS:
+            if with_images:
+                images.append(str(p))
+                return f"[图片 {raw}]"
+            return m.group(0)                              # 未接多模态 → 原样
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            return m.group(0)
+        lines = text.splitlines()
+        if len(lines) > _MAX_LINES:
+            text = "\n".join(lines[:_MAX_LINES]) + f"\n…（已截断，文件共 {len(lines)} 行）"
+        inlined.append(f"[文件 {raw}]\n{text}")
+        return f"@{raw}"                                   # 正文保留引用，内容附末尾
+
+    processed = _MENTION_RE.sub(_sub, line)
+    if inlined:
+        processed = processed + "\n\n" + "\n\n".join(inlined)
+    return processed, images

--- a/ivyea_agent/providers/anthropic_provider.py
+++ b/ivyea_agent/providers/anthropic_provider.py
@@ -60,6 +60,15 @@ def _split_messages(messages: list[dict]) -> tuple[str, list[dict]]:
                 _append_user_block({"type": "text", "text": content})
             elif isinstance(content, list):
                 for b in content:
+                    if isinstance(b, dict) and b.get("type") == "image_url":   # 多模态→Anthropic image 块
+                        iu = b.get("image_url")
+                        url = iu.get("url") if isinstance(iu, dict) else iu
+                        if url and str(url).startswith("data:"):
+                            head, b64 = str(url).split(",", 1)
+                            media = head.split(":", 1)[1].split(";", 1)[0]
+                            _append_user_block({"type": "image", "source": {
+                                "type": "base64", "media_type": media, "data": b64}})
+                        continue
                     _append_user_block(b)
     return "\n\n".join(system_parts), out
 

--- a/ivyea_agent/providers/codex_provider.py
+++ b/ivyea_agent/providers/codex_provider.py
@@ -108,6 +108,12 @@ def parse_responses_sse(lines: Iterable[str]) -> Iterator[dict]:
                 yield {"type": "text", "text": delta}
             continue
 
+        if event_type in ("response.reasoning_summary_text.delta", "response.reasoning_text.delta"):
+            delta = chunk.get("delta")
+            if isinstance(delta, str) and delta:
+                yield {"type": "reasoning", "text": delta}   # 思考流 → 思考事件
+            continue
+
         if event_type == "response.function_call_arguments.delta":
             slot = tool_slot(chunk.get("output_index"))
             delta = chunk.get("delta")
@@ -344,6 +350,7 @@ class CodexProvider(LLMProvider):
                 "input": input_items,
                 "stream": True,
                 "store": False,
+                "reasoning": {"summary": "auto"},   # GPT-5 思考摘要流（→ reasoning 事件，显示 ✻ 思考）
             }
             if instructions:
                 payload["instructions"] = instructions

--- a/ivyea_agent/providers/codex_provider.py
+++ b/ivyea_agent/providers/codex_provider.py
@@ -263,11 +263,22 @@ class CodexProvider(LLMProvider):
                         "name": fn.get("name", ""),
                         "arguments": arguments,
                     })
-            text = _content_text(msg.get("content"))
+            content = msg.get("content")
+            item_role = "assistant" if role == "assistant" else "user"
+            parts: list[dict[str, Any]] = []
+            if isinstance(content, list) and item_role == "user":   # 多模态：附带图片
+                for it in content:
+                    if isinstance(it, dict) and it.get("type") == "image_url":
+                        iu = it.get("image_url")
+                        url = iu.get("url") if isinstance(iu, dict) else iu
+                        if url:
+                            parts.append({"type": "input_image", "image_url": url})
+            text = _content_text(content)
             if text:
-                item_role = "assistant" if role == "assistant" else "user"
                 text_type = "output_text" if item_role == "assistant" else "input_text"
-                items.append({"role": item_role, "content": [{"type": text_type, "text": text}]})
+                parts.insert(0, {"type": text_type, "text": text})
+            if parts:
+                items.append({"role": item_role, "content": parts})
         return instructions, items
 
     def _post(self, payload: dict, timeout: float) -> dict:

--- a/ivyea_agent/providers/gemini_provider.py
+++ b/ivyea_agent/providers/gemini_provider.py
@@ -112,8 +112,21 @@ def _messages_to_gemini(messages: list[dict]) -> tuple[str, list[dict[str, Any]]
             })
             continue
 
-        text = _content_text(msg.get("content"))
-        contents.append({"role": "user", "parts": [{"text": text}]})
+        content = msg.get("content")
+        parts_u: list[dict[str, Any]] = []
+        text = _content_text(content)
+        if text:
+            parts_u.append({"text": text})
+        if isinstance(content, list):                     # 多模态→Gemini inlineData
+            for it in content:
+                if isinstance(it, dict) and it.get("type") == "image_url":
+                    iu = it.get("image_url")
+                    url = iu.get("url") if isinstance(iu, dict) else iu
+                    if url and str(url).startswith("data:"):
+                        head, b64 = str(url).split(",", 1)
+                        mime = head.split(":", 1)[1].split(";", 1)[0]
+                        parts_u.append({"inlineData": {"mimeType": mime, "data": b64}})
+        contents.append({"role": "user", "parts": parts_u or [{"text": ""}]})
 
     return "\n\n".join(system_parts), contents
 

--- a/ivyea_agent/providers/openai_compat.py
+++ b/ivyea_agent/providers/openai_compat.py
@@ -47,6 +47,8 @@ def parse_sse(lines: Iterable[str]) -> Iterator[dict]:
         if not choices:
             continue
         delta = choices[0].get("delta") or {}
+        if delta.get("reasoning_content"):   # deepseek-reasoner 等的思考流 → 思考事件
+            yield {"type": "reasoning", "text": delta["reasoning_content"]}
         if delta.get("content"):
             content_parts.append(delta["content"])
             yield {"type": "text", "text": delta["content"]}

--- a/ivyea_agent/tools_general.py
+++ b/ivyea_agent/tools_general.py
@@ -636,6 +636,80 @@ def _run(cmd, args, ctx, kind: str, preview: str, *, auto_ok: bool = False) -> s
     return head + (_truncate(out) if out else "（无输出）")
 
 
+# ── 后台/长任务 bash：非阻塞 Popen + 输出轮询（对标 Claude Code 的后台 bash）──
+_BG_PROCS: dict = {}   # bash_id -> {proc, logpath, cmd, read_pos, started}
+_BG_SEQ = [0]
+
+
+def _run_background(cmd, args, ctx, preview: str, *, auto_ok: bool) -> str:
+    """在后台起进程，立即返回 bash_id；输出写临时日志，供 bash_output 轮询。"""
+    if not auto_ok:
+        ok, msg = _gate(ctx, "run_command", preview)
+        if not ok:
+            return msg
+    workdir = getattr(ctx, "workspace", "") or os.getcwd()
+    import tempfile
+    _BG_SEQ[0] += 1
+    bash_id = f"bg-{_BG_SEQ[0]}"
+    logf = tempfile.NamedTemporaryFile(prefix=f"ivyea-{bash_id}-", suffix=".log", delete=False)
+    try:
+        proc = subprocess.Popen(cmd, cwd=workdir, stdout=logf, stderr=subprocess.STDOUT,
+                                text=True, encoding="utf-8", errors="replace",
+                                preexec_fn=_make_preexec(0) if os.name != "nt" else None)
+    except Exception as e:  # noqa: BLE001
+        logf.close()
+        return f"后台启动失败：{e}"
+    logf.close()
+    _BG_PROCS[bash_id] = {"proc": proc, "logpath": logf.name,
+                          "cmd": (args.get("command") or "")[:200], "read_pos": 0}
+    return (f"已在后台启动：bash_id={bash_id}（pid {proc.pid}）。"
+            f"用 bash_output(bash_id=\"{bash_id}\") 查看输出/状态，kill_bash 终止。")
+
+
+def t_bash_output(args: dict, ctx) -> str:
+    """读取某后台 bash 自上次以来的新增输出 + 运行状态（只读，自动放行）。"""
+    bash_id = str(args.get("bash_id") or "").strip()
+    rec = _BG_PROCS.get(bash_id)
+    if not rec:
+        running = ", ".join(k for k, v in _BG_PROCS.items() if v["proc"].poll() is None)
+        return f"没有该后台任务：{bash_id}。" + (f"运行中的：{running}" if running else "当前无运行中的后台任务。")
+    proc = rec["proc"]
+    try:
+        with open(rec["logpath"], "r", encoding="utf-8", errors="replace") as fh:
+            fh.seek(rec["read_pos"])
+            chunk = fh.read()
+            rec["read_pos"] = fh.tell()
+    except Exception as e:  # noqa: BLE001
+        chunk = f"(读日志失败：{e})"
+    code = proc.poll()
+    status = "运行中" if code is None else f"已结束（退出码 {code}）"
+    body = _truncate(chunk) if chunk else "（无新增输出）"
+    return f"[{bash_id} · {status}]\n{body}"
+
+
+def t_kill_bash(args: dict, ctx) -> str:
+    """终止某后台 bash（写操作，需审批）。"""
+    bash_id = str(args.get("bash_id") or "").strip()
+    rec = _BG_PROCS.get(bash_id)
+    if not rec:
+        return f"没有该后台任务：{bash_id}。"
+    ok, msg = _gate(ctx, "run_command", f"终止后台任务 {bash_id}：{rec['cmd']}")
+    if not ok:
+        return msg
+    proc = rec["proc"]
+    if proc.poll() is not None:
+        return f"{bash_id} 已经结束（退出码 {proc.poll()}）。"
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    except Exception as e:  # noqa: BLE001
+        return f"终止失败：{e}"
+    return f"已终止 {bash_id}。"
+
+
 def t_run_python(args: dict, ctx) -> str:
     import sys
     code = args.get("code", "")
@@ -658,7 +732,10 @@ def t_run_command(args: dict, ctx) -> str:
     import os as _os
     shell = ["cmd", "/c", command] if _os.name == "nt" else ["bash", "-lc", command]
     auto_ok = policy.is_readonly_command(command)   # 只读命令自动放行，省去逐次审批
-    return _run(shell, args, ctx, "run_command", "运行命令：" + _truncate(command, 400), auto_ok=auto_ok)
+    preview = "运行命令：" + _truncate(command, 400)
+    if args.get("run_in_background"):   # 长任务(dev server/watch/构建)：后台非阻塞，返回 bash_id
+        return _run_background(shell, args, ctx, preview, auto_ok=auto_ok)
+    return _run(shell, args, ctx, "run_command", preview, auto_ok=auto_ok)
 
 
 def t_todo_write(args: dict, ctx) -> str:
@@ -768,8 +845,17 @@ GENERAL_TOOL_SCHEMAS = [
         ["path", "old", "new"]),
     _fn("run_python", "在沙箱(限工作目录/超时)运行 Python 代码取 stdout（执行，会弹审批）。可用 pandas/openpyxl 等。",
         {"code": {"type": "string"}, "timeout": {"type": "integer", "description": "秒，默认30"}}, ["code"]),
-    _fn("run_command", "在沙箱运行 shell 命令取输出（执行，会弹审批）。",
-        {"command": {"type": "string"}, "timeout": {"type": "integer"}}, ["command"]),
+    _fn("run_command", "在沙箱运行 shell 命令取输出（执行，会弹审批）。长任务（dev server/watch/"
+        "长构建等不会很快结束的命令）设 run_in_background=true 后台运行，立即返回 bash_id，再用 "
+        "bash_output 轮询输出，别在前台阻塞等待。",
+        {"command": {"type": "string"}, "timeout": {"type": "integer"},
+         "run_in_background": {"type": "boolean", "description": "true=后台非阻塞运行，返回 bash_id"}},
+        ["command"]),
+    _fn("bash_output", "读取某后台 bash 自上次以来的新增输出与运行状态（只读，自动放行）。配合 "
+        "run_command(run_in_background=true) 轮询长任务进展。",
+        {"bash_id": {"type": "string", "description": "run_command 后台返回的 bash_id"}}, ["bash_id"]),
+    _fn("kill_bash", "终止某个后台 bash 任务（写操作，会弹审批）。",
+        {"bash_id": {"type": "string"}}, ["bash_id"]),
     _fn("web_fetch", "抓取一个 URL 的文本内容（GET，只读，自动放行）。",
         {"url": {"type": "string"}}, ["url"]),
     _fn("web_search", "网页搜索关键词（尽力而为，无 key）。",
@@ -843,6 +929,7 @@ GENERAL_DISPATCH = {
     "read_file": t_read_file, "list_dir": t_list_dir,
     "write_file": t_write_file, "edit_file": t_edit_file,
     "run_python": t_run_python, "run_command": t_run_command,
+    "bash_output": t_bash_output, "kill_bash": t_kill_bash,
     "web_fetch": t_web_fetch, "web_search": t_web_search,
     "grep": t_grep, "glob": t_glob, "code_search": t_code_search,
     "code_symbols": t_code_symbols, "code_impact": t_code_impact,

--- a/ivyea_agent/ui.py
+++ b/ivyea_agent/ui.py
@@ -186,6 +186,7 @@ _TOOL_VERBS = {
     "list_dir": "列目录", "glob": "查找文件",
     "grep": "搜索内容", "search_code": "搜索代码", "code_search": "搜索代码",
     "run_command": "执行命令", "run_python": "执行 Python", "run_tests": "运行测试",
+    "bash_output": "查看后台输出", "kill_bash": "终止后台任务",
     "web_search": "联网搜索", "web_fetch": "抓取网页",
     "knowledge_search": "查知识库", "skill_search": "查 skill", "recall": "回忆记忆",
     "todo_write": "更新计划",

--- a/ivyea_agent/vision.py
+++ b/ivyea_agent/vision.py
@@ -18,6 +18,40 @@ DEFAULT_MODELS = {
     "gemini": "gemini-2.5-flash",
 }
 
+
+def clipboard_image() -> str | None:
+    """从系统剪贴板取图片，保存为临时 png，返回路径；无图/不支持返回 None。
+    best-effort 三平台：macOS(pngpaste)、Linux(xclip/wl-paste)、Windows(PowerShell)。
+    仅本地真终端可用；网页终端无法访问系统剪贴板。"""
+    import subprocess
+    import sys
+    import tempfile
+    from . import config
+    try:
+        config.ensure_dirs()
+        out = str(Path(tempfile.mkdtemp(prefix="ivyea-paste-")) / "clip.png")
+    except Exception:
+        out = str(Path(tempfile.gettempdir()) / "ivyea-clip.png")
+    plat = sys.platform
+    cmds: list[list[str]] = []
+    if plat == "darwin":
+        cmds = [["pngpaste", out]]
+    elif plat.startswith("linux"):
+        cmds = [["bash", "-lc", f"wl-paste --type image/png > {out!r}"],
+                ["bash", "-lc", f"xclip -selection clipboard -t image/png -o > {out!r}"]]
+    elif plat.startswith("win"):
+        ps = ("$img=Get-Clipboard -Format Image; if($img){{$img.Save('{p}')}} "
+              "else {{exit 3}}").format(p=out)
+        cmds = [["powershell", "-NoProfile", "-Command", ps]]
+    for cmd in cmds:
+        try:
+            r = subprocess.run(cmd, timeout=10, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except Exception:
+            continue
+        if r.returncode == 0 and os.path.isfile(out) and os.path.getsize(out) > 0:
+            return out
+    return None
+
 API_ENV_KEYS = {
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -195,20 +195,23 @@ def test_approval_marshaled_from_tool_thread():
 # ---- P4 输入对齐 ----
 def test_handle_submit_routes():
     from ivyea_agent.cli import _plan_mode_intent
+    called = {}
     tui = chat_tui.ChatTUI(
         status_fn=lambda: "s", turn_fn=lambda *a, **k: {"text": ""}, render_markdown=lambda s: s,
         slash_commands=[("/exit", "退出"), ("/plan", "计划"), ("/model", "模型")],
         plan_intent_fn=_plan_mode_intent,
         set_plan_mode=lambda on: ("已进入计划模式" if on else "已退出计划模式"),
         cycle_mode=lambda: "自动接受编辑",
+        slash_handlers={"/model": lambda line: called.__setitem__("model", line)},
     )
     assert tui._handle_submit("/exit") == "exit"
     tui.blocks = ["x"]
     assert tui._handle_submit("/clear") == "handled" and tui.blocks == []
     assert tui._handle_submit("进入计划模式") == "handled"
     assert "计划模式" in _plain("\n".join(tui.blocks))
-    assert tui._handle_submit("/model") == "handled"           # 其它 slash → P5 提示
-    assert "P5" in _plain("\n".join(tui.blocks))
+    assert tui._handle_submit("/model gpt") == "handled"       # 有 handler → 执行
+    assert called.get("model") == "/model gpt"
+    assert tui._handle_submit("/unknown") == "turn"            # 无 handler 的 slash → 交给 turn_fn 展开/提示
     assert tui._handle_submit("帮我分析广告") == "turn"        # 普通 → 跑一轮
 
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,54 @@
+"""/rewind 检查点：git_workflow.checkpoint / restore_checkpoint（对话+代码快照）。
+
+硬隔离：全部在 tmp_path 建全新 git 仓，绝不碰真实仓库（禁止默认 cwd、禁 reset 真实仓）。
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from ivyea_agent import git_workflow as gw
+
+
+def _git(root, *args):
+    return subprocess.run(["git", *args], cwd=str(root), stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "t@t.co")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "a.py").write_text("v1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "init")
+    return tmp_path
+
+
+def test_checkpoint_none_outside_git(tmp_path):
+    assert gw.checkpoint(str(tmp_path)) is None                 # 非 git 仓 → None
+
+
+def test_checkpoint_and_restore_roundtrip(repo):
+    cp = gw.checkpoint(str(repo))                                # 干净时快照（stash=""）
+    assert cp is not None and cp["head"]
+    (repo / "a.py").write_text("v2-EDITED\n", encoding="utf-8")  # 改文件
+    ok, msg = gw.restore_checkpoint(cp, str(repo))               # 恢复到快照
+    assert ok
+    assert (repo / "a.py").read_text() == "v1\n"                 # 文件回到 v1
+
+
+def test_checkpoint_captures_dirty_state(repo):
+    (repo / "a.py").write_text("v2\n", encoding="utf-8")         # 先改成 v2
+    cp = gw.checkpoint(str(repo))                                # 快照 v2（stash 非空）
+    assert cp and cp["stash"]
+    (repo / "a.py").write_text("v3\n", encoding="utf-8")         # 再改成 v3
+    ok, _ = gw.restore_checkpoint(cp, str(repo))
+    assert ok and (repo / "a.py").read_text() == "v2\n"          # 恢复到快照时的 v2
+
+
+def test_restore_outside_git_only_conversation(tmp_path):
+    ok, msg = gw.restore_checkpoint({"head": "x"}, str(tmp_path))
+    assert ok is False and "仅回退" in msg                       # 非 git 仓：只回退对话

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -33,6 +33,41 @@ def test_truncates_huge_file(tmp_path):
     assert "已截断" in txt and "共 5000 行" in txt
 
 
+def _tiny_png(p):
+    import base64
+    p.write_bytes(base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="))
+
+
+def test_build_user_content_multimodal(tmp_path):
+    png = tmp_path / "x.png"
+    _tiny_png(png)
+    assert mentions.build_user_content("hi", []) == "hi"          # 无图=纯文本
+    c = mentions.build_user_content("这是什么", [str(png)])
+    assert isinstance(c, list) and c[0]["type"] == "text"
+    assert any(p.get("type") == "image_url" and p["image_url"]["url"].startswith("data:image/png;base64,")
+               for p in c)
+
+
+def test_providers_accept_multimodal_content(tmp_path):
+    png = tmp_path / "x.png"
+    _tiny_png(png)
+    content = mentions.build_user_content("这是什么", [str(png)])
+    msgs = [{"role": "user", "content": content}]
+    # codex → input_image
+    from ivyea_agent.providers.codex_provider import CodexProvider
+    _, items = CodexProvider.__new__(CodexProvider)._input(msgs)
+    assert any(c.get("type") == "input_image" for it in items for c in it.get("content", []))
+    # anthropic → image 块
+    from ivyea_agent.providers.anthropic_provider import _split_messages
+    _, out = _split_messages(msgs)
+    assert any(b.get("type") == "image" for m in out for b in (m.get("content") or []) if isinstance(b, dict))
+    # gemini → inlineData
+    from ivyea_agent.providers.gemini_provider import _messages_to_gemini
+    _, contents = _messages_to_gemini(msgs)
+    assert any("inlineData" in p for c in contents for p in c.get("parts", []))
+
+
 def test_at_path_completion(tmp_path):
     (tmp_path / "alpha.py").write_text("x", encoding="utf-8")
     (tmp_path / "beta.txt").write_text("y", encoding="utf-8")

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,47 @@
+"""@文件引用展开（mentions.expand）+ @路径补全。"""
+from __future__ import annotations
+
+from ivyea_agent import mentions
+
+
+def test_text_file_inlined(tmp_path):
+    (tmp_path / "foo.py").write_text("print('hi')\n# 关键实现\n", encoding="utf-8")
+    txt, imgs = mentions.expand("解释 @foo.py 这个文件", str(tmp_path))
+    assert "@foo.py" in txt                       # 正文保留引用
+    assert "[文件 foo.py]" in txt and "关键实现" in txt  # 内容内联到末尾
+    assert imgs == []
+
+
+def test_missing_path_left_literal(tmp_path):
+    txt, imgs = mentions.expand("看看 @nope.py 和 @user 提及", str(tmp_path))
+    assert "@nope.py" in txt and "[文件" not in txt
+    assert imgs == []
+
+
+def test_image_default_literal_but_collected_with_flag(tmp_path):
+    (tmp_path / "a.png").write_bytes(b"\x89PNG\r\n")
+    t1, i1 = mentions.expand("@a.png 这是啥", str(tmp_path))
+    assert i1 == [] and "@a.png" in t1            # 默认不接多模态 → 原样
+    t2, i2 = mentions.expand("@a.png 这是啥", str(tmp_path), with_images=True)
+    assert len(i2) == 1 and i2[0].endswith("a.png") and "[图片 a.png]" in t2
+
+
+def test_truncates_huge_file(tmp_path):
+    big = "\n".join(f"line{i}" for i in range(5000))
+    (tmp_path / "big.txt").write_text(big, encoding="utf-8")
+    txt, _ = mentions.expand("@big.txt", str(tmp_path))
+    assert "已截断" in txt and "共 5000 行" in txt
+
+
+def test_at_path_completion(tmp_path):
+    (tmp_path / "alpha.py").write_text("x", encoding="utf-8")
+    (tmp_path / "beta.txt").write_text("y", encoding="utf-8")
+    import os
+    from ivyea_agent import chat_input
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        got = sorted(c.text for c in chat_input._at_completions("al"))
+    finally:
+        os.chdir(cwd)
+    assert "alpha.py" in got

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -23,6 +23,35 @@ def test_parse_sse_text_and_tool_calls():
     assert final["usage"]["prompt_tokens"] == 10
 
 
+def test_parse_sse_reasoning():
+    lines = [
+        'data: {"choices":[{"delta":{"reasoning_content":"先想想"}}]}',
+        'data: {"choices":[{"delta":{"content":"答案"}}]}',
+        "data: [DONE]",
+    ]
+    events = list(parse_sse(lines))
+    assert {"type": "reasoning", "text": "先想想"} in events              # 思考流 → reasoning 事件
+    assert any(e["type"] == "text" and e["text"] == "答案" for e in events)
+
+
+def test_run_turn_stream_routes_reasoning():
+    from ivyea_agent import agent_loop
+    from ivyea_agent.agent_tools import ToolContext
+
+    class FakeProv:
+        def stream_chat(self, messages, tools=None):
+            yield {"type": "reasoning", "text": "思考中"}
+            yield {"type": "text", "text": "你好"}
+            yield {"type": "final", "content": "你好", "tool_calls": [], "usage": {}}
+
+    got = {"r": [], "t": []}
+    out = agent_loop.run_turn_stream(
+        FakeProv(), ToolContext(), [{"role": "user", "content": "hi"}],
+        render=lambda t: got["t"].append(t),
+        render_reasoning=lambda t: got["r"].append(t))
+    assert got["r"] == ["思考中"] and out["text"] == "你好"               # 思考单独路由，不混进正文
+
+
 def test_parse_sse_handles_bytes_and_blank():
     lines = [b'data: {"choices":[{"delta":{"content":"hi"}}]}', "", b"data: [DONE]"]
     events = list(parse_sse(lines))

--- a/tests/test_tools_general.py
+++ b/tests/test_tools_general.py
@@ -48,6 +48,32 @@ def test_write_blocked_in_plan_mode(tmp_path):
     assert "计划模式" in r and not f.exists()
 
 
+# ── 后台 bash（Phase 1）──
+def test_run_command_background_and_output(tmp_path):
+    import re
+    import time
+    ctx = _ctx(tmp_path, allow=["run_command"])
+    r = tg.t_run_command({"command": "echo hello-bg", "run_in_background": True}, ctx)
+    assert "bash_id=" in r
+    bid = re.search(r"bash_id=(bg-\d+)", r).group(1)
+    out = ""
+    for _ in range(50):
+        out = tg.t_bash_output({"bash_id": bid}, ctx)
+        if "已结束" in out:
+            break
+        time.sleep(0.1)
+    assert "hello-bg" in out and "已结束" in out       # 轮询到输出 + 退出状态
+
+
+def test_kill_bash(tmp_path):
+    import re
+    ctx = _ctx(tmp_path, allow=["run_command"])
+    r = tg.t_run_command({"command": "sleep 30", "run_in_background": True}, ctx)
+    bid = re.search(r"bash_id=(bg-\d+)", r).group(1)
+    assert "已终止" in tg.t_kill_bash({"bash_id": bid}, ctx)
+    assert "没有该后台任务" in tg.t_bash_output({"bash_id": "bg-9999"}, ctx)
+
+
 # ── edit_file ──
 def test_edit_unique(tmp_path):
     f = tmp_path / "e.txt"


### PR DESCRIPTION
两大块（9 commit，524 测试全绿）：

**A. 补齐 6 项能力欠缺**：①后台bash(run_in_background/bash_output/kill_bash) ②@文件引用+路径补全 ③对话图片输入(@图片//paste,codex/openai/anthropic/gemini四通) ④思考可见(✻思考,deepseek-reasoner+codex) ⑤渐进式markdown流式 ⑥/rewind检查点(对话+代码git快照)

**B. 输入框钉底重构（设为默认）**：常驻底部 app(full_screen=False+patch_stdout)——输入框钉底、生成中也在，保留原生鼠标滚轮+框选复制(对标 Claude/Ink)。IVYEA_TUI=1→alt-screen；IVYEA_PLAIN=1→旧行式。

真机 pty 验证全链路。

🤖 Generated with [Claude Code](https://claude.com/claude-code)