### PR TITLE
fix(serve): 流式心跳 + 断开不打断轮次 + 引证回答恢复流式输出

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.8.6"
+__version__ = "1.8.7"

--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -447,7 +447,8 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
                     cancel_check: Callable[[], bool] | None = None,
                     render_reasoning: Callable[[str], None] = None,
                     emit: Callable[[dict], None] | None = None,
-                    tools: list | None = None) -> dict:
+                    tools: list | None = None,
+                    defer_citation_text: bool = True) -> dict:
     """流式跑一轮：token 边出边渲染、工具实时叙述、累计用量。
     返回 {text, usage}（usage 为本轮各步累加）。render(token) 逐字输出助手文本。
 
@@ -456,7 +457,10 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
     返回 True 则抛 KeyboardInterrupt，交给上层保留会话并恢复输入。
     emit(event)：结构化事件回调（stream-json），每个模型步发一条 assistant 事件、
     每个工具结果发一条 tool_result 事件；默认 None 零开销。
-    tools：受限工具子集（与 run_turn 对齐）；默认全量 TOOL_SCHEMAS。"""
+    tools：受限工具子集（与 run_turn 对齐）；默认全量 TOOL_SCHEMAS。
+    defer_citation_text：带 [K#] 知识引证时是否把正文压到引证门通过后一次性输出。
+    终端（CLI）保持 True——中间草稿打出去收不回来；Web/serve 传 False 边生成边流式，
+    前端以 final 事件的 text 为准整体替换，引证重写不会留下脏文本。"""
     task_scope.prepare_messages(ctx, messages)
     tool_schemas = tools or TOOL_SCHEMAS
     render = render or (lambda s: print(s, end="", flush=True))
@@ -488,7 +492,7 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
                 and not getattr(ctx, "progress_final", {})
                 and not getattr(ctx, "plan_mode", False)
             )
-            or bool(getattr(ctx, "knowledge_citations", []))
+            or (defer_citation_text and bool(getattr(ctx, "knowledge_citations", [])))
         )
         for ev in provider.stream_chat(messages, tools=tool_schemas):
             if cancel_check():

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -7,6 +7,7 @@ import hashlib
 import os
 import base64
 import binascii
+import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
@@ -1436,7 +1437,43 @@ class _Handler(BaseHTTPRequestHandler):
         body = self._read_json()
         if parsed.path == "/v1/chat/stream":
             self._sse_begin()
-            chat_stream(body, self._sse_send)
+            # 心跳：单个慢工具（如市场调研 MCP）可能几分钟不产出任何 SSE 事件，
+            # 中间代理/客户端的"单次 read 静默超时"会掐断仍在健康执行的轮次。
+            # 每 15s 写一行 SSE 注释（": ping"）保持链路有字节流动；注释行没有
+            # data 字段，所有标准 SSE 解析器都会忽略。写锁保证与事件写入互斥。
+            write_lock = threading.Lock()
+            done = threading.Event()
+            client_gone = threading.Event()
+
+            def _locked_send(event: str, data: dict[str, Any]) -> None:
+                # 客户端断开不打断轮次：写失败后降级为"无声跑完"，让 chat_stream
+                # 正常收尾并把完整会话落盘——用户随后能在历史会话里拿到回答。
+                if client_gone.is_set():
+                    return
+                try:
+                    with write_lock:
+                        self._sse_send(event, data)
+                except Exception:
+                    client_gone.set()
+
+            def _heartbeat() -> None:
+                while not done.wait(15.0):
+                    if client_gone.is_set():
+                        return
+                    try:
+                        with write_lock:
+                            self.wfile.write(b": ping\n\n")
+                            self.wfile.flush()
+                    except Exception:
+                        client_gone.set()
+                        return  # 客户端已断开：心跳退出，轮次本身继续跑
+
+            beat = threading.Thread(target=_heartbeat, daemon=True, name="chat-stream-heartbeat")
+            beat.start()
+            try:
+                chat_stream(body, _locked_send)
+            finally:
+                done.set()
             return
         if parsed.path == "/v1/chat":
             try:

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1130,6 +1130,9 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None)
             narrate=narrate,
             render=lambda text: send("token", {"text": security.redact_text(str(text))}),
             model=model_cfg.get("model", ""),
+            # Web 前端以 final.text 为准整体替换气泡：带知识引证也照常流式，
+            # 否则命中检索的问题（运营问题几乎全命中）从头到尾一个字不吐。
+            defer_citation_text=False,
         )
     except LLMError as exc:
         data = {"ok": False, "error": "model_error", "detail": str(exc)}


### PR DESCRIPTION
## 三个 serve 端可靠性修复（配合 IvyeaOps v1.1.112）

1. **/v1/chat/stream 15s 心跳**：长轮次里单个慢工具（市场调研 MCP 等）几分钟零字节，中间代理"单次 read 静默超时"会掐断健康的流。每 15s 写 SSE 注释保活，写锁与事件写入互斥。
2. **客户端断开不打断轮次**：写失败降级"无声跑完"，轮次照常收尾并持久化——用户在历史会话里总能拿到回答。
3. **带知识引证的回答恢复流式**（`defer_citation_text` 参数）：命中检索的问题此前全部正文压到引证门通过后一次性输出，Web 端全程零 token 像卡死。CLI 默认不变；serve 传 False 边生成边流式，前端以 final 规范文本整体替换。

## 验证
17 个 streaming/citations 测试全过；生产实测 17 分钟长轮完整落盘 + 知识问题逐字流式 E2E 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)