### PR TITLE
fix(memory): recall 搜 MEMORY.md 文件本身 + 启动注入 MEMORY.md 摘要

### DIFF
--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1378,6 +1378,9 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             content += "\n\n" + profile_context
         if instructions:
             content += "\n\n[长期指令/画像]\n" + instructions
+        memory_digest = memory.load_memory_digest()   # MEMORY.md 摘要，开箱即知记忆内容
+        if memory_digest:
+            content += "\n\n[记忆摘要 / MEMORY.md（其余用「回忆记忆」检索）]\n" + memory_digest
         return {"role": "system", "content": content}
 
     # ── resume / continue ─────────────────────────────────────────────

--- a/ivyea_agent/memory.py
+++ b/ivyea_agent/memory.py
@@ -183,6 +183,23 @@ def instruction_paths(cwd: str = "") -> list:
     return paths
 
 
+def load_memory_digest(limit: int = 3500) -> str:
+    """启动注入用：全局 MEMORY.md 的摘要，让 agent 开箱就知道记忆里有什么、不必每次靠回忆检索
+    （曾出现"文件里明明有、recall 却说没有"）。超长则截断，其余仍可用「回忆记忆」按需检索。"""
+    try:
+        p = note_path("")
+        if not p.exists():
+            return ""
+        text = p.read_text(encoding="utf-8").strip()
+    except Exception:
+        return ""
+    if not text:
+        return ""
+    if len(text) > limit:
+        text = text[:limit].rstrip() + "\n…（记忆较长，其余用「回忆记忆」检索）"
+    return text
+
+
 def load_instructions(cwd: str = "", limit: int = 6000) -> str:
     """汇总 USER.md(画像) + AGENTS.md(账户/项目打法)，启动注入 system。"""
     parts = []

--- a/ivyea_agent/retrieval.py
+++ b/ivyea_agent/retrieval.py
@@ -198,7 +198,53 @@ def _memory_hits(query: str, limit: int) -> list[dict[str, Any]]:
             "asin": row.get("asin", ""),
             "ts": row.get("ts"),
         })
+    # 兜底：直接搜策展 markdown 文件本身（MEMORY.md / account/*.md）。FTS 索引只包含经 remember()
+    # 写入的条目，用户手改 MEMORY.md、或重装后 memory.db 丢失而 markdown 仍在时，索引里没有但文件里
+    # 明明有——这一步以文件为真相，保证这些内容也能被回忆到（曾出现"文件里有、recall 却说没有"）。
+    for h in _memory_md_hits(query, limit):
+        if not any(h["snippet"][:120] == e.get("snippet", "")[:120] for e in hits):
+            hits.append(h)
     return hits
+
+
+def _memory_md_hits(query: str, limit: int) -> list[dict[str, Any]]:
+    """直接对策展 markdown 文件做词项匹配（不经 FTS 索引）。按空行分段，保留数据库连接串/schema
+    这类多行块的完整上下文。"""
+    terms = [t.lower() for t in re.findall(r"[\w一-鿿+.-]+", query) if len(t) >= 2]
+    if not terms:
+        return []
+    mem_md = memory.note_path("")          # ~/.ivyea/MEMORY.md
+    paths = [mem_md]
+    acc_dir = mem_md.parent / "account"
+    try:
+        if acc_dir.exists():
+            paths.extend(sorted(acc_dir.glob("*.md")))
+    except Exception:
+        pass
+    hits: list[dict[str, Any]] = []
+    for p in paths:
+        try:
+            text = p.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        is_acc = p.parent.name == "account"
+        for j, block in enumerate(b.strip() for b in re.split(r"\n\s*\n", text) if b.strip()):
+            low = block.lower()
+            matched = [t for t in terms if t in low]
+            if not matched:
+                continue
+            hits.append({
+                "source": "memory",
+                "id": f"memory_md:{p.stem}:{j}",
+                "title": p.stem if is_acc else "MEMORY.md",
+                "snippet": block[:600],
+                "score": 26 + min(40, len(matched) * 12),
+                "asin": p.stem if is_acc else "",
+                "ts": None,
+                "match": matched,
+            })
+    hits.sort(key=lambda h: h["score"], reverse=True)
+    return hits[:limit]
 
 
 def _memory_score(query: str, text: str, rank: int) -> int:


### PR DESCRIPTION
用户报 MEMORY.md 里有数据库访问方法但 recall 说没有。根因:memory.search 只搜 FTS 索引,手改 MEMORY.md 不进索引→抓瞎。修:①recall 增加直接搜 MEMORY.md/account/*.md(以文件为真相兜底);②启动注入 MEMORY.md 摘要,开箱即知。528测试全绿。🤖 Generated with [Claude Code](https://claude.com/claude-code)