### PR TITLE
fix(lint): 修 ruff E402 + F821(rerender 漏 import markdown)

### DIFF
--- a/ivyea_agent/chat_input.py
+++ b/ivyea_agent/chat_input.py
@@ -8,15 +8,15 @@
 """
 from __future__ import annotations
 
-import sys
 import os
+import re as _re
+import sys
 from typing import Callable
 
 from . import config
 
 EXIT = object()  # 哨兵：用户在框内 Ctrl+C/Ctrl+D 退出
 
-import re as _re
 _AT_RE = _re.compile(r"(?<!\S)@([^\s@]*)$")   # 光标前最后一个 @路径片段（用于补全）
 
 

--- a/ivyea_agent/chat_ui.py
+++ b/ivyea_agent/chat_ui.py
@@ -162,6 +162,7 @@ class _StreamPrinter:
             self._erase(self.block)
             self._emit_md(self.block)
         elif not self._emitted:                    # 从没定稿过（如空回复）→ 兜底渲染全文
+            from . import markdown
             print(f"{_C['c']}●{_C['x']} " + markdown.render(final_text))
         self.block = ""
 


### PR DESCRIPTION
CI lint(ruff)红:E402(chat_input import 归位)+F821(chat_ui.rerender 兜底分支漏 import markdown,空回复会崩的真bug)。ruff全过,524全绿。🤖 Generated with [Claude Code](https://claude.com/claude-code)