### PR TITLE
feat(serve): 支持 use_tools=false 的纯文本轮次

### DIFF
--- a/docs/使用与操作文档.md
+++ b/docs/使用与操作文档.md
@@ -322,6 +322,9 @@ ivyea retrieval index
 ivyea retrieval sync
 ivyea retrieval search "主图 转化" --json
 curl -s http://127.0.0.1:8765/v1/chat -H 'Content-Type: application/json' -d '{"message":"否词前需要检查哪些风险？"}'
+# 纯文本生成（把 agent 当写作/抽取引擎用）：use_tools=false 不挂任何工具，
+# 模型不会耗步数去查工具，正文里也不会夹带工具叙述。默认 true。
+curl -s http://127.0.0.1:8765/v1/chat -H 'Content-Type: application/json' -d '{"message":"根据下面数据写报告…","use_tools":false}'
 curl -s http://127.0.0.1:8765/v1/chat/sessions
 curl -s http://127.0.0.1:8765/v1/mcp/self-config
 curl -s http://127.0.0.1:8765/v1/system/bootstrap

--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.8.7"
+__version__ = "1.8.8"

--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -412,9 +412,10 @@ def run_turn(provider: LLMProvider, ctx: ToolContext, messages: list,
              max_steps: int | None = None, narrate: Callable[[str], None] = print,
              tools: list | None = None) -> str:
     """跑一轮对话（messages 含 system+历史+本次 user）。就地追加消息，返回最终回答。
-    tools 可传受限工具子集（如只读子 agent）；默认用全量 TOOL_SCHEMAS。"""
+    tools 可传受限工具子集（如只读子 agent）；传 [] = 不挂工具（纯文本生成）；
+    None = 全量 TOOL_SCHEMAS。"""
     task_scope.prepare_messages(ctx, messages)
-    tool_schemas = tools or TOOL_SCHEMAS
+    tool_schemas = TOOL_SCHEMAS if tools is None else tools
     max_steps = _resolve_max_steps(max_steps, "chat_max_tool_steps")
     status = TurnStatus(max_steps=max_steps, behavioral_task=bool(getattr(ctx, "behavioral_task", False)))
     for step_idx in range(max_steps):
@@ -457,12 +458,12 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
     返回 True 则抛 KeyboardInterrupt，交给上层保留会话并恢复输入。
     emit(event)：结构化事件回调（stream-json），每个模型步发一条 assistant 事件、
     每个工具结果发一条 tool_result 事件；默认 None 零开销。
-    tools：受限工具子集（与 run_turn 对齐）；默认全量 TOOL_SCHEMAS。
+    tools：受限工具子集（与 run_turn 对齐）；[] = 不挂工具，None = 全量 TOOL_SCHEMAS。
     defer_citation_text：带 [K#] 知识引证时是否把正文压到引证门通过后一次性输出。
     终端（CLI）保持 True——中间草稿打出去收不回来；Web/serve 传 False 边生成边流式，
     前端以 final 事件的 text 为准整体替换，引证重写不会留下脏文本。"""
     task_scope.prepare_messages(ctx, messages)
-    tool_schemas = tools or TOOL_SCHEMAS
+    tool_schemas = TOOL_SCHEMAS if tools is None else tools
     render = render or (lambda s: print(s, end="", flush=True))
     render_reasoning = render_reasoning or (lambda s: None)
     cancel_check = cancel_check or (lambda: False)

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1044,7 +1044,8 @@ def chat_run(payload: dict[str, Any], provider: Any | None = None) -> dict[str, 
 
     try:
         provider = provider or build_chain(model_cfg, api_key, narrate=narrate)
-        text = agent_loop.run_turn(provider, ctx, messages, max_steps=(_int(payload.get("max_steps"), 0) or None), narrate=narrate)
+        text = agent_loop.run_turn(provider, ctx, messages, max_steps=(_int(payload.get("max_steps"), 0) or None),
+                                   narrate=narrate, tools=_tools_for(payload))
     except LLMError as exc:
         return {"ok": False, "error": "model_error", "detail": str(exc), "events": events}
 
@@ -1128,6 +1129,7 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None)
             messages,
             max_steps=(_int(payload.get("max_steps"), 0) or None),
             narrate=narrate,
+            tools=_tools_for(payload),
             render=lambda text: send("token", {"text": security.redact_text(str(text))}),
             model=model_cfg.get("model", ""),
             # Web 前端以 final.text 为准整体替换气泡：带知识引证也照常流式，
@@ -1803,6 +1805,15 @@ def _int(value: Any, default: int) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _tools_for(payload: dict[str, Any]) -> list | None:
+    """工具集：use_tools=false → 不挂任何工具（纯文本生成，模型不会绕去查工具，
+    也不会在正文里夹带工具叙述）；默认 None = 全量 TOOL_SCHEMAS。
+    IvyeaOps 把 agent 当文本引擎用（报告合成/JSON 抽取）时传 false。"""
+    if payload.get("use_tools") is False:
+        return []
+    return None
 
 
 def _model_requires_key(settings: dict[str, Any]) -> bool:

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1134,7 +1134,9 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None)
             model=model_cfg.get("model", ""),
             # Web 前端以 final.text 为准整体替换气泡：带知识引证也照常流式，
             # 否则命中检索的问题（运营问题几乎全命中）从头到尾一个字不吐。
-            defer_citation_text=False,
+            # 只累加 token、不认 final 的调用方（IvyeaOps 的报告合成）传 true：
+            # 引证门会让模型带着 [K#] 把整篇重写一遍，不 defer 就会收到两份报告。
+            defer_citation_text=payload.get("defer_citation_text") is True,
         )
     except LLMError as exc:
         data = {"ok": False, "error": "model_error", "detail": str(exc)}

--- a/tests/test_parallel_dispatch.py
+++ b/tests/test_parallel_dispatch.py
@@ -1,6 +1,7 @@
 """Parallel dispatch of read-only tool calls (order preserved, concurrency real)."""
 from __future__ import annotations
 
+import threading
 import time
 
 from ivyea_agent import agent_loop
@@ -12,10 +13,17 @@ def _silent(_s):
 
 
 def test_parallel_readonly_preserves_order_and_runs_concurrently(monkeypatch):
-    sleep_s, n = 0.5, 4
+    n = 4
+    lock = threading.Lock()
+    live = {"now": 0, "peak": 0}
 
     def fake(name, args, ctx):
-        time.sleep(sleep_s)
+        with lock:
+            live["now"] += 1
+            live["peak"] = max(live["peak"], live["now"])
+        time.sleep(0.3)
+        with lock:
+            live["now"] -= 1
         return ToolResult(True, f"got-{args['k']}")
 
     monkeypatch.setattr(agent_loop, "dispatch_result", fake)
@@ -23,18 +31,16 @@ def test_parallel_readonly_preserves_order_and_runs_concurrently(monkeypatch):
     status = agent_loop.TurnStatus(max_steps=10)
     calls = [{"id": f"c{i}", "name": "read_file", "arguments": {"k": i}} for i in range(n)]
 
-    t0 = time.time()
     agent_loop._dispatch_tool_calls(ctx, messages, status, calls, 0, 10, _silent)
-    elapsed = time.time() - t0
 
     assert [m["tool_call_id"] for m in messages] == [f"c{i}" for i in range(n)]
     assert [m["content"] for m in messages] == [f"got-{i}" for i in range(n)]
     assert status.tool_calls == n
-    # Sequential would take n*sleep_s; require finishing faster than (n-1) sleeps
-    # to prove real overlap. This keeps a large absolute margin for thread-startup
-    # / GIL overhead on slow, contended CI runners — a tighter 0.6*n*sleep bound
-    # with sleep_s=0.3 was flaky on windows-latest · py3.11 (0.86s vs 0.72s).
-    assert elapsed < sleep_s * (n - 1), f"not concurrent: {elapsed:.2f}s"
+    # Overlap measured directly (peak simultaneous calls) instead of wall clock:
+    # a contended CI runner makes any elapsed-time bound flaky — the previous
+    # `elapsed < sleep*(n-1)` still failed on windows-latest (1.84s vs 1.5s)
+    # even though the calls did overlap.
+    assert live["peak"] > 1, f"not concurrent: peak={live['peak']}"
 
 
 def test_mixed_batch_runs_sequentially(monkeypatch):

--- a/tests/test_use_tools_off.py
+++ b/tests/test_use_tools_off.py
@@ -48,3 +48,34 @@ def test_service_payload_flag():
     assert service._tools_for({"use_tools": False}) == []
     assert service._tools_for({"use_tools": True}) is None
     assert service._tools_for({}) is None          # 默认不变：带全量工具
+
+
+def test_defer_citation_text_suppresses_the_superseded_draft():
+    """引证门会让模型带 [K#] 重写整篇；只累加 token 的调用方不 defer 会收到两份。"""
+    from ivyea_agent.agent_tools import ToolContext
+
+    class _TwoPass:
+        def __init__(self):
+            self.n = 0
+
+        def stream_chat(self, messages, tools=None, **kw):
+            self.n += 1
+            text = "初稿正文" if self.n == 1 else "终稿正文 [K1]"
+            yield {"type": "text", "text": text}
+            yield {"type": "final", "content": text, "tool_calls": [], "usage": {}}
+
+    def run(defer):
+        ctx = ToolContext()
+        ctx.knowledge_citations = [{"id": "K1", "title": "知识卡"}]
+        out, seen = [], _TwoPass()
+        res = agent_loop.run_turn_stream(seen, ctx, [{"role": "user", "content": "写报告"}],
+                                         tools=[], render=out.append,
+                                         defer_citation_text=defer)
+        return "".join(out), res["text"]
+
+    streamed_defer, final_defer = run(True)
+    assert "初稿正文" not in streamed_defer          # 被压住，不外泄
+    assert final_defer in streamed_defer            # 终稿只出一次
+
+    streamed_live, _ = run(False)
+    assert "初稿正文" in streamed_live               # 默认（Web 以 final 整体替换）行为不变

--- a/tests/test_use_tools_off.py
+++ b/tests/test_use_tools_off.py
@@ -1,0 +1,50 @@
+"""不挂工具的纯文本轮次（IvyeaOps 把 agent 当文本引擎用时走这条）。
+
+以前 `tools or TOOL_SCHEMAS` 把 [] 当假值退回全量工具，等于关不掉：模型会花步数
+去查工具（plan_mode 下 MCP 调用还会被拒），中间叙述被逐 token 流成"报告"。
+"""
+from __future__ import annotations
+
+from ivyea_agent import agent_loop, service
+from ivyea_agent.agent_tools import ToolContext
+
+
+class _Prov:
+    def __init__(self):
+        self.seen = []
+
+    def chat(self, messages, tools=None, **kw):
+        self.seen.append(tools)
+        return {"content": "报告正文", "tool_calls": []}
+
+    def stream_chat(self, messages, tools=None, **kw):
+        self.seen.append(tools)
+        yield {"type": "text", "text": "报告正文"}
+        yield {"type": "final", "content": "报告正文", "tool_calls": [], "usage": {}}
+
+
+def test_empty_tools_list_means_no_tools():
+    prov = _Prov()
+    out = agent_loop.run_turn(prov, ToolContext(), [{"role": "user", "content": "写报告"}], tools=[])
+    assert out == "报告正文"
+    assert prov.seen == [[]]                      # 空工具集透传给 provider，不回落全量
+
+
+def test_empty_tools_list_means_no_tools_streaming():
+    prov = _Prov()
+    out = agent_loop.run_turn_stream(prov, ToolContext(), [{"role": "user", "content": "写报告"}],
+                                     tools=[], render=lambda _t: None)
+    assert out["text"] == "报告正文"
+    assert prov.seen == [[]]
+
+
+def test_default_still_gets_the_full_tool_set():
+    prov = _Prov()
+    agent_loop.run_turn(prov, ToolContext(), [{"role": "user", "content": "hi"}])
+    assert prov.seen[0] is agent_loop.TOOL_SCHEMAS
+
+
+def test_service_payload_flag():
+    assert service._tools_for({"use_tools": False}) == []
+    assert service._tools_for({"use_tools": True}) is None
+    assert service._tools_for({}) is None          # 默认不变：带全量工具


### PR DESCRIPTION
## 为什么

IvyeaOps 把 agent 当文本引擎用（市场调研报告合成 / JSON 抽取）时，一直是**挂着全量工具**调进来的。结果模型不写报告，先去查工具：

> 让我先检查是否有 IvyeaOps 工具可以直接查询 Sorftime 市场数据…
> MCP 有 Sorftime 的 86 个工具可用！让我获取完整列表…

而 `plan_mode` 下 `t_mcp_call_tool` 本来就硬拒（`tools_general.py:495`），自救注定失败，步数耗尽，这些中间叙述被逐 token 流出去，在面板里就成了"报告"正文。

## 改了什么

- `agent_loop.run_turn` / `run_turn_stream`：`tools or TOOL_SCHEMAS` 会把 `[]` 当假值退回全量工具，等于工具**关不掉**；改成显式判 `None`。
- `service`：`/v1/chat` 与 `/v1/chat/stream` 支持 `use_tools`（默认 `true`，行为不变），为 `false` 时传 `tools=[]`。

## 实测（本机 serve）

| 请求 | 工具事件 | 结果 |
|---|---|---|
| `use_tools:false` | 无 | 模型没能力调工具，零工具执行 |
| 默认 | `mcp_list_tools(server='sorftime')` | 真调用，返回 86 个工具 |

`pytest tests -q` 705 passed（含新增 `tests/test_use_tools_off.py`）。

配套：IvyeaOps 侧合成改为传 `use_tools:false`（旧版 agent 忽略该字段，退化为当前行为，不会炸）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)