### PR TITLE
feat(anthropic): Claude extended thinking + 修 Windows CI [v1.4.1]

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/ivyea_agent/providers/anthropic_provider.py
+++ b/ivyea_agent/providers/anthropic_provider.py
@@ -16,14 +16,27 @@ from .base import LLMError, LLMProvider
 _DEFAULT_MAX_TOKENS = 8192
 # Claude 订阅版 OAuth token 打 messages API 的已知硬要求：system 首块须是 Claude Code 身份，否则 401/403。
 _CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude."
+_THINK_BUDGET = {"low": 4096, "medium": 8192, "high": 16384}   # 思考旋钮 → extended thinking token 预算
 
 
-def _split_messages(messages: list[dict]) -> tuple[str, list[dict]]:
+def _thinking_kw(effort: str, base_max_tokens: int) -> dict:
+    """思考旋钮 → Claude extended thinking 请求参数；off/auto 不开思考。
+    Anthropic 要求 max_tokens > budget_tokens，故按需抬高 max_tokens。"""
+    budget = _THINK_BUDGET.get(effort or "")
+    if not budget:
+        return {}
+    return {"thinking": {"type": "enabled", "budget_tokens": budget},
+            "max_tokens": budget + base_max_tokens}
+
+
+def _split_messages(messages: list[dict], thinking_cache: dict | None = None) -> tuple[str, list[dict]]:
     """OpenAI 格式 → (system 文本, Anthropic messages)。
 
     - system 角色 → 汇成顶层 system 串
     - assistant.tool_calls → content 里的 tool_use 块
     - role=tool → 合并成 user 消息里的 tool_result 块（连续的合并到一条）
+    - thinking_cache（按 tool_call id 缓存的 thinking 块）：开思考时，带工具的 assistant 轮须把
+      thinking 块排在 tool_use 之前回传，否则 Anthropic API 400。
     """
     system_parts: list[str] = []
     out: list[dict] = []
@@ -45,9 +58,14 @@ def _split_messages(messages: list[dict]) -> tuple[str, list[dict]]:
                                 "content": str(m.get("content", ""))})
         elif role == "assistant":
             blocks: list[dict] = []
+            tcs = m.get("tool_calls") or []
+            if thinking_cache and tcs:   # thinking 块必须排在最前（Anthropic 硬要求）
+                cached = thinking_cache.get(tcs[0].get("id", ""))
+                if cached:
+                    blocks.extend(cached)
             if m.get("content"):
                 blocks.append({"type": "text", "text": m["content"]})
-            for tc in (m.get("tool_calls") or []):
+            for tc in tcs:
                 fn = tc.get("function", {})
                 try:
                     args = json.loads(fn.get("arguments") or "{}")
@@ -110,16 +128,23 @@ def _norm_usage(usage: Any) -> dict:
 
 
 def _extract(message: Any) -> dict:
-    """Anthropic Message → 统一 {content, tool_calls, usage}。"""
-    text_parts, tool_calls = [], []
+    """Anthropic Message → 统一 {content, tool_calls, usage, _thinking}。
+    _thinking：原样保留的 thinking/redacted_thinking 块（带 signature），供工具循环里回传（否则 API 400）。"""
+    text_parts, tool_calls, thinking = [], [], []
     for block in (message.content or []):
         bt = getattr(block, "type", None)
         if bt == "text":
             text_parts.append(block.text)
         elif bt == "tool_use":
             tool_calls.append({"id": block.id, "name": block.name, "arguments": block.input or {}})
+        elif bt == "thinking":
+            thinking.append({"type": "thinking", "thinking": getattr(block, "thinking", ""),
+                             "signature": getattr(block, "signature", "")})
+        elif bt == "redacted_thinking":
+            thinking.append({"type": "redacted_thinking", "data": getattr(block, "data", "")})
     return {"role": "assistant", "content": "".join(text_parts),
-            "tool_calls": tool_calls, "usage": _norm_usage(getattr(message, "usage", None))}
+            "tool_calls": tool_calls, "usage": _norm_usage(getattr(message, "usage", None)),
+            "_thinking": thinking}
 
 
 class AnthropicProvider(LLMProvider):
@@ -130,6 +155,13 @@ class AnthropicProvider(LLMProvider):
         self.base_url = (base_url or "").rstrip("/")
         self.oauth = oauth          # True=订阅版 OAuth：走 Bearer + oauth beta 头 + Claude Code 身份
         self._client = None
+        self._thinking_cache: dict[str, list] = {}   # tool_call id → 该 assistant 轮的 thinking 块（工具循环回传用）
+
+    def _cache_thinking(self, ex: dict) -> None:
+        tcs = ex.get("tool_calls") or []
+        th = ex.get("_thinking") or []
+        if tcs and th:
+            self._thinking_cache[tcs[0]["id"]] = th
 
     def _system(self, system: str):
         """system 块。OAuth 模式下首块必须是 Claude Code 身份（Max token 硬要求）。"""
@@ -170,9 +202,10 @@ class AnthropicProvider(LLMProvider):
         return "".join(b.text for b in msg.content if getattr(b, "type", None) == "text")
 
     def chat(self, messages, tools=None, temperature=0.3, timeout=120.0):
-        system, msgs = _split_messages(messages)
+        system, msgs = _split_messages(messages, self._thinking_cache)
         kw: dict[str, Any] = {"model": self.model, "max_tokens": _DEFAULT_MAX_TOKENS,
                               "system": self._system(system), "messages": msgs}
+        kw.update(_thinking_kw(self.reasoning_effort, _DEFAULT_MAX_TOKENS))   # 思考深度旋钮
         at = _tools_to_anthropic(tools)
         if at:
             kw["tools"] = at
@@ -180,22 +213,33 @@ class AnthropicProvider(LLMProvider):
             msg = self._cli().with_options(timeout=timeout).messages.create(**kw)
         except Exception as e:  # noqa: BLE001
             raise LLMError(f"Claude 调用失败：{e}") from e
-        return _extract(msg)
+        ex = _extract(msg)
+        self._cache_thinking(ex)
+        return ex
 
     def stream_chat(self, messages, tools=None, temperature=0.3, timeout=120.0):
-        system, msgs = _split_messages(messages)
+        system, msgs = _split_messages(messages, self._thinking_cache)
         kw: dict[str, Any] = {"model": self.model, "max_tokens": _DEFAULT_MAX_TOKENS,
                               "system": self._system(system), "messages": msgs}
+        kw.update(_thinking_kw(self.reasoning_effort, _DEFAULT_MAX_TOKENS))   # 思考深度旋钮
         at = _tools_to_anthropic(tools)
         if at:
             kw["tools"] = at
         try:
             with self._cli().with_options(timeout=timeout).messages.stream(**kw) as stream:
-                for text in stream.text_stream:
-                    yield {"type": "text", "text": text}
+                for event in stream:   # 思考增量→reasoning 事件(显示 ✻ 思考)，正文增量→text
+                    et = getattr(event, "type", "")
+                    if et == "content_block_delta":
+                        delta = getattr(event, "delta", None)
+                        dt = getattr(delta, "type", "")
+                        if dt == "thinking_delta":
+                            yield {"type": "reasoning", "text": getattr(delta, "thinking", "") or ""}
+                        elif dt == "text_delta":
+                            yield {"type": "text", "text": getattr(delta, "text", "") or ""}
                 final = stream.get_final_message()
         except Exception as e:  # noqa: BLE001
             raise LLMError(f"Claude 流式失败：{e}") from e
         ex = _extract(final)
+        self._cache_thinking(ex)   # 缓存本轮 thinking 块，供下一步工具循环回传
         yield {"type": "final", "content": ex["content"],
                "tool_calls": ex["tool_calls"], "usage": ex["usage"]}

--- a/ivyea_agent/tools_general.py
+++ b/ivyea_agent/tools_general.py
@@ -243,9 +243,9 @@ def t_grep(args: dict, ctx) -> str:
         scanned += 1
         text = raw.decode("utf-8", errors="replace")
         try:
-            rel = path.relative_to(root)
+            rel = path.relative_to(root).as_posix()   # 统一正斜杠（与 t_glob 一致，跨平台稳定；修 Windows 反斜杠）
         except ValueError:
-            rel = path
+            rel = path.as_posix()
         for i, line in enumerate(text.splitlines(), 1):
             if rx.search(line):
                 hits.append(f"{rel}:{i}: {line.strip()[:200]}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ivyea-agent"
-version = "1.4.0"
+version = "1.4.1"
 description = "Ivyea Agent — 自托管的亚马逊运营 CLI Agent（对话式 + 多模型 + 领星广告读写审批 + 通用工具 + 记忆）"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_anthropic_thinking.py
+++ b/tests/test_anthropic_thinking.py
@@ -1,0 +1,152 @@
+"""Claude extended thinking：思考旋钮映射 + thinking 块跨工具轮保留（否则 API 400）。
+
+同时覆盖 API key 路径与 OAuth 路径（都走 AnthropicProvider）。
+"""
+from __future__ import annotations
+
+from ivyea_agent.providers import anthropic_provider as ap
+from ivyea_agent.providers.anthropic_provider import AnthropicProvider
+
+
+class _Blk:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class _Msg:
+    def __init__(self, content):
+        self.content = content
+        self.usage = None
+
+
+class _FakeMessages:
+    def __init__(self, outbox, capture):
+        self._outbox = outbox
+        self._capture = capture
+
+    def create(self, **kw):
+        self._capture.append(kw)
+        return self._outbox.pop(0)
+
+
+class _FakeClient:
+    def __init__(self, outbox, capture):
+        self._m = _FakeMessages(outbox, capture)
+
+    def with_options(self, **kw):
+        return self
+
+    @property
+    def messages(self):
+        return self._m
+
+
+def _provider(effort, outbox, capture, oauth=False):
+    p = AnthropicProvider("k", "claude-sonnet-4-6", oauth=oauth)
+    p.reasoning_effort = effort
+    p._client = _FakeClient(outbox, capture)   # 绕过真实 SDK
+    return p
+
+
+# ── 思考旋钮映射 ──
+def test_thinking_kw_mapping():
+    assert ap._thinking_kw("high", 8192) == {"thinking": {"type": "enabled", "budget_tokens": 16384}, "max_tokens": 24576}
+    assert ap._thinking_kw("auto", 8192) == {}
+    assert ap._thinking_kw("off", 8192) == {}
+
+
+def test_extract_captures_thinking():
+    msg = _Msg([_Blk(type="thinking", thinking="想", signature="S"),
+                _Blk(type="tool_use", id="t1", name="grep", input={})])
+    ex = ap._extract(msg)
+    assert ex["_thinking"] == [{"type": "thinking", "thinking": "想", "signature": "S"}]
+    assert ex["tool_calls"][0]["id"] == "t1"
+
+
+def test_split_reinjects_thinking_first():
+    cache = {"t1": [{"type": "thinking", "thinking": "想", "signature": "S"}]}
+    msgs = [{"role": "assistant", "content": "", "tool_calls": [{"id": "t1", "function": {"name": "grep", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "r"}]
+    _, out = ap._split_messages(msgs, cache)
+    assert [b["type"] for b in out[0]["content"]] == ["thinking", "tool_use"]
+    # 无 cache 不注入
+    _, out2 = ap._split_messages(msgs, None)
+    assert [b["type"] for b in out2[0]["content"]] == ["tool_use"]
+
+
+# ── 集成：缓存并在下一轮请求里回放 thinking 块 ──
+def test_thinking_cached_and_replayed_across_tool_loop():
+    capture: list = []
+    outbox = [
+        _Msg([_Blk(type="thinking", thinking="先想", signature="SIG1"),
+              _Blk(type="tool_use", id="t1", name="grep", input={"q": "x"})]),
+        _Msg([_Blk(type="text", text="最终答案")]),
+    ]
+    p = _provider("high", outbox, capture)
+
+    # 第 1 轮：模型返回 thinking + tool_use
+    ex1 = p.chat([{"role": "user", "content": "查一下"}])
+    assert ex1["tool_calls"][0]["id"] == "t1"
+    assert capture[0].get("thinking") == {"type": "enabled", "budget_tokens": 16384}   # 请求带思考
+    assert capture[0]["max_tokens"] > 16384
+
+    # 第 2 轮：把 assistant(tool_calls) + tool_result 回灌（模拟 agent_loop）
+    history = [
+        {"role": "user", "content": "查一下"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t1", "function": {"name": "grep", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "结果"},
+    ]
+    p.chat(history)
+    sent = capture[1]["messages"]           # 第 2 次请求发出的 messages
+    asst = next(m for m in sent if m["role"] == "assistant")
+    types = [b["type"] for b in asst["content"]]
+    assert types[0] == "thinking" and "tool_use" in types      # thinking 块被回放且在最前
+    assert asst["content"][0]["signature"] == "SIG1"            # 原样带 signature
+
+
+def test_no_thinking_param_when_auto():
+    capture: list = []
+    p = _provider("auto", [_Msg([_Blk(type="text", text="hi")])], capture)
+    p.chat([{"role": "user", "content": "hi"}])
+    assert "thinking" not in capture[0]
+
+
+def test_oauth_path_also_gets_thinking():
+    """OAuth 路径同走 AnthropicProvider —— 思考同样生效，且 system 仍带 Claude Code 身份。"""
+    capture: list = []
+    p = _provider("high", [_Msg([_Blk(type="text", text="ok")])], capture, oauth=True)
+    p.chat([{"role": "user", "content": "hi"}])
+    assert capture[0].get("thinking", {}).get("budget_tokens") == 16384
+    assert capture[0]["system"][0]["text"].startswith("You are Claude Code")
+
+
+def test_stream_yields_reasoning_events():
+    """流式：thinking_delta → reasoning 事件，text_delta → text 事件。"""
+    class _Ev:
+        def __init__(self, type, delta=None):
+            self.type = type; self.delta = delta
+
+    class _Stream:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def __iter__(self):
+            yield _Ev("content_block_delta", _Blk(type="thinking_delta", thinking="想想"))
+            yield _Ev("content_block_delta", _Blk(type="text_delta", text="答"))
+        def get_final_message(self):
+            return _Msg([_Blk(type="text", text="答")])
+
+    class _M:
+        def stream(self, **kw): return _Stream()
+
+    class _C:
+        def with_options(self, **kw): return self
+        @property
+        def messages(self): return _M()
+
+    p = AnthropicProvider("k", "claude-sonnet-4-6")
+    p.reasoning_effort = "high"
+    p._client = _C()
+    evs = list(p.stream_chat([{"role": "user", "content": "hi"}]))
+    kinds = [e["type"] for e in evs]
+    assert "reasoning" in kinds and "text" in kinds and kinds[-1] == "final"
+    assert next(e["text"] for e in evs if e["type"] == "reasoning") == "想想"


### PR DESCRIPTION
## 改动
1. **Claude extended thinking**（补上 reasoning_effort 对 Claude 的支持，API key + 订阅 OAuth 两路径同覆盖）：`_thinking_kw` 按旋钮映射预算并抬高 max_tokens；`_extract` 捕获 thinking/redacted_thinking 块（带 signature），provider 按 tool_call id 缓存、`_split_messages` 在带工具的 assistant 轮把 thinking 块排在 tool_use 之前回传（否则 Anthropic API 400）；stream_chat 遍历原始事件（thinking_delta→reasoning）。
2. **修 Windows CI**：`t_grep` 输出路径统一正斜杠（`as_posix`，与 `t_glob` 一致），修 `test_grep_brace_glob_matches` 在 windows-latest 全版本失败（此前 v1.3.0 起 Windows CI 一直红，mac/ubuntu 绿）。

## 验证
- `pytest -q` → **602 passed**（+7 thinking 测试，含"跨工具轮回放 thinking 块"集成 + OAuth 路径 + 流式 reasoning）
- Windows 失败根因是路径分隔符断言，本次已从产品侧统一为正斜杠

## 注意
extended thinking 的活体 Anthropic API 校验需真实 key/订阅，沙箱只单测了消息构造；用户已知悉、选择直接发版（`/think auto` 可关闭 Claude 思考作为逃生开关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)