### PR TITLE
feat(chat): 会话导入接口 + de-flake CI

### DIFF
--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -121,6 +121,7 @@ def manifest() -> dict[str, Any]:
             {"method": "POST", "path": "/v1/system/service/autostart", "description": "write local autostart template"},
             {"method": "GET", "path": "/v1/chat/sessions", "description": "list persisted embedded chat sessions"},
             {"method": "POST", "path": "/v1/chat/sessions", "description": "create an embedded chat session"},
+            {"method": "POST", "path": "/v1/chat/sessions/import", "description": "seed a chat session with pre-existing messages (migration, no LLM turn)"},
             {"method": "GET", "path": "/v1/chat/sessions/{id}", "description": "load embedded chat session"},
             {"method": "POST", "path": "/v1/chat", "description": "run one read-only embedded agent turn"},
             {"method": "POST", "path": "/v1/chat/stream", "description": "run one read-only embedded agent turn as server-sent events"},
@@ -1178,6 +1179,34 @@ def chat_session_create(payload: dict[str, Any]) -> dict[str, Any]:
     return {"ok": True, "session": _public_session_detail(data)}
 
 
+def chat_session_import(payload: dict[str, Any]) -> dict[str, Any]:
+    """Seed a persisted session with pre-existing messages (no LLM turn).
+
+    Used to migrate an external transcript store into the embedded session
+    library so both callers share one history. Only plain text turns are kept."""
+    raw = payload.get("messages")
+    messages: list[dict[str, Any]] = []
+    if isinstance(raw, list):
+        for m in raw:
+            if not isinstance(m, dict):
+                continue
+            role = str(m.get("role") or "")
+            content = m.get("content")
+            if role in {"system", "user", "assistant"} and isinstance(content, str) and content.strip():
+                messages.append({"role": role, "content": content})
+    if not messages:
+        return {"ok": False, "error": "no messages"}
+    session_id = str(payload.get("id") or "") or sessions.new_id()
+    created = payload.get("created")
+    sessions.save(
+        session_id,
+        messages,
+        model=str(payload.get("model") or config.get_model_config().get("model", "")),
+        created=float(created) if isinstance(created, (int, float)) else None,
+    )
+    return {"ok": True, "id": session_id, "turns": sum(1 for m in messages if m["role"] == "user")}
+
+
 def make_server(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, api_token: str = "") -> ThreadingHTTPServer:
     server = ThreadingHTTPServer((host, int(port)), _Handler)
     server.api_token = api_token or ""  # type: ignore[attr-defined]
@@ -1414,6 +1443,9 @@ class _Handler(BaseHTTPRequestHandler):
                 self._json(200, chat_run(body))
             except ValueError as exc:
                 self._json(400, {"ok": False, "error": str(exc)})
+            return
+        if parsed.path == "/v1/chat/sessions/import":
+            self._json(200, chat_session_import(body))
             return
         if parsed.path == "/v1/chat/sessions":
             self._json(200, chat_session_create(body))

--- a/tests/test_parallel_dispatch.py
+++ b/tests/test_parallel_dispatch.py
@@ -12,7 +12,7 @@ def _silent(_s):
 
 
 def test_parallel_readonly_preserves_order_and_runs_concurrently(monkeypatch):
-    sleep_s, n = 0.3, 4
+    sleep_s, n = 0.5, 4
 
     def fake(name, args, ctx):
         time.sleep(sleep_s)
@@ -30,9 +30,11 @@ def test_parallel_readonly_preserves_order_and_runs_concurrently(monkeypatch):
     assert [m["tool_call_id"] for m in messages] == [f"c{i}" for i in range(n)]
     assert [m["content"] for m in messages] == [f"got-{i}" for i in range(n)]
     assert status.tool_calls == n
-    # sequential would be n*sleep; concurrent must be well under (generous margin
-    # for thread-startup overhead on slow CI runners — proves real concurrency).
-    assert elapsed < sleep_s * n * 0.6, f"not concurrent: {elapsed:.2f}s"
+    # Sequential would take n*sleep_s; require finishing faster than (n-1) sleeps
+    # to prove real overlap. This keeps a large absolute margin for thread-startup
+    # / GIL overhead on slow, contended CI runners — a tighter 0.6*n*sleep bound
+    # with sleep_s=0.3 was flaky on windows-latest · py3.11 (0.86s vs 0.72s).
+    assert elapsed < sleep_s * (n - 1), f"not concurrent: {elapsed:.2f}s"
 
 
 def test_mixed_batch_runs_sequentially(monkeypatch):


### PR DESCRIPTION
## 内容
- **新增 `POST /v1/chat/sessions/import`**：用已有消息（system/user/assistant 文本轮次）直接落盘一个会话（复用 `sessions.save`，可指定 id / 保留 created 时间戳），无需跑 LLM。用于把 IvyeaOps 的 brain_chat 旧历史一次性迁入 agent 原生会话库，让浮标与知识库工作台对话**共用一份历史**。
- **de-flake CI**：`test_parallel_dispatch` 的并发断言在 windows-latest · py3.11 偶发失败（0.86s vs 0.72s 边界），改为 `elapsed < sleep_s*(n-1)` 并把 sleep 提到 0.5s，给慢 runner 留足线程启动/GIL 开销余量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)