### PR TITLE
feat(chat): 版本号显示 + 启动检测更新 + /update 一键更新

### DIFF
--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1202,6 +1202,7 @@ SLASH_COMMANDS = [
     ("/cost", "本会话 token 用量与成本估算"),
     ("/compact", "压缩上下文；/compact auto on|off 控制自动压缩"),
     ("/rewind", "回退检查点：截断对话到某轮之前 + 恢复代码文件（对话+代码快照）"),
+    ("/update", "检查并更新到最新版（有新版时自动提示）"),
     ("/init", "生成账户指令模板 AGENTS.md（长期打法/边界，自动注入）"),
     ("/paste", "把剪贴板里的图片喂给多模态模型（也可直接 @图片路径）"),
     ("/raw", "切换 Markdown 渲染 / 原始流式输出"),
@@ -1425,8 +1426,9 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         _n_knowledge = len(_kb_mod.list_cards())   # 知识文档（内置 + 用户上传）
     except Exception:
         _n_knowledge = 0
+    from . import __version__ as _ver
     _welcome_lines = [
-        f"{_C['c']}✻{_C['x']} {_C['b']}亚马逊运营 Agent{_C['x']} · 规则引擎+LLM复核+审核制执行 · 自托管",
+        f"{_C['c']}✻{_C['x']} {_C['b']}亚马逊运营 Agent{_C['x']} {_C['d']}v{_ver}{_C['x']} · 规则引擎+LLM复核+审核制执行 · 自托管",
         f"{_C['d']}主脑 {_label()}（{keyst}）· 执行 {mode}{_C['x']}",
         f"{_C['d']}{_n_tools} 工具 · {_n_skills} skills · {_n_mcp} MCP · {_n_knowledge} 知识 · 会话 {(sid or '新')[:8]}{_C['x']}",
         f"{_C['d']}/ 命令 · ↑↓+Enter 选择 · Alt+Enter 换行 · /exit 退出{_C['x']}",
@@ -1449,15 +1451,29 @@ def _cmd_chat(args: argparse.Namespace) -> int:
     _health = cfg.main_brain_health()
     _health_msg = "" if _health.get("ok") else ui.message("warn", _health.get("hint", "主脑不可用，请用 /model 切换。"))
     # TUI 模式：banner+欢迎框作为 transcript 首块（打印会被 alt-screen 清掉）；行式则直接打印。
+    _upd_msg = ""
+    try:   # 启动非阻塞检测更新：有新版则提示 /update 一键更新
+        from . import updater as _updater
+        _uc = _updater.check_latest()
+        if _uc.get("has_update"):
+            _lat = str(_uc["latest"]).lstrip("vV")   # tag 已带 v，去掉避免 vv
+            _upd_msg = ui.message("info", f"新版本 v{_lat} 可用（当前 v{_uc['current']}）· 输入 /update 一键更新")
+    except Exception:
+        _upd_msg = ""
+    # TUI 模式：banner+欢迎框作为 transcript 首块（打印会被 alt-screen 清掉）；行式则直接打印。
     _intro = f"{_C['c']}{_C['b']}{_BANNER}{_C['x']}\n" + _welcome_box_str(_welcome_lines, width=64)
     if _health_msg:
         _intro += "\n" + _health_msg
+    if _upd_msg:
+        _intro += "\n" + _upd_msg
     if not _tui_on and not _live_on:   # LIVE/alt-screen 由 chat_tui 打 intro，避免双 banner
         print(f"{_C['c']}{_C['b']}{_BANNER}{_C['x']}")
         _print_welcome_box(_welcome_lines, width=64)
         print()
         if _health_msg:
             print(_health_msg + "\n")
+        if _upd_msg:
+            print(_upd_msg + "\n")
 
     from . import chat_input
 
@@ -1683,6 +1699,26 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             print(ui.message("warn", f"未知模型 id：{mid}。用 /model 看清单。"))
         return True
 
+    def _sh_update(line):
+        """检查最新版并一键更新（源码仓 git pull / 否则 pip·pipx 升级）。"""
+        from . import updater as _updater
+        print(ui.message("info", "正在检查最新版本…"))
+        uc = _updater.check_now()
+        if uc.get("latest") is None:
+            print(ui.message("warn", "无法连接 GitHub 检查更新（离线或超时）。")); return True
+        if not uc.get("has_update"):
+            print(ui.message("success", f"已是最新版 v{uc['current']}。")); return True
+        _lat = str(uc["latest"]).lstrip("vV")
+        print(ui.message("info", f"发现新版本 v{_lat}（当前 v{uc['current']}），开始更新…"))
+        ok, out = _updater.do_update()
+        if out:
+            print(out[-2000:])
+        if ok:
+            print(ui.message("success", "已更新到最新代码。请 /exit 后重开 ivyea chat 生效。"))
+        else:
+            print(ui.message("error", "更新失败，请手动更新（见输出）。"))
+        return True
+
     def _sh_rewind(line):
         """回退检查点：截断对话到某轮之前 + 把代码文件恢复到该轮之前（对标 Claude /rewind）。"""
         nonlocal messages
@@ -1713,7 +1749,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         "/raw": _sh_raw, "/stream": _sh_stream, "/auto-edit": _sh_auto_edit, "/compact": _sh_compact,
         "/diff": _sh_diff, "/init": _sh_init, "/mcp": _sh_mcp, "/knowledge": _sh_knowledge,
         "/skill": _sh_skill, "/tools": _sh_tools, "/memory": _sh_memory, "/status": _sh_status,
-        "/config": _sh_config, "/model": _sh_model, "/rewind": _sh_rewind,
+        "/config": _sh_config, "/model": _sh_model, "/rewind": _sh_rewind, "/update": _sh_update,
         "/workspace": _sh_embedded, "/patch": _sh_embedded, "/gitops": _sh_embedded,
     }
 

--- a/ivyea_agent/updater.py
+++ b/ivyea_agent/updater.py
@@ -1,0 +1,125 @@
+"""版本更新检测 + 一键更新（对标 Claude Code 的启动更新提示）。
+
+- check_latest(): 启动时**非阻塞**检测——读本地缓存立即返回(可能提示)，缓存过期(>6h)则起后台线程
+  刷新供下次用；离线/超时优雅降级(latest=None)。
+- check_now(): /update 命令用的同步检测(带超时)。
+- do_update(): 执行更新——源码 git 仓 → git pull；否则 → pip/pipx 升级(复用 self_manage.upgrade_plan)。
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+from . import __version__, config
+
+_REPO = "Hector-xue/ivyea-agent"
+_TTL = 6 * 3600   # 缓存有效期（秒）
+
+
+def _cache_file() -> Path:
+    return config.IVYEA_DIR / "update_check.json"
+
+
+def _norm(v: str) -> tuple:
+    """'v1.2.3' / '1.2.3' → (1,2,3)，便于比较。"""
+    parts = []
+    for p in (v or "").strip().lstrip("vV").split("."):
+        num = "".join(ch for ch in p if ch.isdigit())
+        parts.append(int(num) if num else 0)
+    return tuple(parts) or (0,)
+
+
+def has_update(current: str, latest: str | None) -> bool:
+    return bool(latest) and _norm(latest) > _norm(current)
+
+
+def _fetch_latest(timeout: float = 3.0) -> str | None:
+    """拉 GitHub 最新 release 的 tag_name；任何异常/离线返回 None。"""
+    try:
+        import httpx
+        r = httpx.get(f"https://api.github.com/repos/{_REPO}/releases/latest",
+                      timeout=timeout, follow_redirects=True,
+                      headers={"Accept": "application/vnd.github+json", "User-Agent": "ivyea-agent"})
+        if r.status_code == 200:
+            return (r.json().get("tag_name") or "").strip() or None
+    except Exception:
+        return None
+    return None
+
+
+def _write_cache(latest: str | None) -> None:
+    try:
+        config.ensure_dirs()
+        _cache_file().write_text(json.dumps({"latest": latest, "checked_at": time.time()}),
+                                 encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _read_cache() -> dict:
+    try:
+        return json.loads(_cache_file().read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def check_latest() -> dict:
+    """启动用**非阻塞**检测：读缓存立即返回；缓存过期则后台刷新(供下次)。
+    返回 {current, latest, has_update}。"""
+    current = __version__
+    data = _read_cache()
+    if time.time() - float(data.get("checked_at", 0)) >= _TTL:
+        threading.Thread(target=lambda: _write_cache(_fetch_latest()), daemon=True).start()
+    latest = data.get("latest")
+    return {"current": current, "latest": latest, "has_update": has_update(current, latest)}
+
+
+def check_now(timeout: float = 5.0) -> dict:
+    """同步检测(拉网络，写缓存)——供 /update 命令用。"""
+    current = __version__
+    latest = _fetch_latest(timeout=timeout)
+    _write_cache(latest)
+    return {"current": current, "latest": latest, "has_update": has_update(current, latest)}
+
+
+def _source_repo() -> Path | None:
+    """本包若在 git 源码仓里(源码安装)→返回仓根；否则 None。"""
+    try:
+        from . import git_workflow
+        return git_workflow.repo_root(Path(__file__).resolve().parent)
+    except Exception:
+        return None
+
+
+def update_commands() -> list[list[str]]:
+    """本机的更新命令：源码仓 → git pull；否则 → self_manage.upgrade_plan 的命令。"""
+    root = _source_repo()
+    if root is not None:
+        return [["git", "-C", str(root), "pull", "--ff-only"]]
+    try:
+        from . import self_manage
+        return [["bash", "-lc", c] for c in self_manage.upgrade_plan().get("commands", [])]
+    except Exception:
+        return [["bash", "-lc", "python -m pip install --upgrade ivyea-agent"]]
+
+
+def do_update() -> tuple[bool, str]:
+    """执行更新命令，返回 (ok, 合并输出)。"""
+    cmds = update_commands()
+    if not cmds:
+        return False, "没有可用的更新命令。"
+    out: list[str] = []
+    for cmd in cmds:
+        out.append("$ " + (" ".join(cmd) if cmd[0] != "bash" else cmd[-1]))
+        try:
+            r = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                               text=True, timeout=300)
+            out.append((r.stdout or "").strip())
+            if r.returncode != 0:
+                return False, "\n".join(out)
+        except Exception as e:   # noqa: BLE001
+            return False, "\n".join(out) + f"\n执行失败：{e}"
+    return True, "\n".join(p for p in out if p)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,42 @@
+"""版本更新检测：版本比较、缓存读取、更新命令。"""
+from __future__ import annotations
+
+import json
+import time
+
+
+def test_norm_and_has_update():
+    from ivyea_agent import updater
+    assert updater._norm("v1.10.0") > updater._norm("v1.9.0")   # 1.10 > 1.9（非字典序）
+    assert updater._norm("v2.0.0") > updater._norm("1.9.9")
+    assert updater.has_update("1.1.2", "v1.1.3") is True
+    assert updater.has_update("1.1.2", "v1.1.2") is False
+    assert updater.has_update("1.1.3", "v1.1.2") is False        # 本地更新则不提示
+    assert updater.has_update("1.1.2", None) is False            # 离线/拉取失败
+
+
+def test_check_latest_uses_fresh_cache(ivyea_home, monkeypatch):
+    from ivyea_agent import updater, config, __version__
+    config.ensure_dirs()
+    (config.IVYEA_DIR / "update_check.json").write_text(
+        json.dumps({"latest": "v999.0.0", "checked_at": time.time()}), encoding="utf-8")
+    # 缓存新鲜 → 不应发网络
+    monkeypatch.setattr(updater, "_fetch_latest",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("不应发网络")))
+    r = updater.check_latest()
+    assert r["latest"] == "v999.0.0" and r["has_update"] is True and r["current"] == __version__
+
+
+def test_check_now_writes_cache(ivyea_home, monkeypatch):
+    from ivyea_agent import updater, config
+    monkeypatch.setattr(updater, "_fetch_latest", lambda *a, **k: "v9.9.9")
+    r = updater.check_now()
+    assert r["latest"] == "v9.9.9" and r["has_update"] is True
+    cached = json.loads((config.IVYEA_DIR / "update_check.json").read_text(encoding="utf-8"))
+    assert cached["latest"] == "v9.9.9"
+
+
+def test_update_commands_source_repo():
+    from ivyea_agent import updater
+    cmds = updater.update_commands()          # 本仓即源码仓 → git pull
+    assert cmds and cmds[0][0] == "git" and "pull" in cmds[0]


### PR DESCRIPTION
欢迎框显示版本号;启动非阻塞检测更新(缓存6h,离线优雅),有新版提示;/update 命令(可tab补全)一键更新(源码仓 git pull/否则 pip·pipx)。ruff过,528全绿。🤖 Generated with [Claude Code](https://claude.com/claude-code)