### PR TITLE
fix(scripts): release 脚本改读 __init__.__version__，修复发版崩溃

### DIFF
--- a/scripts/build_offline_bundle.py
+++ b/scripts/build_offline_bundle.py
@@ -22,13 +22,13 @@ def run(cmd: list[str]) -> None:
 
 
 def project_version() -> str:
-    try:
-        import tomllib  # Python 3.11+
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
-
-    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    return str(data["project"]["version"])
+    # Single source of truth: ivyea_agent/__init__.py.__version__ (pyproject.toml
+    # declares version dynamically from this same attr, so it's no longer static).
+    for line in (ROOT / "ivyea_agent" / "__init__.py").read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if s.startswith("__version__"):
+            return s.split("=", 1)[1].strip().strip('"').strip("'")
+    raise SystemExit("could not read __version__ from ivyea_agent/__init__.py")
 
 
 def copy_tree(src: Path, dst: Path) -> None:

--- a/scripts/build_standalone.py
+++ b/scripts/build_standalone.py
@@ -14,12 +14,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def project_version() -> str:
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
-    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    return str(data["project"]["version"])
+    # Single source of truth: ivyea_agent/__init__.py.__version__ (pyproject.toml
+    # declares version dynamically from this same attr, so it's no longer static).
+    for line in (ROOT / "ivyea_agent" / "__init__.py").read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if s.startswith("__version__"):
+            return s.split("=", 1)[1].strip().strip('"').strip("'")
+    raise SystemExit("could not read __version__ from ivyea_agent/__init__.py")
 
 
 def exe_name(version: str) -> str:

--- a/scripts/sync_portal_docs.py
+++ b/scripts/sync_portal_docs.py
@@ -12,12 +12,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def project_version() -> str:
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
-    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    return str(data["project"]["version"])
+    # Single source of truth: ivyea_agent/__init__.py.__version__ (pyproject.toml
+    # declares version dynamically from this same attr, so it's no longer static).
+    for line in (ROOT / "ivyea_agent" / "__init__.py").read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if s.startswith("__version__"):
+            return s.split("=", 1)[1].strip().strip('"').strip("'")
+    raise SystemExit("could not read __version__ from ivyea_agent/__init__.py")
 
 
 def replace_versions(text: str, version: str) -> str:


### PR DESCRIPTION
继 #59：version 改 dynamic 后，build_offline_bundle/build_standalone/sync_portal_docs 仍读 pyproject[project][version] → KeyError 使 v1.8.6 release 工作流失败。改为读单一版本源 __init__.__version__。三脚本本地均已验证输出 1.8.6。

🤖 Generated with [Claude Code](https://claude.com/claude-code)