### PR TITLE
docs(tests): 跨平台路径断言约定

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,13 @@
-"""测试隔离：把 IVYEA_HOME 指向临时目录，绝不触碰真实 ~/.ivyea。"""
+"""测试隔离：把 IVYEA_HOME 指向临时目录，绝不触碰真实 ~/.ivyea。
+
+写测试的约定（踩过的坑，勿再犯）：
+- **跨平台路径**：断言路径时别硬编码正斜杠 `"a/b/c"`——Windows 上工具输出可能是反斜杠。
+  工具的路径输出统一走 `Path.as_posix()`（正斜杠），断言也用同款或 `os.sep`-无关写法；
+  CI 跑 ubuntu/macos/**windows** 三平台，本地只在一个平台过 ≠ 全绿。
+  （历史：`t_grep` 曾用原生分隔符输出，Windows CI 上 `sub\\c.ts` 让断言 `sub/c.ts` 失败。）
+- **隔离**：碰 ~/.ivyea 的用例用下面的 `ivyea_home` fixture；碰 git 的用例在临时目录里 init，
+  绝不在真实仓库跑 git 写操作。
+"""
 from __future__ import annotations
 
 import importlib


### PR DESCRIPTION
复盘 Windows CI 路径分隔符踩坑，把'测试勿硬编码 / 分隔符、断言用 as_posix' 写进 tests/conftest.py 约定。纯文档，无代码/版本变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)