### PR TITLE
feat(auth): Claude(Anthropic) 订阅版 OAuth 登录 [v1.4.0]

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -151,6 +151,9 @@ def _print_provider_auth_required(provider: dict) -> None:
     elif pid == "qwen-oauth":
         print("  ivyea model auth qwen-oauth --login")
         print("  ivyea model auth qwen-oauth --probe")
+    elif pid == "anthropic-oauth":
+        print("  ivyea model auth anthropic-oauth --login")
+        print("  ivyea model auth anthropic-oauth --probe")
     else:
         print(f"  ivyea model auth {pid}")
 
@@ -164,6 +167,8 @@ def _interactive_provider_login(provider: dict) -> bool:
             oauth_auth.codex_device_code_login(notify=print)
         elif pid == "google-gemini-cli":
             oauth_auth.google_oauth_login(open_browser=True, notify=print)
+        elif pid == "anthropic-oauth":
+            oauth_auth.anthropic_oauth_login(notify=print)
         elif pid == "qwen-oauth":
             oauth_auth.qwen_cli_login()
         elif pid == "copilot":
@@ -388,14 +393,16 @@ def _cmd_model_auth(args: argparse.Namespace, action: str) -> int:
                 and not getattr(args, "token", None):
             return 0
     if getattr(args, "refresh", False):
-        if provider_id not in ("qwen-oauth", "openai-codex", "google-gemini-cli"):
-            print("--refresh 目前支持 qwen-oauth / openai-codex / google-gemini-cli", file=sys.stderr)
+        if provider_id not in ("qwen-oauth", "openai-codex", "google-gemini-cli", "anthropic-oauth"):
+            print("--refresh 目前支持 qwen-oauth / openai-codex / google-gemini-cli / anthropic-oauth", file=sys.stderr)
             return 2
         try:
             if provider_id == "qwen-oauth":
                 oauth_auth.refresh_qwen_token()
             elif provider_id == "openai-codex":
                 oauth_auth.refresh_codex_token()
+            elif provider_id == "anthropic-oauth":
+                oauth_auth.refresh_anthropic_token()
             else:
                 oauth_auth.refresh_google_token()
         except oauth_auth.OAuthAuthError as exc:
@@ -404,12 +411,15 @@ def _cmd_model_auth(args: argparse.Namespace, action: str) -> int:
         print(f"{provider_id}: 已刷新本地认证（token 已隐藏）")
         return 0
     if getattr(args, "login", False):
-        if provider_id not in ("google-gemini-cli", "qwen-oauth"):
-            print("--login 目前支持 google-gemini-cli / qwen-oauth", file=sys.stderr)
+        if provider_id not in ("google-gemini-cli", "qwen-oauth", "anthropic-oauth"):
+            print("--login 目前支持 google-gemini-cli / qwen-oauth / anthropic-oauth", file=sys.stderr)
             return 2
         try:
             if provider_id == "google-gemini-cli":
                 oauth_auth.google_oauth_login(open_browser=not getattr(args, "no_browser", False), notify=print)
+            elif provider_id == "anthropic-oauth":
+                oauth_auth.anthropic_oauth_login(notify=print)
+                print("提示：登录后建议 `ivyea model auth anthropic-oauth --probe` 验证 token 可用，再选它当主脑。")
             else:
                 oauth_auth.qwen_cli_login()
         except oauth_auth.OAuthAuthError as exc:
@@ -473,8 +483,16 @@ def _cmd_model_auth(args: argparse.Namespace, action: str) -> int:
         if not getattr(args, "probe", False):
             return 0
     if getattr(args, "probe", False):
+        if provider_id == "anthropic-oauth":
+            ok, msg = oauth_auth.probe_anthropic_oauth(timeout=getattr(args, "timeout", 30.0) or 30.0)
+            print(f"anthropic-oauth: {msg}")
+            if not ok:
+                print("排查：token 可能失效（`--refresh` 或重新 `--login`）；若持续 401/403，"
+                      "可能是逆向的 client_id/beta 头/身份要求已被 Anthropic 变更，用 IVYEA_ANTHROPIC_OAUTH_* 环境变量覆盖。",
+                      file=sys.stderr)
+            return 0 if ok else 1
         if provider_id not in ("google-gemini-cli", "openai-codex", "copilot", "qwen-oauth"):
-            print("--probe 目前支持 google-gemini-cli / openai-codex / copilot / qwen-oauth", file=sys.stderr)
+            print("--probe 目前支持 google-gemini-cli / openai-codex / copilot / qwen-oauth / anthropic-oauth", file=sys.stderr)
             return 2
         token = oauth_auth.resolve_provider_token(provider_id, provider.get("key_env", ""), refresh=True)
         if not token:

--- a/ivyea_agent/models.py
+++ b/ivyea_agent/models.py
@@ -97,6 +97,21 @@ PROVIDERS: list[dict[str, Any]] = [
         "note": "Codex OAuth device-code 登录后走 chatgpt.com/backend-api/codex Responses；支持 Responses streaming 和工具调用。",
     },
     {
+        "id": "anthropic-oauth",
+        "label": "Claude 订阅 OAuth",
+        "group": "OAuth / 订阅",
+        "kind": "anthropic",
+        "api_mode": "anthropic_oauth",
+        "auth_type": "oauth_external",
+        "base": "https://api.anthropic.com",
+        "key_env": "",
+        "models": ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
+        "default_model": "claude-sonnet-4-6",
+        "status": "usable",
+        "note": "用 Claude 订阅(Max/Pro) OAuth 登录跑主脑：ivyea model auth anthropic-oauth --login 后 --probe 验证。"
+                "注意：为生态逆向、非官方，Anthropic 可能变更/限制；相关常量可用 IVYEA_ANTHROPIC_OAUTH_* 环境变量覆盖。",
+    },
+    {
         "id": "copilot",
         "label": "GitHub Copilot / GitHub Models",
         "group": "OAuth / 订阅",
@@ -493,6 +508,7 @@ def provider_capabilities(provider: dict[str, Any]) -> dict[str, Any]:
     tool_modes = {
         "chat_completions",
         "anthropic_messages",
+        "anthropic_oauth",
         "gemini_native",
         "gemini_code_assist",
         "bedrock_converse",
@@ -502,6 +518,7 @@ def provider_capabilities(provider: dict[str, Any]) -> dict[str, Any]:
     stream_modes = {
         "chat_completions",
         "anthropic_messages",
+        "anthropic_oauth",
         "gemini_native",
         "gemini_code_assist",
         "copilot_chat_completions",
@@ -516,17 +533,17 @@ def provider_capabilities(provider: dict[str, Any]) -> dict[str, Any]:
         "chat": provider.get("status", "usable") == "usable",
         "tools": api_mode in tool_modes,
         "streaming": api_mode in stream_modes,
-        "vision": pid in {"openai", "anthropic", "gemini"} or api_mode == "gemini_native",
+        "vision": pid in {"openai", "anthropic", "anthropic-oauth", "gemini"} or api_mode == "gemini_native",
         "oauth": auth in {"oauth_external", "oauth_device_code", "copilot"},
         "api_key": auth == "api_key",
         "local": auth == "none" or base.startswith(("http://localhost", "http://127.0.0.1")),
         "aws_sdk": auth == "aws_sdk",
         "custom_endpoint": pid in {"custom", "azure-foundry"} or not bool(base),
         "live_model_catalog": live_catalog,
-        "real_probe": pid in {"google-gemini-cli", "openai-codex", "copilot", "qwen-oauth"},
+        "real_probe": pid in {"google-gemini-cli", "openai-codex", "copilot", "qwen-oauth", "anthropic-oauth"},
         "model_refresh": live_catalog,
         "supports_code_tasks": pid in {
-            "openai", "anthropic", "google-gemini-cli", "openai-codex", "copilot",
+            "openai", "anthropic", "anthropic-oauth", "google-gemini-cli", "openai-codex", "copilot",
             "qwen", "qwen-oauth", "kimi-coding", "openrouter", "ollama", "custom",
         },
     }

--- a/ivyea_agent/oauth_auth.py
+++ b/ivyea_agent/oauth_auth.py
@@ -39,6 +39,15 @@ CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_AUTH_ISSUER = "https://auth.openai.com"
 CODEX_REFRESH_SKEW_SECONDS = 120
+# Claude(Anthropic) 订阅版 OAuth —— 常量为生态逆向值（非官方，Anthropic 可能变），全部 env 可覆盖，
+# 便于失效时无需改码即可修正。默认走 Claude 订阅(Max/Pro)登录，token 带 oauth beta 头打 messages API。
+ANTHROPIC_OAUTH_CLIENT_ID = os.getenv("IVYEA_ANTHROPIC_OAUTH_CLIENT_ID", "9d1c250a-e61b-44d9-88ed-5944d1962f5e")
+ANTHROPIC_OAUTH_AUTHORIZE_URL = os.getenv("IVYEA_ANTHROPIC_OAUTH_AUTHORIZE_URL", "https://claude.ai/oauth/authorize")
+ANTHROPIC_OAUTH_TOKEN_URL = os.getenv("IVYEA_ANTHROPIC_OAUTH_TOKEN_URL", "https://console.anthropic.com/v1/oauth/token")
+ANTHROPIC_OAUTH_REDIRECT_URI = os.getenv("IVYEA_ANTHROPIC_OAUTH_REDIRECT_URI", "https://console.anthropic.com/oauth/code/callback")
+ANTHROPIC_OAUTH_SCOPE = os.getenv("IVYEA_ANTHROPIC_OAUTH_SCOPE", "org:create_api_key user:profile user:inference")
+ANTHROPIC_OAUTH_BETA = os.getenv("IVYEA_ANTHROPIC_OAUTH_BETA", "oauth-2025-04-20")
+ANTHROPIC_REFRESH_SKEW_SECONDS = 120
 COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 COPILOT_TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token"
 COPILOT_UNSUPPORTED_PREFIX = "ghp_"
@@ -855,6 +864,146 @@ def codex_device_code_login(*, timeout: float = 15.0, max_wait: float = 15 * 60,
     )
 
 
+def anthropic_oauth_url(*, code_challenge: str, state: str) -> str:
+    params = {
+        "code": "true",
+        "client_id": ANTHROPIC_OAUTH_CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": ANTHROPIC_OAUTH_REDIRECT_URI,
+        "scope": ANTHROPIC_OAUTH_SCOPE,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    return ANTHROPIC_OAUTH_AUTHORIZE_URL + "?" + urllib.parse.urlencode(params)
+
+
+def _parse_anthropic_callback(raw: str) -> tuple[str, str]:
+    """从用户粘回的内容解析 (code, state)：支持 `code#state`、完整回调 URL、或纯 code。"""
+    value = (raw or "").strip()
+    if not value:
+        return "", ""
+    if value.startswith(("http://", "https://")):
+        parsed = urllib.parse.urlparse(value)
+        q = urllib.parse.parse_qs(parsed.query)
+        code = (q.get("code") or [""])[0]
+        state = (q.get("state") or [""])[0]
+        if code:
+            return code, (state or parsed.fragment or "")
+    if "#" in value:
+        code, _, state = value.partition("#")
+        return _extract_oauth_code(code), state.strip()
+    return _extract_oauth_code(value), ""
+
+
+def anthropic_oauth_login(*, notify: Any = None, prompt: Any = None, timeout: float = 30.0) -> None:
+    """Claude 订阅版 OAuth 登录（授权码 + PKCE + 手动粘码，网页终端也能用）。"""
+    def emit(text: str) -> None:
+        if notify:
+            notify(text)
+    ask = prompt or (lambda p: input(p))
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+    url = anthropic_oauth_url(code_challenge=challenge, state=state)
+    emit("用浏览器打开下面链接，登录并授权 Claude：")
+    emit(f"  {url}")
+    emit("授权后页面会显示一段 `code#state`，整段复制后粘回这里：")
+    try:
+        raw = ask("粘贴 code：")
+    except (EOFError, KeyboardInterrupt) as exc:
+        raise OAuthAuthError("Claude OAuth 登录已取消。") from exc
+    code, got_state = _parse_anthropic_callback(str(raw))
+    if not code:
+        raise OAuthAuthError("没有解析到授权码，请重试（复制整段 code#state）。")
+    if got_state and got_state != state:
+        raise OAuthAuthError("state 不匹配（可能粘错或授权被篡改），请重试。")
+    try:
+        resp = httpx.post(
+            ANTHROPIC_OAUTH_TOKEN_URL,
+            json={
+                "grant_type": "authorization_code",
+                "code": code,
+                "state": state,
+                "redirect_uri": ANTHROPIC_OAUTH_REDIRECT_URI,
+                "client_id": ANTHROPIC_OAUTH_CLIENT_ID,
+                "code_verifier": verifier,
+            },
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            timeout=timeout,
+        )
+    except httpx.HTTPError as exc:
+        raise OAuthAuthError(f"Claude token 交换失败：{exc}") from exc
+    if resp.status_code >= 400:
+        raise OAuthAuthError(f"Claude token 交换返回 HTTP {resp.status_code}：{resp.text[:200]}")
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise OAuthAuthError(f"Claude token 交换返回非 JSON：{exc}") from exc
+    access = str((payload or {}).get("access_token") or "").strip()
+    if not access:
+        raise OAuthAuthError("Claude token 交换未返回 access_token。")
+    set_auth_token(
+        "anthropic-oauth", access,
+        refresh_token=str(payload.get("refresh_token") or "").strip(),
+        expires_at=_expires_at_from_payload(payload, _jwt_expires_at(access)),
+        source="oauth",
+    )
+
+
+def refresh_anthropic_token(timeout: float = 20.0) -> str:
+    item = get_auth("anthropic-oauth")
+    refresh_token = str(item.get("refresh_token") or "").strip()
+    if not refresh_token:
+        raise OAuthAuthError("Claude OAuth refresh_token 缺失，请重新 `ivyea model auth anthropic-oauth --login`。")
+    try:
+        resp = httpx.post(
+            ANTHROPIC_OAUTH_TOKEN_URL,
+            json={"grant_type": "refresh_token", "refresh_token": refresh_token,
+                  "client_id": ANTHROPIC_OAUTH_CLIENT_ID},
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            timeout=timeout,
+        )
+    except httpx.HTTPError as exc:
+        raise OAuthAuthError(f"Claude OAuth 刷新失败：{exc}") from exc
+    if resp.status_code >= 400:
+        raise OAuthAuthError(f"Claude OAuth 刷新返回 HTTP {resp.status_code}：{resp.text[:200]}")
+    payload = resp.json() if resp.text else {}
+    access = str((payload or {}).get("access_token") or "").strip()
+    if not access:
+        raise OAuthAuthError("Claude OAuth 刷新未返回 access_token。")
+    set_auth_token("anthropic-oauth", access,
+                   refresh_token=str(payload.get("refresh_token") or refresh_token).strip(),
+                   expires_at=_expires_at_from_payload(payload, _jwt_expires_at(access)),
+                   source=str(item.get("source") or "oauth"))
+    return access
+
+
+def probe_anthropic_oauth(timeout: float = 30.0, *, model: str = "claude-haiku-4-5") -> tuple[bool, str]:
+    """用当前 OAuth token 对 messages API 发一条最小请求，验证 token 真能用（含 Claude Code 身份头）。"""
+    token = resolve_provider_token("anthropic-oauth")
+    if not token:
+        return False, "本地没有 Claude OAuth token，请先 `--login`。"
+    try:
+        resp = httpx.post(
+            "https://api.anthropic.com/v1/messages",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "anthropic-version": "2023-06-01",
+                "anthropic-beta": ANTHROPIC_OAUTH_BETA,
+                "Content-Type": "application/json",
+            },
+            json={"model": model, "max_tokens": 1,
+                  "system": "You are Claude Code, Anthropic's official CLI for Claude.",
+                  "messages": [{"role": "user", "content": "ping"}]},
+            timeout=timeout,
+        )
+    except httpx.HTTPError as exc:
+        return False, f"请求失败：{exc}"
+    if resp.status_code < 400:
+        return True, "Claude OAuth token 可用。"
+    return False, f"HTTP {resp.status_code}：{resp.text[:300]}"
+
+
 def resolve_provider_token(provider_id: str, env_name: str = "", *, refresh: bool = True) -> str:
     from . import config
     config.load_env()
@@ -868,6 +1017,10 @@ def resolve_provider_token(provider_id: str, env_name: str = "", *, refresh: boo
         item = get_auth(provider_id)
         if refresh and item.get("access_token") and item.get("refresh_token") and _is_expiring(item.get("expires_at"), CODEX_REFRESH_SKEW_SECONDS):
             return refresh_codex_token()
+    if provider_id == "anthropic-oauth":
+        item = get_auth(provider_id)
+        if refresh and item.get("access_token") and item.get("refresh_token") and _is_expiring(item.get("expires_at"), ANTHROPIC_REFRESH_SKEW_SECONDS):
+            return refresh_anthropic_token()
     if provider_id == "google-gemini-cli":
         item = get_auth(provider_id)
         if refresh and item.get("access_token") and item.get("refresh_token") and _is_expiring(item.get("expires_at"), GOOGLE_REFRESH_SKEW_SECONDS):

--- a/ivyea_agent/providers/anthropic_provider.py
+++ b/ivyea_agent/providers/anthropic_provider.py
@@ -14,6 +14,8 @@ from typing import Any, Optional
 from .base import LLMError, LLMProvider
 
 _DEFAULT_MAX_TOKENS = 8192
+# Claude 订阅版 OAuth token 打 messages API 的已知硬要求：system 首块须是 Claude Code 身份，否则 401/403。
+_CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude."
 
 
 def _split_messages(messages: list[dict]) -> tuple[str, list[dict]]:
@@ -123,10 +125,18 @@ def _extract(message: Any) -> dict:
 class AnthropicProvider(LLMProvider):
     name = "anthropic"
 
-    def __init__(self, api_key: str, model: str, base_url: str = ""):
+    def __init__(self, api_key: str, model: str, base_url: str = "", oauth: bool = False):
         super().__init__(api_key, model or "claude-opus-4-8")
         self.base_url = (base_url or "").rstrip("/")
+        self.oauth = oauth          # True=订阅版 OAuth：走 Bearer + oauth beta 头 + Claude Code 身份
         self._client = None
+
+    def _system(self, system: str):
+        """system 块。OAuth 模式下首块必须是 Claude Code 身份（Max token 硬要求）。"""
+        base = _system_param(system) or []
+        if self.oauth:
+            return [{"type": "text", "text": _CLAUDE_CODE_IDENTITY}] + base
+        return base or None
 
     def _cli(self):
         if self._client is None:
@@ -135,8 +145,15 @@ class AnthropicProvider(LLMProvider):
             except ImportError as e:
                 raise LLMError("未安装 anthropic SDK：pip install 'ivyea-agent[anthropic]'") from e
             if not self.api_key:
-                raise LLMError("ANTHROPIC_API_KEY 未配置（ivyea model 选 Claude 并配 key）")
-            kw: dict[str, Any] = {"api_key": self.api_key}
+                raise LLMError("Claude OAuth 未登录，先 `ivyea model auth anthropic-oauth --login`"
+                               if self.oauth else "ANTHROPIC_API_KEY 未配置（ivyea model 选 Claude 并配 key）")
+            kw: dict[str, Any] = {}
+            if self.oauth:   # 订阅版：Bearer token + oauth beta 头（不传 api_key）
+                from ..oauth_auth import ANTHROPIC_OAUTH_BETA
+                kw["auth_token"] = self.api_key
+                kw["default_headers"] = {"anthropic-beta": ANTHROPIC_OAUTH_BETA}
+            else:
+                kw["api_key"] = self.api_key
             if self.base_url:
                 kw["base_url"] = self.base_url
             self._client = anthropic.Anthropic(**kw)
@@ -146,7 +163,7 @@ class AnthropicProvider(LLMProvider):
         try:
             msg = self._cli().with_options(timeout=timeout).messages.create(
                 model=self.model, max_tokens=_DEFAULT_MAX_TOKENS,
-                system=_system_param(system),   # cache the (often-repeated) system prefix
+                system=self._system(system),   # cache the (often-repeated) system prefix；OAuth 加 Claude Code 身份
                 messages=[{"role": "user", "content": user}])
         except Exception as e:  # noqa: BLE001
             raise LLMError(f"Claude 调用失败：{e}") from e
@@ -155,7 +172,7 @@ class AnthropicProvider(LLMProvider):
     def chat(self, messages, tools=None, temperature=0.3, timeout=120.0):
         system, msgs = _split_messages(messages)
         kw: dict[str, Any] = {"model": self.model, "max_tokens": _DEFAULT_MAX_TOKENS,
-                              "system": _system_param(system), "messages": msgs}
+                              "system": self._system(system), "messages": msgs}
         at = _tools_to_anthropic(tools)
         if at:
             kw["tools"] = at
@@ -168,7 +185,7 @@ class AnthropicProvider(LLMProvider):
     def stream_chat(self, messages, tools=None, temperature=0.3, timeout=120.0):
         system, msgs = _split_messages(messages)
         kw: dict[str, Any] = {"model": self.model, "max_tokens": _DEFAULT_MAX_TOKENS,
-                              "system": _system_param(system), "messages": msgs}
+                              "system": self._system(system), "messages": msgs}
         at = _tools_to_anthropic(tools)
         if at:
             kw["tools"] = at

--- a/ivyea_agent/providers/base.py
+++ b/ivyea_agent/providers/base.py
@@ -94,7 +94,9 @@ def _build_provider(model_cfg: dict, api_key: str) -> LLMProvider:
         # 只认 anthropic 自有网关；忽略切换残留的他家 base_url（默认走 api.anthropic.com）
         raw = (model_cfg.get("base_url") or model_cfg.get("base") or "")
         gw = raw if "anthropic" in raw.lower() else ""
-        return AnthropicProvider(api_key, model, gw)
+        # 订阅版 OAuth：api_mode=anthropic_oauth 或 auth_type=oauth_external → Bearer + oauth beta 头
+        oauth = api_mode == "anthropic_oauth" or (model_cfg.get("auth_type") or "").lower() == "oauth_external"
+        return AnthropicProvider(api_key, model, gw, oauth=oauth)
     if kind == "native":
         raise LLMError(f"{model_cfg.get('label', model)} 走厂商原生 API，适配规划中；"
                        "当前可用：Claude 原生 + Gemini 原生 + Bedrock Converse + OpenAI 兼容类（OpenAI/DeepSeek/通义/Kimi/GLM/豆包/MiniMax/OpenRouter/本地/自定义）。")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ivyea-agent"
-version = "1.3.0"
+version = "1.4.0"
 description = "Ivyea Agent — 自托管的亚马逊运营 CLI Agent（对话式 + 多模型 + 领星广告读写审批 + 通用工具 + 记忆）"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_anthropic_oauth.py
+++ b/tests/test_anthropic_oauth.py
@@ -1,0 +1,119 @@
+"""Claude(Anthropic) 订阅版 OAuth 登录：URL/解析、token 交换/刷新、resolve 分派、provider OAuth 模式。"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from ivyea_agent import oauth_auth as oa
+
+
+class _Resp:
+    def __init__(self, status=200, payload=None, text=""):
+        self.status_code = status
+        self._payload = payload if payload is not None else {}
+        self.text = text or ""
+    def json(self):
+        return self._payload
+
+
+# ── URL / 解析 ──
+def test_authorize_url_has_pkce_and_state():
+    url = oa.anthropic_oauth_url(code_challenge="CHAL", state="ST")
+    for frag in ("client_id=", "code_challenge=CHAL", "code_challenge_method=S256",
+                 "state=ST", "response_type=code", "redirect_uri="):
+        assert frag in url
+
+
+def test_parse_callback_forms():
+    assert oa._parse_anthropic_callback("abc#ST") == ("abc", "ST")
+    assert oa._parse_anthropic_callback("  bare  ") == ("bare", "")
+    code, state = oa._parse_anthropic_callback(
+        "https://console.anthropic.com/oauth/code/callback?code=xyz&state=QQ")
+    assert code == "xyz" and state == "QQ"
+
+
+# ── token 交换（登录）──
+def test_login_exchanges_and_stores(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(oa, "set_auth_token",
+                        lambda pid, tok, **kw: captured.update({"pid": pid, "tok": tok, **kw}))
+    posted = {}
+
+    def fake_post(url, **kw):
+        posted["url"] = url; posted["json"] = kw.get("json")
+        return _Resp(200, {"access_token": "acc-1", "refresh_token": "ref-1", "expires_in": 3600})
+    monkeypatch.setattr(oa.httpx, "post", fake_post)
+
+    oa.anthropic_oauth_login(notify=lambda s: None, prompt=lambda p: "thecode")
+    assert posted["url"] == oa.ANTHROPIC_OAUTH_TOKEN_URL
+    body = posted["json"]
+    assert body["grant_type"] == "authorization_code" and body["code"] == "thecode"
+    assert body["code_verifier"] and body["client_id"] == oa.ANTHROPIC_OAUTH_CLIENT_ID
+    assert captured["pid"] == "anthropic-oauth" and captured["tok"] == "acc-1"
+    assert captured["refresh_token"] == "ref-1"
+
+
+def test_login_state_mismatch_raises(monkeypatch):
+    monkeypatch.setattr(oa.httpx, "post", lambda *a, **k: _Resp(200, {"access_token": "x"}))
+    # 粘回的 state 与内部生成的随机 state 必不相等 → 报错
+    with pytest.raises(oa.OAuthAuthError):
+        oa.anthropic_oauth_login(notify=lambda s: None, prompt=lambda p: "code#WRONGSTATE")
+
+
+# ── 刷新 ──
+def test_refresh_uses_refresh_token(monkeypatch):
+    monkeypatch.setattr(oa, "get_auth", lambda pid: {"access_token": "old", "refresh_token": "ref-1", "source": "oauth"})
+    captured = {}
+    monkeypatch.setattr(oa, "set_auth_token", lambda pid, tok, **kw: captured.update({"tok": tok}))
+    monkeypatch.setattr(oa.httpx, "post", lambda url, **kw: _Resp(200, {"access_token": "acc-2"}, text="{}"))
+    assert oa.refresh_anthropic_token() == "acc-2" and captured["tok"] == "acc-2"
+
+
+def test_resolve_provider_token_refreshes_when_expiring(monkeypatch):
+    monkeypatch.setattr(oa, "get_auth", lambda pid: {"access_token": "old", "refresh_token": "r", "expires_at": 1})
+    monkeypatch.setattr(oa, "refresh_anthropic_token", lambda: "REFRESHED")
+    assert oa.resolve_provider_token("anthropic-oauth", "") == "REFRESHED"
+
+
+# ── provider OAuth 模式 ──
+def test_from_settings_builds_oauth_provider():
+    from ivyea_agent.providers import base
+    p = base.from_settings({"kind": "anthropic", "model": "claude-sonnet-4-6",
+                            "api_mode": "anthropic_oauth", "auth_type": "oauth_external"}, "bearer-tok")
+    assert p.oauth is True and p.name == "anthropic"
+
+
+def test_oauth_client_uses_bearer_and_beta(monkeypatch):
+    from ivyea_agent.providers.anthropic_provider import AnthropicProvider
+    captured = {}
+    fake = types.ModuleType("anthropic")
+    fake.Anthropic = lambda **kw: captured.update(kw) or object()
+    monkeypatch.setitem(sys.modules, "anthropic", fake)
+    p = AnthropicProvider("bearer-tok", "claude-sonnet-4-6", oauth=True)
+    p._cli()
+    assert captured.get("auth_token") == "bearer-tok" and "api_key" not in captured
+    assert captured["default_headers"]["anthropic-beta"] == oa.ANTHROPIC_OAUTH_BETA
+
+
+def test_oauth_system_prepends_claude_code_identity():
+    from ivyea_agent.providers.anthropic_provider import AnthropicProvider
+    p = AnthropicProvider("t", "claude-sonnet-4-6", oauth=True)
+    blocks = p._system("你是亚马逊运营 Agent")
+    assert blocks[0]["text"].startswith("You are Claude Code")
+    assert any("亚马逊" in b.get("text", "") for b in blocks)
+    # 非 oauth 不注入身份
+    p2 = AnthropicProvider("k", "claude-sonnet-4-6", oauth=False)
+    b2 = p2._system("x")
+    assert not any("Claude Code" in b.get("text", "") for b in (b2 or []))
+
+
+# ── 登记 ──
+def test_models_entry_registered():
+    from ivyea_agent import models
+    e = models.provider_by_id("anthropic-oauth")
+    assert e and e["kind"] == "anthropic" and e["api_mode"] == "anthropic_oauth"
+    assert e["auth_type"] == "oauth_external"
+    caps = models.provider_capabilities(e)
+    assert caps["tools"] and caps["streaming"] and caps["oauth"]


### PR DESCRIPTION
## 背景
ivyea-agent 已有 Codex/Google/Qwen OAuth，唯独没有 Claude。本 PR 对标 Codex OAuth，新增用 **Claude 订阅(Max/Pro)登录**跑主脑（不必贴 API key）。

## 改动
- **oauth_auth.py**：`anthropic_oauth_login`（授权码 + PKCE + 手动粘 `code#state`，网页终端也能用）、`refresh_anthropic_token`、`probe_anthropic_oauth`、`resolve_provider_token` 加分支。常量（client_id/端点/scope/beta）全 `IVYEA_ANTHROPIC_OAUTH_*` env 可覆盖。
- **anthropic_provider.py**：OAuth 模式走 `auth_token`(Bearer) + `anthropic-beta` 头，system 首块注入 Claude Code 身份（Max token 硬要求）。
- **base.from_settings / models.py / cli.py**：路由 + provider 条目 + `model auth anthropic-oauth --login/--refresh/--probe` + `/model` 选择器登录分支。

## 验证
- `pytest -q` → **595 passed**（+10）
- 沙箱内：`--login` 生成正确 PKCE 授权 URL、`--probe` 优雅降级、`model providers` 正确列出。

## ⚠️ 需使用者本机实测
活体 OAuth 需 Claude 订阅 + 浏览器：`ivyea model auth anthropic-oauth --login` → `--probe` 确认 token 可用。常量为生态逆向、非官方，Anthropic 可能变更/限制（`--probe` 报错 + env 覆盖即可修）；可能踩 ToS，使用者自担。

🤖 Generated with [Claude Code](https://claude.com/claude-code)