### PR TITLE
fix: 单一版本源，根治 __version__ 漂移导致的"永远有更新"

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.8.3"
+__version__ = "1.8.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ivyea-agent"
-version = "1.8.5"
+# Single-sourced from ivyea_agent.__version__ (see [tool.setuptools.dynamic]) so
+# a version bump only ever touches ivyea_agent/__init__.py and can't drift.
+dynamic = ["version"]
 description = "Ivyea Agent — 自托管的亚马逊运营 CLI Agent（对话式 + 多模型 + 领星广告读写审批 + 通用工具 + 记忆）"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -54,6 +56,9 @@ ignore = ["E501", "E722", "E741", "E702"]
 
 [project.scripts]
 ivyea = "ivyea_agent.cli:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "ivyea_agent.__version__" }
 
 [tool.setuptools.packages.find]
 include = ["ivyea_agent*"]


### PR DESCRIPTION
## 背景
1.8.4/1.8.5 发版只改了 `pyproject.toml` 的 version，漏改 `ivyea_agent/__init__.py` 的 `__version__`（停在 1.8.3）。serve `/health`（service.py）和 `ivyea --version`（cli.py）都读 `__version__` → 任何部署自报 1.8.3。IvyeaOps 的 `agent_update_available` 拿它和 GitHub 最新 release 比 → 永远为真 → **系统配置卡片永远显示"有更新"**，即使用户就是最新版。

## 改法
- `__init__.py.__version__` 作为唯一版本源，bump 到 **1.8.6**
- `pyproject.toml` 改 `dynamic = ["version"]` + `[tool.setuptools.dynamic] version = {attr = "ivyea_agent.__version__"}`
- 以后 bump 只改一处，永不再漂

## 验证
import / `ivyea --version` 均报 1.8.6；隔离 PEP517 构建产出 `ivyea_agent-1.8.6-py3-none-any.whl`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)