### PR TITLE
feat(chat): 默认alt-screen(输入框钉死)+鼠标滚轮+知识文档数

### DIFF
--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -20,14 +20,17 @@ import time
 from typing import Callable
 
 _TRUTHY = ("1", "true", "on", "yes")
+_FALSY = ("0", "false", "off", "no")
 _SPIN = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 
 def tui_enabled() -> bool:
-    """是否走全屏 TUI（alt-screen）。默认**关**——走行式（正常滚动缓冲区），
-    这样鼠标滚轮/框选复制原生可用（对标 Claude Code）。仅 `IVYEA_TUI=1/true/on/yes`
-    才进全屏 TUI（opt-in）。非 TTY / prompt_toolkit 不可用时也回退到行式。"""
-    if os.environ.get("IVYEA_TUI", "").strip().lower() not in _TRUTHY:
+    """是否走全屏 alt-screen TUI（输入框彻底钉死、翻历史也在）。**默认开**。
+    `IVYEA_TUI=0/false/off/no` 或 `IVYEA_LIVE=1`（要滚动区）→ 关；
+    非 TTY / prompt_toolkit 不可用时也回退。"""
+    if os.environ.get("IVYEA_LIVE", "").strip().lower() in _TRUTHY:
+        return False
+    if os.environ.get("IVYEA_TUI", "").strip().lower() in _FALSY:
         return False
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return False

--- a/ivyea_agent/chat_tui.py
+++ b/ivyea_agent/chat_tui.py
@@ -67,6 +67,24 @@ def _visual_lines(text: str, width: int) -> list[str]:
     return out
 
 
+def _make_scroll_control(get_text, on_scroll):
+    """FormattedTextControl + 鼠标滚轮处理（alt-screen 下 transcript 被裁到末屏、内容不溢出，
+    需自己接滚轮）。SCROLL_UP/DOWN → on_scroll(delta)。Shift+拖选仍由终端原生处理（复制）。"""
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    from prompt_toolkit.mouse_events import MouseEventType
+
+    class _C(FormattedTextControl):
+        def mouse_handler(self, mouse_event):
+            et = mouse_event.event_type
+            if et == MouseEventType.SCROLL_UP:
+                on_scroll(-3); return None
+            if et == MouseEventType.SCROLL_DOWN:
+                on_scroll(3); return None
+            return super().mouse_handler(mouse_event)
+
+    return _C(get_text)
+
+
 def _ptprint(s: str) -> None:
     """打印带 ANSI 的一段到滚动缓冲区。patch_stdout 下必须走 print_formatted_text(ANSI())，
     直接 print 原始 ANSI 会被当字面量（显示成 ?[36m）。"""
@@ -491,8 +509,8 @@ class ChatTUI:
                 Window(FormattedTextControl(self._footer), height=1),        # 状态栏（生成中也在）
             ])
         else:
-            # alt-screen：内部 transcript（末屏裁剪+贴底+键盘滚动；审批面板在 _body_ansi 末尾）
-            self._body_window = Window(FormattedTextControl(self._body_ansi), wrap_lines=True)
+            # alt-screen：内部 transcript（末屏裁剪+贴底+键盘/鼠标滚轮滚动；审批面板在 _body_ansi 末尾）
+            self._body_window = Window(_make_scroll_control(self._body_ansi, self._scroll_by), wrap_lines=True)
             root = HSplit([
                 self._body_window,
                 top_border,
@@ -612,11 +630,11 @@ class ChatTUI:
             "run": "ansiyellow", "prompt": "ansicyan bold",
             "mode": "ansicyan bold", "auto-suggestion": "ansibrightblack",
         })
-        # mouse_support=False：不抢鼠标，终端原生选中/复制可用。scrollback 模式 full_screen=False
-        # （常驻底部 app，输出经 patch_stdout 落滚动缓冲区）；alt-screen 模式 full_screen=True。
+        # alt-screen：mouse_support=True → 鼠标滚轮滚 transcript；Shift+拖选仍走终端原生选中(复制)。
+        # scrollback：mouse_support=False → 完全交给终端(原生滚轮+框选复制)，full_screen=False。
         self.app = Application(
             layout=Layout(root, focused_element=ta), key_bindings=kb, style=style,
-            full_screen=not self.scrollback, mouse_support=False, refresh_interval=0.3,
+            full_screen=not self.scrollback, mouse_support=not self.scrollback, refresh_interval=0.3,
         )
         return self.app
 

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1420,10 +1420,15 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         _n_mcp = len(cfg.load_mcp().get("mcpServers", {}))
     except Exception:
         _n_tools = _n_skills = _n_mcp = 0
+    try:
+        from . import knowledge as _kb_mod
+        _n_knowledge = len(_kb_mod.list_cards())   # 知识文档（内置 + 用户上传）
+    except Exception:
+        _n_knowledge = 0
     _welcome_lines = [
         f"{_C['c']}✻{_C['x']} {_C['b']}亚马逊运营 Agent{_C['x']} · 规则引擎+LLM复核+审核制执行 · 自托管",
         f"{_C['d']}主脑 {_label()}（{keyst}）· 执行 {mode}{_C['x']}",
-        f"{_C['d']}{_n_tools} 工具 · {_n_skills} skills · {_n_mcp} MCP · 会话 {(sid or '新')[:8]}{_C['x']}",
+        f"{_C['d']}{_n_tools} 工具 · {_n_skills} skills · {_n_mcp} MCP · {_n_knowledge} 知识 · 会话 {(sid or '新')[:8]}{_C['x']}",
         f"{_C['d']}/ 命令 · ↑↓+Enter 选择 · Alt+Enter 换行 · /exit 退出{_C['x']}",
     ]
     from . import chat_tui as _chat_tui  # noqa: F401

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1426,21 +1426,21 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         f"{_C['d']}{_n_tools} 工具 · {_n_skills} skills · {_n_mcp} MCP · 会话 {(sid or '新')[:8]}{_C['x']}",
         f"{_C['d']}/ 命令 · ↑↓+Enter 选择 · Alt+Enter 换行 · /exit 退出{_C['x']}",
     ]
-    from . import chat_tui as _chat_tui
-    _tui_on = _chat_tui.tui_enabled()   # IVYEA_TUI=1 → 全屏 alt-screen
-    # 常驻底部 app（滚动缓冲区）为**默认**：输入框钉底、生成中也在，保留原生滚轮/复制（对标
-    # Claude/Ink）。IVYEA_PLAIN=1 退回旧行式循环；非 TTY / prompt_toolkit 不可用也退回。
-    def _live_default() -> bool:
-        if _tui_on or not (sys.stdin.isatty() and sys.stdout.isatty()):
-            return False
-        if os.environ.get("IVYEA_PLAIN", "").strip().lower() in ("1", "true", "on", "yes"):
-            return False
+    from . import chat_tui as _chat_tui  # noqa: F401
+    # 聊天界面三态：**默认全屏 alt-screen TUI**（输入框彻底钉死、翻历史也在，用户选定）；
+    # IVYEA_LIVE=1 或 IVYEA_TUI=0 → 滚动区常驻底部 app（原生滚轮/复制，输入框仅生成中固定）；
+    # IVYEA_PLAIN=1 / 非 TTY / prompt_toolkit 不可用 → 旧行式循环。
+    _env = lambda k: os.environ.get(k, "").strip().lower()   # noqa: E731
+    _tty_ok = sys.stdin.isatty() and sys.stdout.isatty()
+    if _tty_ok:
         try:
             import prompt_toolkit  # noqa: F401
         except Exception:
-            return False
-        return True
-    _live_on = _live_default()
+            _tty_ok = False
+    _plain = (_env("IVYEA_PLAIN") in ("1", "true", "on", "yes")) or not _tty_ok
+    _live_on = (not _plain) and (_env("IVYEA_LIVE") in ("1", "true", "on", "yes")
+                                 or _env("IVYEA_TUI") in ("0", "false", "off", "no"))
+    _tui_on = (not _plain) and (not _live_on)   # 默认 alt-screen
     _health = cfg.main_brain_health()
     _health_msg = "" if _health.get("ok") else ui.message("warn", _health.get("hint", "主脑不可用，请用 /model 切换。"))
     # TUI 模式：banner+欢迎框作为 transcript 首块（打印会被 alt-screen 清掉）；行式则直接打印。

--- a/tests/test_chat_tui.py
+++ b/tests/test_chat_tui.py
@@ -13,16 +13,18 @@ def _plain(s: str) -> str:
     return re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", s)
 
 
-def test_tui_default_off_and_opt_in(monkeypatch):
+def test_tui_default_on_and_opt_out(monkeypatch):
     import types
     monkeypatch.setattr(chat_tui.sys, "stdin", types.SimpleNamespace(isatty=lambda: True))
     monkeypatch.setattr(chat_tui.sys, "stdout", types.SimpleNamespace(isatty=lambda: True))
     monkeypatch.delenv("IVYEA_TUI", raising=False)
-    assert chat_tui.tui_enabled() is False                # 默认走行式（正常滚动缓冲区）
-    for on in ("1", "true", "On", "YES"):
-        monkeypatch.setenv("IVYEA_TUI", on)
-        assert chat_tui.tui_enabled() is True             # IVYEA_TUI=1 才进全屏 TUI（opt-in）
-    monkeypatch.setenv("IVYEA_TUI", "0")
+    monkeypatch.delenv("IVYEA_LIVE", raising=False)
+    assert chat_tui.tui_enabled() is True                 # 默认全屏 alt-screen TUI（输入框钉死）
+    for off in ("0", "false", "Off", "NO"):
+        monkeypatch.setenv("IVYEA_TUI", off)
+        assert chat_tui.tui_enabled() is False            # IVYEA_TUI=0 → 滚动区/行式
+    monkeypatch.delenv("IVYEA_TUI", raising=False)
+    monkeypatch.setenv("IVYEA_LIVE", "1")                 # IVYEA_LIVE=1（要滚动区）→ 不进 alt-screen
     assert chat_tui.tui_enabled() is False
 
 
@@ -30,7 +32,7 @@ def test_tui_disabled_when_not_tty(monkeypatch):
     import types
     monkeypatch.setattr(chat_tui.sys, "stdin", types.SimpleNamespace(isatty=lambda: False))
     monkeypatch.setattr(chat_tui.sys, "stdout", types.SimpleNamespace(isatty=lambda: True))
-    monkeypatch.setenv("IVYEA_TUI", "1")                  # 即便 opt-in，非 TTY 也回退行式
+    monkeypatch.delenv("IVYEA_TUI", raising=False)        # 默认开，但非 TTY 也回退
     assert chat_tui.tui_enabled() is False
 
 


### PR DESCRIPTION
1)默认切回全屏alt-screen(输入框彻底钉死/翻历史也在);IVYEA_TUI=0或IVYEA_LIVE=1→滚动区;IVYEA_PLAIN=1→行式。2)alt-screen恢复鼠标滚轮(mouse_support=True,滚轮滚transcript+Shift拖选复制)。3)欢迎框加显知识文档数(N 知识)。真机验证,524全绿。🤖 Generated with [Claude Code](https://claude.com/claude-code)