### PR TITLE
serve: 结构化步骤与远程审批 + 会话安全/并发修复 (v1.9.0)

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.8.8"
+__version__ = "1.9.0"

--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -259,7 +259,8 @@ def _observe_tool_discipline(ctx: ToolContext, tc: dict, res: ToolResult) -> Non
 
 def _record_tool_result(ctx: ToolContext, messages: list, tc: dict, res, duration_ms: int,
                         narrate: Callable[[str], None],
-                        emit: Callable[[dict], None] | None = None) -> None:
+                        emit: Callable[[dict], None] | None = None, seq: int = 0,
+                        blocked: bool = False) -> None:
     _observe_tool_discipline(ctx, tc, res)
     progress_reporting.observe_tool_result(ctx, tc.get("name") or "", res)
     result = res.text
@@ -277,13 +278,26 @@ def _record_tool_result(ctx: ToolContext, messages: list, tc: dict, res, duratio
         narrate(ui.tool_result(result, ok=res.ok))
     _emit_safe(emit, stream_json.tool_result_event(
         getattr(ctx, "session_id", ""), tc["id"], result, not res.ok))
+    # 步骤收尾事件：耗时在这里才拿得到（traces 记的也是这个数），一并进事件流，
+    # UI 画执行时间线就不用再去 join traces.db。
+    _emit_safe(emit, stream_json.step_event(
+        getattr(ctx, "session_id", ""), getattr(ctx, "turn_id", ""),
+        tc["id"], seq, tc["name"], tc.get("arguments") or {},
+        "blocked" if blocked else ("ok" if res.ok else "error"), duration_ms))
     messages.append({"role": "tool", "tool_call_id": tc["id"], "content": result})
 
 
 def _run_one(tc: dict, ctx: ToolContext):
+    """执行一个工具调用，返回 (结果, 耗时ms, 是否被前置护栏拦下)。
+
+    "被护栏拦下"和"工具真的失败了"对模型是一回事（都要改做法），对用户不是：
+    前者是流程纠偏（先列计划再动手），后者才是出错。分开标出来，UI 才不会把
+    一次正常的流程纠偏画成红叉。
+    """
     started = time.time()
-    res = _guard_tool_call(ctx, tc) or dispatch_result(tc["name"], tc["arguments"], ctx)
-    return res, int((time.time() - started) * 1000)
+    guarded = _guard_tool_call(ctx, tc)
+    res = guarded or dispatch_result(tc["name"], tc["arguments"], ctx)
+    return res, int((time.time() - started) * 1000), guarded is not None
 
 
 def _dispatch_tool_calls(ctx: ToolContext, messages: list, status: TurnStatus, tool_calls: list,
@@ -292,21 +306,35 @@ def _dispatch_tool_calls(ctx: ToolContext, messages: list, status: TurnStatus, t
     """派发本步所有工具调用：叙述、执行、记 trace、把结果按原顺序回灌到 messages。
     当本步全部是只读且并行安全的工具时并发执行（降延迟）；否则顺序执行（保留审批/写入语义）。"""
     parallel = len(tool_calls) > 1 and all(tc["name"] in PARALLEL_SAFE for tc in tool_calls)
+
+    def announce(tc: dict) -> int:
+        """叙述 + 发"开始"步骤事件，返回本步在整轮里的序号。
+
+        序号取 status.tool_calls（record_tool_call 刚自增过），全轮单调递增，
+        UI 靠它排时间线；配对靠 tc["id"]，与 tool_result 事件同一把钥匙。
+        """
+        status.record_tool_call()
+        seq = status.tool_calls
+        narrate(ui.tool_call(tc["name"], tc.get("arguments") or {}))
+        _emit_safe(emit, stream_json.step_event(
+            getattr(ctx, "session_id", ""), getattr(ctx, "turn_id", ""),
+            tc["id"], seq, tc["name"], tc.get("arguments") or {}, "running"))
+        return seq
+
     if parallel:
-        for tc in tool_calls:
-            status.record_tool_call()
-            narrate(ui.tool_call(tc["name"], tc.get("arguments") or {}))
+        # 并行分支：先把所有"开始"发出去（UI 同时亮起几枚芯片），再并发执行；
+        # 收尾按原调用顺序回灌，与结果顺序保持一致。
+        seqs = [announce(tc) for tc in tool_calls]
         with ThreadPoolExecutor(max_workers=min(len(tool_calls), 8)) as ex:
             outcomes = list(ex.map(lambda tc: _run_one(tc, ctx), tool_calls))
-        for tc, (res, dur) in zip(tool_calls, outcomes):
-            _record_tool_result(ctx, messages, tc, res, dur, narrate, emit=emit)
+        for tc, (res, dur, blocked), seq in zip(tool_calls, outcomes, seqs):
+            _record_tool_result(ctx, messages, tc, res, dur, narrate, emit=emit, seq=seq, blocked=blocked)
             status.observe_tool_result(tc["name"], res)
         return
     for tc in tool_calls:
-        status.record_tool_call()
-        narrate(ui.tool_call(tc["name"], tc.get("arguments") or {}))
-        res, dur = _run_one(tc, ctx)
-        _record_tool_result(ctx, messages, tc, res, dur, narrate, emit=emit)
+        seq = announce(tc)
+        res, dur, blocked = _run_one(tc, ctx)
+        _record_tool_result(ctx, messages, tc, res, dur, narrate, emit=emit, seq=seq, blocked=blocked)
         status.observe_tool_result(tc["name"], res)
 
 

--- a/ivyea_agent/agent_tools.py
+++ b/ivyea_agent/agent_tools.py
@@ -30,6 +30,7 @@ class ToolContext:
     lingxing_result: dict = field(default_factory=dict)   # 最近一次领星巡检候选
     plan_mode: bool = False                                # 计划模式：禁止写入执行
     workspace: str = ""                                    # 通用工具的工作目录（默认 cwd）
+    workspace_declared: str = ""                           # 调用方显式指定的工作区；范围锁定不得越过它往上放宽
     todos: list = field(default_factory=list)              # 当前任务计划（todo_write 维护）
     perm: permission.PermissionState = field(default_factory=permission.PermissionState)
     session_id: str = ""                                   # 用于运行时间线

--- a/ivyea_agent/agent_tools.py
+++ b/ivyea_agent/agent_tools.py
@@ -527,14 +527,51 @@ def _t_ivyea_ops_list_tools(args: dict, ctx: ToolContext) -> str:
     return _compact_json_text(data, limit=12000)
 
 
+def _ops_tool_catalog(ctx: ToolContext) -> dict[str, dict[str, Any]]:
+    """板块能力目录（name → 元数据），按 ctx 缓存一次。
+
+    目录里每条自带中文 title 和 destructive 标记，是审批卡文案和"要不要拦"的
+    判断依据。一轮里可能调好几个板块工具，没必要每次都去问一遍。
+    """
+    cached = getattr(ctx, "_ops_tool_catalog", None)
+    if cached is not None:
+        return cached
+    catalog: dict[str, dict[str, Any]] = {}
+    data = _ops_bridge_request(ctx, "/tools", {}, timeout=20.0)
+    for row in (data.get("tools") or []):
+        if isinstance(row, dict) and row.get("name"):
+            catalog[str(row["name"])] = row
+    try:
+        ctx._ops_tool_catalog = catalog          # noqa: SLF001 — 就近缓存，随 ctx 生灭
+    except Exception:  # noqa: BLE001
+        pass
+    return catalog
+
+
 def _t_ivyea_ops_call_tool(args: dict, ctx: ToolContext) -> str:
     name = str(args.get("name") or "").strip()
     if not name:
         return "错误：需要提供工具名 name。"
-    payload = {
-        "name": name,
-        "arguments": args.get("arguments") if isinstance(args.get("arguments"), dict) else {},
-    }
+    arguments = args.get("arguments") if isinstance(args.get("arguments"), dict) else {}
+
+    # 写类板块能力（建项目、启动审计、开领星可写开关…）在**有人可问**的时候必须
+    # 先过审批。只在接了审批通道（serve 的远程确认卡）时才拦：没有通道就说明
+    # 没人能确认，此时保持既有行为不变——嵌入式对话一直是这么跑的，这里不改。
+    if ctx.perm.prompt_fn is not None:
+        meta = _ops_tool_catalog(ctx).get(name) or {}
+        if meta.get("destructive"):
+            title = str(meta.get("title") or name)
+            preview_lines = [f"调用板块能力：{title}（{name}）"]
+            for key, val in list(arguments.items())[:8]:
+                preview_lines.append(f"- {key}: {str(val)[:120]}")
+            decision = permission.request_intent(
+                {"op_type": "ops_tool_call", "tool": name},
+                "\n".join(preview_lines), ctx.perm,
+            )
+            if decision != permission.APPROVE:
+                return f"已取消：用户未批准调用板块能力「{title}」。"
+
+    payload = {"name": name, "arguments": arguments}
     # 板块工具里有长任务（如生成市场调研/打法报告，要采集+AI合成），给宽限超时。
     data = _ops_bridge_request(ctx, "/call", payload, timeout=300.0)
     return _compact_json_text(data)

--- a/ivyea_agent/permission.py
+++ b/ivyea_agent/permission.py
@@ -13,6 +13,12 @@ from .actions import Action
 
 APPROVE, DENY, ABORT = "approve", "deny", "abort"
 
+# 审批提问通道。默认走 tui.select（终端菜单）；serve 注入一个把选项发到网页、
+# 阻塞等前端回决策的实现，于是同一套审批引擎既服务 CLI 也服务工作台。
+# 签名：(title, body, options, meta) -> 选中的 option key
+# meta 带上终端菜单用不着、但网页确认卡需要的东西（op_type/destructive/摘要）。
+PromptFn = Callable[[str, str, list, dict], str]
+
 
 @dataclass
 class PermissionState:
@@ -22,6 +28,21 @@ class PermissionState:
     accept_edits: bool = False                         # opt-in：本会话所有写操作自动放行（/auto-edit on）
     policy_auto: bool = False                          # --permission-mode policy：无人值守下按 policy.json
     #                                                    allow/deny 自动判定，不弹交互、永不 ABORT
+    prompt_fn: PromptFn | None = None                  # 非 None = 走远程审批（网页确认卡），不碰 stdin
+
+
+def _ask(state: "PermissionState", title: str, body: str, options: list,
+         input_fn: Callable[[str], str], meta: dict | None = None) -> str:
+    """问一次，拿一个决策。
+
+    有 prompt_fn（远程）时不碰终端：远端没法做"改一下"这种就地编辑（要多轮
+    交互输入），所以先把 edit 选项摘掉——宁可让用户取消后重新提要求，也不要
+    给一个点了会卡在服务端 stdin 上的按钮。
+    """
+    if state.prompt_fn is not None:
+        remote_options = [o for o in options if o[0] != "edit"]
+        return state.prompt_fn(title, body, remote_options, dict(meta or {}))
+    return tui.select(title, body, options, kind="warn", input_fn=input_fn)
 
 
 def _policy_decide(intent: dict) -> str:
@@ -75,7 +96,9 @@ def request(a: Action, state: PermissionState,
     options = [("approve", "批准本次"), ("session", "本会话同类都批准"),
                ("deny", "拒绝"), ("edit", "修改"), ("abort", "全部停止")]
     while True:
-        choice = tui.select("需要确认写操作", preview(a), options, kind="warn", input_fn=input_fn)
+        choice = _ask(state, "需要确认写操作", preview(a), options, input_fn,
+                      {"op_type": f"action:{a.kind}", "destructive": True,
+                       "summary": a.summary()})
         if choice == "approve":
             return APPROVE
         if choice == "session":
@@ -109,7 +132,8 @@ def request_intent(intent: dict, preview_text: str, state: PermissionState,
     if has_edit:
         options.append(("edit", "修改"))
     options.append(("abort", "全部停止"))
-    choice = tui.select("需要确认写操作", preview_text, options, kind="warn", input_fn=input_fn)
+    choice = _ask(state, "需要确认写操作", preview_text, options, input_fn,
+                  {"op_type": op_type, "destructive": True})
     if choice == "approve":
         return APPROVE
     if choice == "session":

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -17,7 +17,7 @@ from urllib.parse import parse_qs, urlparse
 
 from . import (
     __version__, ads_evidence, agent_loop, code_agent, config, knowledge, knowledge_evidence,
-    knowledge_governance, knowledge_quality, knowledge_sync, models, permission,
+    knowledge_governance, knowledge_quality, knowledge_sync, models,
     progress_reporting, retrieval, security, self_manage, sessions, skills, stream_json,
     task_runner, traces, workspace,
 )

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1119,7 +1119,7 @@ def chat_run(payload: dict[str, Any], provider: Any | None = None) -> dict[str, 
         ctx.ops_bridge = dict(payload.get("ops_bridge") or {})
     if isinstance(payload.get("ops_context"), dict):
         ctx.ops_context = dict(payload.get("ops_context") or {})
-    ctx.session_id = str(payload.get("session_id") or "") or sessions.new_id()
+    ctx.session_id = _checked_session_id(payload.get("session_id"))
     ctx.turn_id = str(payload.get("turn_id") or "")
     if payload.get("workspace"):
         ctx.workspace_declared = str(payload.get("workspace") or "")
@@ -1203,7 +1203,7 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
         ctx.ops_bridge = dict(payload.get("ops_bridge") or {})
     if isinstance(payload.get("ops_context"), dict):
         ctx.ops_context = dict(payload.get("ops_context") or {})
-    ctx.session_id = str(payload.get("session_id") or "") or sessions.new_id()
+    ctx.session_id = _checked_session_id(payload.get("session_id"))
     ctx.turn_id = str(payload.get("turn_id") or "")
     # 调用方显式给了工作区 = 一条边界，范围锁定只能在里面收窄，不能往上放宽。
     if payload.get("workspace"):
@@ -1301,7 +1301,7 @@ def chat_session_delete(session_id: str) -> dict[str, Any]:
 
 
 def chat_session_create(payload: dict[str, Any]) -> dict[str, Any]:
-    session_id = str(payload.get("id") or "") or sessions.new_id()
+    session_id = _checked_session_id(payload.get("id"))
     initial = str(payload.get("message") or payload.get("title") or "").strip()
     messages: list[dict[str, Any]] = []
     if initial:
@@ -1309,6 +1309,20 @@ def chat_session_create(payload: dict[str, Any]) -> dict[str, Any]:
     sessions.save(session_id, messages, model=config.get_model_config().get("model", ""))
     data = sessions.load(session_id) or {"id": session_id, "messages": messages}
     return {"ok": True, "session": _public_session_detail(data)}
+
+
+def _checked_session_id(raw: Any) -> str:
+    """把调用方给的 session_id 收成安全 id，留空则新生成。
+
+    id 直接拼成文件名，所以非法值必须在入口就打回 —— 拖到 sessions.save 才炸
+    就变成 500，调用方只能看到"服务器错误"，查不出是自己传了个越界的 id。
+    """
+    sid = str(raw or "")
+    if not sid:
+        return sessions.new_id()
+    if not sessions.is_safe_id(sid):
+        raise ValueError("invalid session_id")
+    return sid
 
 
 def chat_session_import(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1328,7 +1342,7 @@ def chat_session_import(payload: dict[str, Any]) -> dict[str, Any]:
                 messages.append({"role": role, "content": content})
     if not messages:
         return {"ok": False, "error": "no messages"}
-    session_id = str(payload.get("id") or "") or sessions.new_id()
+    session_id = _checked_session_id(payload.get("id"))
     created = payload.get("created")
     sessions.save(
         session_id,
@@ -1604,6 +1618,10 @@ class _Handler(BaseHTTPRequestHandler):
             try:
                 # client_gone 传下去，远程审批才知道"页面已经关了，别再等人确认"。
                 chat_stream(body, _locked_send, client_gone=client_gone)
+            except ValueError as exc:
+                # 入参问题（如非法 session_id）。响应头早发出去了，退不回 400，
+                # 只能走 error 事件 —— 直接抛会让连接无声断掉，前端只看到"卡住了"。
+                _locked_send("error", {"detail": str(exc)})
             finally:
                 done.set()
             return
@@ -1629,10 +1647,16 @@ class _Handler(BaseHTTPRequestHandler):
                 self._json(400, {"ok": False, "error": str(exc)})
             return
         if parsed.path == "/v1/chat/sessions/import":
-            self._json(200, chat_session_import(body))
+            try:
+                self._json(200, chat_session_import(body))
+            except ValueError as exc:
+                self._json(400, {"ok": False, "error": str(exc)})
             return
         if parsed.path == "/v1/chat/sessions":
-            self._json(200, chat_session_create(body))
+            try:
+                self._json(200, chat_session_create(body))
+            except ValueError as exc:
+                self._json(400, {"ok": False, "error": str(exc)})
             return
         if parsed.path == "/v1/knowledge/cards":
             try:

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -7,23 +7,111 @@ import hashlib
 import os
 import base64
 import binascii
+import queue
 import threading
 import time
+import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from . import (
     __version__, ads_evidence, agent_loop, code_agent, config, knowledge, knowledge_evidence,
-    knowledge_governance, knowledge_quality, knowledge_sync, models,
-    progress_reporting, retrieval, security, self_manage, sessions, skills, task_runner,
-    traces, workspace,
+    knowledge_governance, knowledge_quality, knowledge_sync, models, permission,
+    progress_reporting, retrieval, security, self_manage, sessions, skills, stream_json,
+    task_runner, traces, workspace,
 )
 from .agent_tools import ToolContext
 
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
+
+# ---------------------------------------------------------------------------
+# 远程人在环审批
+#
+# CLI 里写操作会弹 tui.select 等人选；嵌进网页后没有 TTY，所以 serve 一直强制
+# 只读（execute=False + plan_mode=True），写工具直接回一句"计划模式：不执行"。
+# 这条通道把那张审批卡投影到网页上：审批引擎、选项、语义完全复用 permission.py，
+# 只是把"在终端等一个按键"换成"在队列上等一个 HTTP 决策"。
+#
+# 每个待决策请求一个单槽队列，键是 request_id。跑轮次的那个请求线程阻塞在
+# queue.get 上；决策由 POST /v1/chat/permission 从另一个线程 put 进来
+# （ThreadingHTTPServer 每请求一线程，不会互相饿死）。
+#
+# 三条兜底路径都收敛到"拒绝"，绝不把 agent 永久挂在一个没人会回的确认上：
+# 超时、客户端断开、以及进程重启（队列在内存里，重启即失效，轮次本身也没了）。
+# ---------------------------------------------------------------------------
+_PENDING_APPROVALS: dict[str, "queue.Queue[str]"] = {}
+_APPROVALS_LOCK = threading.Lock()
+DEFAULT_APPROVAL_TIMEOUT = 600.0   # 10 分钟没人理 = 拒绝
+
+
+def resolve_permission(request_id: str, choice: str) -> bool:
+    """回送一个审批决策，解开阻塞中的那一步。未知/已过期的 request_id 返回 False。"""
+    with _APPROVALS_LOCK:
+        slot = _PENDING_APPROVALS.get(str(request_id or ""))
+    if slot is None:
+        return False
+    try:
+        slot.put_nowait(str(choice or ""))
+    except queue.Full:
+        return False    # 已经有决策在路上，忽略重复提交
+    return True
+
+
+def pending_permissions() -> list[str]:
+    with _APPROVALS_LOCK:
+        return list(_PENDING_APPROVALS.keys())
+
+
+class RemoteApproval:
+    """permission.PromptFn 的远程实现：发事件 → 阻塞等决策 → 返回选项 key。"""
+
+    def __init__(self, send: Any, session_id: str,
+                 client_gone: "threading.Event | None" = None,
+                 timeout: float = DEFAULT_APPROVAL_TIMEOUT) -> None:
+        self._send = send
+        self._session_id = session_id
+        self._client_gone = client_gone
+        self._timeout = float(timeout)
+
+    def prompt(self, title: str, body: str, options: list, meta: dict) -> str:
+        keys = [str(o[0]) for o in options]
+        fallback = "deny" if "deny" in keys else (keys[-1] if keys else "deny")
+        request_id = uuid.uuid4().hex[:16]
+        slot: "queue.Queue[str]" = queue.Queue(maxsize=1)
+        with _APPROVALS_LOCK:
+            _PENDING_APPROVALS[request_id] = slot
+        deadline = time.time() + self._timeout
+        try:
+            self._send("permission_request", {
+                "request_id": request_id,
+                "session_id": self._session_id,
+                "op_type": str(meta.get("op_type") or ""),
+                "title": title,
+                "preview": body,
+                "options": [{"key": str(k), "label": str(label)} for k, label in options],
+                "destructive": bool(meta.get("destructive", True)),
+                "expires_at": deadline,
+            })
+            # 分段等待而不是一次 get(timeout=600)：这样客户端一断开就能尽早收摊，
+            # 不用把那一步在服务端干挂十分钟。
+            while True:
+                try:
+                    choice = slot.get(timeout=1.0)
+                except queue.Empty:
+                    if self._client_gone is not None and self._client_gone.is_set():
+                        return fallback     # 页面已经关了，没人能确认了 → 拒绝
+                    if time.time() >= deadline:
+                        self._send("permission_timeout", {"request_id": request_id})
+                        return fallback
+                    continue
+                # 只认这次真发出去的选项，别让前端塞个奇怪的值改变语义。
+                return choice if choice in keys else fallback
+        finally:
+            with _APPROVALS_LOCK:
+                _PENDING_APPROVALS.pop(request_id, None)
 
 
 def health() -> dict[str, Any]:
@@ -1076,7 +1164,8 @@ def chat_run(payload: dict[str, Any], provider: Any | None = None) -> dict[str, 
     return result
 
 
-def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None) -> dict[str, Any]:
+def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
+                client_gone: "threading.Event | None" = None) -> dict[str, Any]:
     """Run one embedded agent turn and emit SSE-style events through send(event, data)."""
     from .providers import LLMError, build_chain
 
@@ -1092,11 +1181,18 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None)
         send("error", data)
         return data
 
+    # 远程审批模式：只有调用方明确要（approval="remote"）才放开写。
+    # 不传 approval 时下面这几行的结果与改动前逐字一致 —— 老调用方零影响。
+    remote_approval = str(payload.get("approval") or "none").strip() == "remote"
     plan_mode = payload.get("plan_mode")
     if plan_mode is None:
+        # 只读仍是默认。开了远程审批的调用方通常会显式传 plan_mode=false；
+        # 没传就仍按只读走，宁可少做也不要在没人看着的时候动线上数据。
         plan_mode = True
     ctx = ToolContext(
-        execute=False,
+        # execute 只在"能真的问到人"的前提下打开：写工具落地前必过 permission，
+        # 而 permission 这时走的是网页确认卡。
+        execute=bool(remote_approval and not plan_mode),
         plan_mode=bool(plan_mode),
         workspace=str(payload.get("workspace") or ""),
         task_id=str(payload.get("task_id") or ""),
@@ -1109,6 +1205,11 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None)
     ctx.turn_id = str(payload.get("turn_id") or "")
     if payload.get("asin"):
         ctx.asin = str(payload.get("asin") or "")
+    if remote_approval:
+        ctx.perm.prompt_fn = RemoteApproval(
+            send, ctx.session_id, client_gone=client_gone,
+            timeout=float(payload.get("approval_timeout") or DEFAULT_APPROVAL_TIMEOUT),
+        ).prompt
 
     try:
         messages, created_at = _chat_messages(message, payload, ctx)
@@ -1116,10 +1217,27 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None)
         data = {"ok": False, "error": str(exc)}
         send("error", data)
         return data
-    send("start", {"ok": True, "session_id": ctx.session_id, "read_only": bool(plan_mode), "model": health()["model"]})
+    send("start", {"ok": True, "session_id": ctx.session_id, "read_only": bool(plan_mode),
+                   "approval": "remote" if remote_approval else "none",
+                   "model": health()["model"]})
+
+    # 自动技能匹配：serve 一直只注入知识证据、不选技能（CLI 会）。开了 auto_skill
+    # 就用同一套 skills.context_for_query，并把命中结果发给前端画技能芯片。
+    if payload.get("auto_skill") and not str(payload.get("skill") or "").strip():
+        matched = _auto_skill_context(message, messages)
+        if matched:
+            send("skill_match", stream_json.skill_match_event(ctx.session_id, matched))
 
     def narrate(text: str) -> None:
         send("event", {"type": "event", "text": security.redact_text(str(text))})
+
+    def emit(ev: dict) -> None:
+        # run_turn_stream 的结构化事件通道原本只喂 CLI 的 stream-json。这里只放行
+        # 步骤类事件：assistant/tool_result 的内容前端已经能从 token/final 拿到，
+        # 再发一份就是重复。
+        kind = str(ev.get("type") or "")
+        if kind in ("step", "skill_match"):
+            send(kind, ev)
 
     try:
         provider = provider or build_chain(model_cfg, api_key, narrate=narrate)
@@ -1129,6 +1247,7 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None)
             messages,
             max_steps=(_int(payload.get("max_steps"), 0) or None),
             narrate=narrate,
+            emit=emit,
             tools=_tools_for(payload),
             render=lambda text: send("token", {"text": security.redact_text(str(text))}),
             model=model_cfg.get("model", ""),
@@ -1478,9 +1597,25 @@ class _Handler(BaseHTTPRequestHandler):
             beat = threading.Thread(target=_heartbeat, daemon=True, name="chat-stream-heartbeat")
             beat.start()
             try:
-                chat_stream(body, _locked_send)
+                # client_gone 传下去，远程审批才知道"页面已经关了，别再等人确认"。
+                chat_stream(body, _locked_send, client_gone=client_gone)
             finally:
                 done.set()
+            return
+        if parsed.path == "/v1/chat/permission":
+            request_id = str(body.get("request_id") or "").strip()
+            choice = str(body.get("choice") or "").strip()
+            if not request_id or not choice:
+                self._json(400, {"ok": False, "error": "request_id 与 choice 必填"})
+                return
+            ok = resolve_permission(request_id, choice)
+            self._json(200 if ok else 404, {
+                "ok": ok,
+                "request_id": request_id,
+                # 过期/未知一律照实说：这一步多半已经超时被拒或轮次已收尾，
+                # 前端据此把卡片改成"已失效"，而不是让用户以为点成功了。
+                "error": "" if ok else "unknown_or_expired_request",
+            })
             return
         if parsed.path == "/v1/chat":
             try:
@@ -1906,6 +2041,56 @@ def _chat_messages(message: str, payload: dict[str, Any], ctx: ToolContext) -> t
         ctx.knowledge_query = message
     messages.append({"role": "user", "content": _with_payload_images(user_content, payload)})
     return messages, created_at
+
+
+def _auto_skill_context(message: str, messages: list) -> list[dict[str, Any]]:
+    """按用户问题自动匹配 skill、注入本轮 user 消息，返回命中列表供 skill_match 事件用。
+
+    serve 一直只做知识证据注入、不选技能（选技能只有 CLI 会做），于是同一个问题
+    在终端和网页会走出两套流程。这里复用 cli.py 那条路上的同一个
+    skills.context_for_query 和同一段注入文案，把两边拉齐。
+
+    不另设"是不是亚马逊问题"的闸：skills 库全是亚马逊域，纯代码问题打分为 0
+    自然不会命中，多一道判断反而多一处会跟 CLI 走偏的地方。
+    """
+    try:
+        sctx, sids = skills.context_for_query(message, limit=2)
+    except Exception:  # noqa: BLE001 — 技能匹配失败绝不该让整轮对话挂掉
+        return []
+    if not sctx or not sids:
+        return []
+    note = ("\n\n[Ivyea Skill：本轮相关可复用流程]\n" + sctx
+            + "\n\n要求：优先按 skill workflow 组织执行步骤；涉及事实依据时再结合知识库。")
+    for msg in reversed(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            msg["content"] = content + note
+        elif isinstance(content, list):
+            # 多模态消息：追加到文本块，图片块原样不动。
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    part["text"] = str(part.get("text") or "") + note
+                    break
+            else:
+                content.insert(0, {"type": "text", "text": note})
+        break
+    scores = {}
+    try:
+        scores = {sk.id: score for sk, score in skills.search(message, limit=len(sids))}
+    except Exception:  # noqa: BLE001
+        pass
+    out: list[dict[str, Any]] = []
+    for sid in sids:
+        sk = skills.get_skill(sid)
+        out.append({
+            "id": sid,
+            "title": (sk.title if sk else sid),
+            "domain": (sk.domain if sk else ""),
+            "score": scores.get(sid, 0),
+        })
+    return out
 
 
 def _with_payload_images(user_content: str, payload: dict[str, Any]):

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1121,6 +1121,8 @@ def chat_run(payload: dict[str, Any], provider: Any | None = None) -> dict[str, 
         ctx.ops_context = dict(payload.get("ops_context") or {})
     ctx.session_id = str(payload.get("session_id") or "") or sessions.new_id()
     ctx.turn_id = str(payload.get("turn_id") or "")
+    if payload.get("workspace"):
+        ctx.workspace_declared = str(payload.get("workspace") or "")
     if payload.get("asin"):
         ctx.asin = str(payload.get("asin") or "")
 
@@ -1203,6 +1205,9 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
         ctx.ops_context = dict(payload.get("ops_context") or {})
     ctx.session_id = str(payload.get("session_id") or "") or sessions.new_id()
     ctx.turn_id = str(payload.get("turn_id") or "")
+    # 调用方显式给了工作区 = 一条边界，范围锁定只能在里面收窄，不能往上放宽。
+    if payload.get("workspace"):
+        ctx.workspace_declared = str(payload.get("workspace") or "")
     if payload.get("asin"):
         ctx.asin = str(payload.get("asin") or "")
     if remote_approval:

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1126,7 +1126,7 @@ def chat_run(payload: dict[str, Any], provider: Any | None = None) -> dict[str, 
     if payload.get("asin"):
         ctx.asin = str(payload.get("asin") or "")
 
-    messages, created_at = _chat_messages(message, payload, ctx)
+    messages, created_at, turn_base = _chat_messages(message, payload, ctx)
     events: list[dict[str, Any]] = []
 
     def narrate(text: str) -> None:
@@ -1156,9 +1156,10 @@ def chat_run(payload: dict[str, Any], provider: Any | None = None) -> dict[str, 
         except (FileNotFoundError, OSError, ValueError):
             pass
     if payload.get("persist", True):
-        sessions.save(
+        sessions.append_turn(
             ctx.session_id,
-            messages,
+            str(messages[0].get("content") or "") if messages else "",
+            messages[turn_base:],
             model=model_cfg.get("model", ""),
             usage={},
             created=created_at,
@@ -1217,7 +1218,7 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
         ).prompt
 
     try:
-        messages, created_at = _chat_messages(message, payload, ctx)
+        messages, created_at, turn_base = _chat_messages(message, payload, ctx)
     except ValueError as exc:
         data = {"ok": False, "error": str(exc)}
         send("error", data)
@@ -1268,7 +1269,11 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
         return data
 
     if payload.get("persist", True):
-        sessions.save(ctx.session_id, messages, model=model_cfg.get("model", ""), usage={}, created=created_at)
+        sessions.append_turn(
+            ctx.session_id,
+            str(messages[0].get("content") or "") if messages else "",
+            messages[turn_base:],
+            model=model_cfg.get("model", ""), usage={}, created=created_at)
     data = {
         "ok": True,
         "session_id": ctx.session_id,
@@ -1989,7 +1994,8 @@ def _model_requires_key(settings: dict[str, Any]) -> bool:
     return bool(settings.get("key_env") or auth in ("oauth_external", "oauth_device_code", "copilot"))
 
 
-def _chat_messages(message: str, payload: dict[str, Any], ctx: ToolContext) -> tuple[list[dict[str, Any]], float | None]:
+def _chat_messages(message: str, payload: dict[str, Any],
+                   ctx: ToolContext) -> tuple[list[dict[str, Any]], float | None, int]:
     system = agent_loop.SYSTEM_PROMPT + agent_loop.runtime_context_note()
     if ctx.plan_mode:
         system += agent_loop.PLAN_NOTE
@@ -2068,8 +2074,11 @@ def _chat_messages(message: str, payload: dict[str, Any], ctx: ToolContext) -> t
         ctx.knowledge_retrieval_expected = False
         ctx.knowledge_risk = "none"
         ctx.knowledge_query = message
+    # 本轮起点：这之前都是历史，这之后（含这条 user 和后续工具/回答）才是本轮新增。
+    # 落盘时只写这一段，见 sessions.append_turn —— 整份覆盖会吃掉并发的另一轮。
+    base = len(messages)
     messages.append({"role": "user", "content": _with_payload_images(user_content, payload)})
-    return messages, created_at
+    return messages, created_at, base
 
 
 def _auto_skill_context(message: str, messages: list) -> list[dict[str, Any]]:

--- a/ivyea_agent/sessions.py
+++ b/ivyea_agent/sessions.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import re as _re
 import secrets
 import time
 from pathlib import Path
@@ -29,7 +30,22 @@ def new_id() -> str:
     return f"{stamp}-{millis:03d}-{secrets.token_hex(2)}"
 
 
+# 会话 id 会直接拼进文件名，而 id 是**调用方给的**（serve 的 payload.session_id、
+# 导入接口的 id），所以必须当成不可信输入。不校验的话 `../../../x` 就是一次
+# 任意路径写入 —— daemon 常以 root 跑，代价是整台机器。
+#
+# 字符集按 new_id() 的产物取（时间戳-毫秒-随机十六进制），另外放行下划线，
+# 好让外部系统的 id 迁进来。落盘的 164 个历史会话全部符合，收紧不误伤存量。
+_SAFE_ID = _re.compile(r"[A-Za-z0-9_-]{1,120}")
+
+
+def is_safe_id(sid: str) -> bool:
+    return bool(sid) and _SAFE_ID.fullmatch(sid) is not None
+
+
 def path_for(sid: str) -> Path:
+    if not is_safe_id(sid):
+        raise ValueError(f"unsafe session id: {sid[:40]!r}")
     return _dir() / f"{sid}.json"
 
 
@@ -44,6 +60,8 @@ def save(sid: str, messages: list[dict], *, model: str = "", usage: Optional[dic
 
 
 def load(sid: str) -> Optional[dict[str, Any]]:
+    if not is_safe_id(sid):
+        return None          # 查询语义：非法 id 等同"查无此会话"，不必抛
     p = path_for(sid)
     if not p.exists():
         return None
@@ -61,7 +79,7 @@ def latest_id() -> Optional[str]:
 def delete(sid: str) -> bool:
     """Delete one persisted session file. Returns True if a file was removed.
     Guards against path traversal — only deletes inside the sessions dir."""
-    if not sid:
+    if not is_safe_id(sid):
         return False
     p = path_for(sid)
     try:

--- a/ivyea_agent/sessions.py
+++ b/ivyea_agent/sessions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import re as _re
 import secrets
+import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -49,14 +50,60 @@ def path_for(sid: str) -> Path:
     return _dir() / f"{sid}.json"
 
 
+# 一条会话一把锁。会话文件是**整份覆盖**写的，所以"读出来→改→写回去"这段必须
+# 串起来 —— 否则两个标签页在同一会话里同时发消息，后写的那份会把先写的整轮
+# （连问带答）悄悄吃掉。实测复现过：两轮都正常出了字，落盘只剩一轮。
+_LOCKS: dict[str, threading.RLock] = {}
+_LOCKS_GUARD = threading.Lock()
+
+
+def _lock_for(sid: str) -> threading.RLock:
+    with _LOCKS_GUARD:
+        lock = _LOCKS.get(sid)
+        if lock is None:
+            lock = _LOCKS[sid] = threading.RLock()
+        return lock
+
+
 def save(sid: str, messages: list[dict], *, model: str = "", usage: Optional[dict] = None,
          created: Optional[float] = None) -> None:
+    with _lock_for(sid):
+        _save(sid, messages, model=model, usage=usage, created=created)
+
+
+def _save(sid: str, messages: list[dict], *, model: str = "", usage: Optional[dict] = None,
+          created: Optional[float] = None) -> None:
     p = path_for(sid)
     data = {"id": sid, "created": created or time.time(), "updated": time.time(),
             "model": model, "messages": messages, "usage": usage or {}}
     tmp = p.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
     tmp.replace(p)
+
+
+def append_turn(sid: str, system: str, new_messages: list[dict], *, model: str = "",
+                usage: Optional[dict] = None, created: Optional[float] = None) -> None:
+    """把**这一轮新增的**消息并进磁盘上那份，而不是拿内存里的整份覆盖。
+
+    为什么不能整份覆盖：一轮的流程是"开始时读全部历史 → 跑 → 结束时写回全部"。
+    两个标签页同时在一条会话里发消息，各自读到的都是那一刻的历史，结束时各自写回
+    自己那份 —— 后写的赢，先写的那一整轮就没了。而且**没有任何报错**，两边界面上
+    都好好地出了字，只有刷新之后才会发现少了一轮。
+
+    改成只追加增量之后，两轮都留得下来（顺序按落盘先后交错，但一条都不丢）。
+    整段读改写在会话锁里，所以两个并发的收尾不会互相踩。
+    """
+    with _lock_for(sid):
+        cur = load(sid) or {}
+        msgs = list(cur.get("messages") or [])
+        # system 用本轮这份：它带着当前的技能/知识注入，是这一轮的运行时上下文
+        if msgs and msgs[0].get("role") == "system":
+            msgs[0] = {"role": "system", "content": system}
+        else:
+            msgs.insert(0, {"role": "system", "content": system})
+        msgs.extend(new_messages)
+        _save(sid, msgs, model=model, usage=usage,
+              created=cur.get("created") or created)
 
 
 def load(sid: str) -> Optional[dict[str, Any]]:

--- a/ivyea_agent/sessions.py
+++ b/ivyea_agent/sessions.py
@@ -39,9 +39,23 @@ def new_id() -> str:
 # 好让外部系统的 id 迁进来。落盘的 164 个历史会话全部符合，收紧不误伤存量。
 _SAFE_ID = _re.compile(r"[A-Za-z0-9_-]{1,120}")
 
+# Windows 的保留设备名。`NUL.json` 在 Windows 上**就是空设备** —— 写进去内容直接
+# 消失，而且不报错；`CON` 会去开控制台。字符集守卫拦不住它们（全是合法字符），
+# 所以单独列一份。带扩展名也一样算设备，所以比的是整个 id。
+_WINDOWS_RESERVED = frozenset(
+    ["CON", "PRN", "AUX", "NUL"]
+    + [f"COM{i}" for i in range(1, 10)]
+    + [f"LPT{i}" for i in range(1, 10)]
+)
+
 
 def is_safe_id(sid: str) -> bool:
-    return bool(sid) and _SAFE_ID.fullmatch(sid) is not None
+    if not sid or _SAFE_ID.fullmatch(sid) is None:
+        return False
+    # 无论当前跑在哪个系统都拒：会话文件会跟着备份/同步挪到 Windows 机器上，
+    # 而且 daemon 本身就支持 Windows。只在 nt 上拦，等于放任生成一批到了
+    # Windows 才炸的 id。
+    return sid.upper() not in _WINDOWS_RESERVED
 
 
 def path_for(sid: str) -> Path:

--- a/ivyea_agent/sessions.py
+++ b/ivyea_agent/sessions.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re as _re
 import secrets
 import threading
@@ -90,9 +91,23 @@ def _save(sid: str, messages: list[dict], *, model: str = "", usage: Optional[di
     p = path_for(sid)
     data = {"id": sid, "created": created or time.time(), "updated": time.time(),
             "model": model, "messages": messages, "usage": usage or {}}
-    tmp = p.with_suffix(".json.tmp")
+    # 临时文件名带进程号和随机后缀。固定成 `<id>.json.tmp` 的话，两个**进程**同时
+    # 写同一条会话（比如工作台的 serve 和一个 `ivyea chat`）会写进同一个临时文件，
+    # 互相踩出半截 JSON。进程内的会话锁管不到跨进程。
+    tmp = p.with_name(f"{p.stem}.{os.getpid()}.{secrets.token_hex(3)}.tmp")
     tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
-    tmp.replace(p)
+    # Windows 上 os.replace 会在**别的进程正开着目标文件**时抛 PermissionError
+    # （POSIX 从不会）。这里的目标恰恰是会被并发读的会话文件，而 Windows 是主要
+    # 用户环境 —— 不重试的话，赶上一次就是这一轮的回答没落盘。
+    for attempt in range(6):
+        try:
+            tmp.replace(p)
+            return
+        except PermissionError:
+            if attempt == 5:
+                tmp.unlink(missing_ok=True)   # 别把半截临时文件留在会话目录里
+                raise
+            time.sleep(0.05 * (attempt + 1))
 
 
 def append_turn(sid: str, system: str, new_messages: list[dict], *, model: str = "",

--- a/ivyea_agent/stream_json.py
+++ b/ivyea_agent/stream_json.py
@@ -45,6 +45,87 @@ def tool_result_event(session_id: str, tool_use_id: str, text: str, is_error: bo
                  "content": text, "is_error": bool(is_error)}]}}
 
 
+# 一次工具调用的参数里，值得放进事件的键。整包参数可能很大（文件内容、报表行），
+# 事件是给 UI 画芯片用的，只带够画一行摘要的量。
+_ARG_KEEP = (
+    "query", "q", "keyword", "asin", "pattern", "path", "url", "command",
+    "name", "tool", "server", "marketplace", "country", "site", "mode", "days",
+    "project_id", "job_id", "sid", "skill_name", "task", "limit",
+)
+_ARG_VALUE_MAX = 200
+
+
+def _slim_args(args: dict | None) -> dict:
+    """裁剪工具参数：只留可读的标量键，长值截断。"""
+    out: dict = {}
+    for key in _ARG_KEEP:
+        val = (args or {}).get(key)
+        if val is None or isinstance(val, (dict, list)):
+            continue
+        text = str(val)
+        if not text:
+            continue
+        out[key] = text[:_ARG_VALUE_MAX]
+    return out
+
+
+def step_event(session_id: str, turn_id: str, call_id: str, seq: int, name: str,
+               arguments: dict | None, status: str, duration_ms: int | None = None) -> dict:
+    """一次工具调用的步骤事件（开始 running，收尾 ok/error）。
+
+    stream-json 的 assistant/tool_result 事件足够回放对话，但不足以画出参考产品
+    那种「中文工具名 · ✓ · 5.2s」的执行时间线：它既没有耗时，也没有把真正被调用
+    的东西说清楚 —— agent 不把 MCP / 板块工具扁平化进工具名空间，真实工具藏在
+    参数里（`mcp_call_tool(server=…, tool=…)`、`ivyea_ops_call_tool(name=…)`）。
+    这里统一拆包提到顶层，消费方不必再去猜参数结构。
+
+    耗时本来只进 traces.db；同时放进事件流，UI 就不用为了显示一个秒数去 join 另一张表。
+    """
+    args = arguments or {}
+    phase = "tool"
+    tool = ""
+    server = ""
+    if name == "mcp_call_tool":
+        phase = "mcp"
+        server = str(args.get("server") or "")
+        tool = str(args.get("tool") or "")
+    elif name == "ivyea_ops_call_tool":
+        phase = "board"
+        tool = str(args.get("name") or "")
+    elif name == "dispatch_subagent":
+        phase = "subagent"
+    elif name in ("knowledge_search", "recall", "skill_search"):
+        phase = "knowledge"
+    elif name in ("todo_write", "progress_update", "self_critique"):
+        # 规划/汇报类调用在一轮里能占到大多数步（实测 19 步里 12 步是它们）。
+        # 它们不是"做了什么"，是"在组织怎么做"。单独归一类，UI 可以折成一行，
+        # 免得真正干活的那两三步被埋掉。
+        phase = "plan"
+
+    # MCP / 板块工具的真实入参在嵌套的 arguments 里，摘要要看那一层。
+    inner = args.get("arguments") if isinstance(args.get("arguments"), dict) else None
+    ev = {
+        "type": "step", "session_id": session_id, "turn_id": turn_id,
+        "id": call_id, "seq": int(seq), "phase": phase, "name": name,
+        "status": status, "args": _slim_args(inner if inner is not None else args),
+    }
+    if tool:
+        ev["tool"] = tool
+    if server:
+        ev["server"] = server
+    if duration_ms is not None:
+        ev["ms"] = int(duration_ms)
+    return ev
+
+
+def skill_match_event(session_id: str, skills: list) -> dict:
+    """本轮命中的 skill —— 对应参考产品的「✓ 理解问题，匹配最合适的技能」。
+
+    skills 里每项形如 {id, title, domain, score}。
+    """
+    return {"type": "skill_match", "session_id": session_id, "skills": list(skills or [])}
+
+
 def result_event(session_id: str, text: str, usage: dict, cost_cny: float,
                  duration_ms: int, num_turns: int = 1, is_error: bool = False) -> dict:
     """收尾事件：最终答案 + 用量/花费汇总。is_error 覆盖 blocked/异常收尾。"""

--- a/ivyea_agent/task_scope.py
+++ b/ivyea_agent/task_scope.py
@@ -292,13 +292,30 @@ def render_note(scope: ScopeResolution, query: str) -> str:
     return "\n".join(lines)
 
 
+def _within(root: str, boundary: str) -> bool:
+    try:
+        Path(root).resolve().relative_to(Path(boundary).resolve())
+        return True
+    except (ValueError, OSError):
+        return False
+
+
 def apply_to_context(ctx: Any, scope: ScopeResolution) -> None:
     ctx.scope_ambiguous = bool(scope.ambiguous)
     ctx.behavioral_task = bool(scope.behavioral)
     if scope.root and not scope.ambiguous:
-        ctx.workspace = scope.root
-        ctx.target_root = scope.root
-        ctx.target_project = scope.project
+        root = scope.root
+        # 调用方**显式声明**了工作区时，范围锁定只能在它内部收窄，绝不能往上放宽。
+        # project_root_for 是向上找 .git / 项目标记的，对 CLI（cwd 深在仓库里）正好；
+        # 但嵌入式调用把工作区绑到某个数据目录时，它会一路走到那个"看起来像项目"的
+        # 祖先目录去。实测：绑定 /tmp/…/wsdir 被放宽成 /tmp，于是 agent 对着 5.5 万
+        # 个文件找一个相对路径文件 —— 既找不到，扫描面也大得离谱。
+        boundary = str(getattr(ctx, "workspace_declared", "") or "")
+        if boundary and not _within(root, boundary):
+            root = boundary
+        ctx.workspace = root
+        ctx.target_root = root
+        ctx.target_project = Path(root).name if root != scope.root else scope.project
         ctx.target_explicit = bool(scope.explicit)
         ctx.scope_confidence = scope.confidence
 
@@ -358,6 +375,12 @@ def adopt_project_from_path(ctx: Any, path: str | os.PathLike[str] | None) -> st
     """Adopt concrete file/list evidence when no conflicting explicit lock exists."""
     root = project_root_for(path)
     if root is None:
+        return ""
+    # 和 apply_to_context 同一条规矩：读到一个文件之后顺势"锁定项目根"时，同样不能
+    # 越过调用方声明的工作区往上走。少了这道闸，第一次 read_file 之后工作区又会被
+    # 悄悄放宽回祖先目录（实测收尾会带一句"后续代码搜索根：/tmp"）。
+    boundary = str(getattr(ctx, "workspace_declared", "") or "")
+    if boundary and not _within(str(root), boundary):
         return ""
     current = str(getattr(ctx, "target_root", "") or "")
     if getattr(ctx, "target_explicit", False) and current and Path(current).resolve() != root:

--- a/ivyea_agent/tools_general.py
+++ b/ivyea_agent/tools_general.py
@@ -93,7 +93,7 @@ def _gate(ctx, kind: str, preview: str, detail: dict | None = None) -> tuple[boo
 
 # ── 读类（自动放行）──────────────────────────────────────────────────────────
 def t_read_file(args: dict, ctx) -> str:
-    p = Path(os.path.expanduser(args.get("path", ""))).resolve()
+    p = _ws_path(ctx, args.get("path", ""))
     ok, msg = policy.check_path(p, "read")
     if not ok:
         return msg
@@ -125,7 +125,7 @@ def t_read_file(args: dict, ctx) -> str:
 
 
 def t_list_dir(args: dict, ctx) -> str:
-    p = Path(os.path.expanduser(args.get("path", ".") or ".")).resolve()
+    p = _ws_path(ctx, args.get("path", "."), ".")
     ok, msg = policy.check_path(p, "read")
     if not ok:
         return msg
@@ -197,6 +197,27 @@ _GREP_BINARY = re.compile(rb"\x00")
 def _ws_root(ctx):
     from . import workspace
     return workspace.resolve_root(getattr(ctx, "workspace", "") or None)
+
+
+def _ws_path(ctx, raw: str, default: str = "") -> Path:
+    """把工具参数里的路径解析成绝对路径：**相对路径按 ctx.workspace 解，不按进程 cwd。**
+
+    ``ToolContext.workspace`` 一直被文档描述为"通用工具的工作目录"，但只有
+    grep/glob/code_* 这几个走 `_ws_root` 的工具真的照做；read_file / list_dir /
+    write_file / edit_file 都是直接 `Path(...).resolve()`，也就是按**进程**的 cwd。
+
+    CLI 下两者恰好一致（`ctx.workspace = os.getcwd()`），所以一直没暴露。但嵌进
+    IvyeaOps 跑时，进程 cwd 是 ops 的安装目录，工作区却可能指向别处 —— 实测
+    `list_dir(".")` 列出来的是 /root/ivyea-ops，而不是用户绑定的工作区目录。
+
+    绝对路径不受影响；`~` 照常展开。
+    """
+    raw = str(raw or default or "")
+    expanded = os.path.expanduser(raw)
+    p = Path(expanded)
+    if not p.is_absolute():
+        p = _ws_root(ctx) / p
+    return p.resolve()
 
 
 def _expand_braces(pattern: str) -> list[str]:
@@ -575,11 +596,11 @@ def t_mcp_get_prompt(args: dict, ctx) -> str:
 
 # ── 写/执行类（门控）─────────────────────────────────────────────────────────
 def t_write_file(args: dict, ctx) -> str:
-    path = os.path.expanduser(args.get("path", ""))
+    path = str(args.get("path", "") or "")
     content = args.get("content", "")
     if not path:
         return "path 为空。"
-    p = Path(path).resolve()
+    p = _ws_path(ctx, path)
     ok, msg = policy.check_path(p, "write")
     if not ok:
         return msg
@@ -602,7 +623,7 @@ def t_write_file(args: dict, ctx) -> str:
 
 
 def t_edit_file(args: dict, ctx) -> str:
-    p = Path(os.path.expanduser(args.get("path", ""))).resolve()
+    p = _ws_path(ctx, args.get("path", ""))
     ok, msg = policy.check_path(p, "write")
     if not ok:
         return msg

--- a/tests/test_agent_discipline.py
+++ b/tests/test_agent_discipline.py
@@ -24,7 +24,7 @@ def test_deadend_forces_list_dir_before_another_search(tmp_path, monkeypatch):
     agent_loop._dispatch_tool_calls(ctx, messages, status, [_call("g1", "grep", pattern="x")],
                                     0, 10, lambda _s: None)
     assert ctx.search_recovery_required is True
-    blocked, _ = agent_loop._run_one(_call("g2", "grep", pattern="y"), ctx)
+    blocked, _, _guarded = agent_loop._run_one(_call("g2", "grep", pattern="y"), ctx)
     assert blocked.ok is False
     assert "先 list_dir" in blocked.text
 
@@ -36,7 +36,7 @@ def test_deadend_forces_list_dir_before_another_search(tmp_path, monkeypatch):
 def test_navigation_budget_stops_unbounded_search(tmp_path, monkeypatch):
     ctx = ToolContext(workspace=str(tmp_path), navigation_since_read=8)
     monkeypatch.setattr(agent_loop, "dispatch_result", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("must block")))
-    result, _ = agent_loop._run_one(_call("g", "glob", pattern="**/*.py"), ctx)
+    result, _, _guarded = agent_loop._run_one(_call("g", "glob", pattern="**/*.py"), ctx)
     assert result.ok is False
     assert "已经导航 8 次" in result.text
     assert "read_file" in result.text
@@ -64,7 +64,7 @@ def test_ambiguous_scope_blocks_search_and_mutation(tmp_path):
     ctx = ToolContext(workspace=str(tmp_path), scope_ambiguous=True)
     for name, args in (("grep", {"pattern": "x"}), ("edit_file", {"path": "a"}),
                        ("run_command", {"command": "echo x"})):
-        result, _ = agent_loop._run_one({"id": name, "name": name, "arguments": args}, ctx)
+        result, _, _guarded = agent_loop._run_one({"id": name, "name": name, "arguments": args}, ctx)
         assert result.ok is False
         assert "目标尚未锁定" in result.text
 

--- a/tests/test_context_sessions.py
+++ b/tests/test_context_sessions.py
@@ -142,3 +142,49 @@ def test_sessions_new_id_is_unique(ivyea_home):
 def test_sessions_load_missing(ivyea_home):
     from ivyea_agent import sessions
     assert sessions.load("nope-does-not-exist") is None
+
+
+# ── 会话 id 是不可信输入 ────────────────────────────────────────────────────
+# session_id 直接拼进文件名，而它是**调用方给的**（serve 的 payload.session_id、
+# 导入接口的 id）。曾实测可打通：往 /v1/chat/sessions POST 一个
+# id="../../../tmp/PWNED"，daemon（常以 root 跑）就在会话目录之外写出了文件。
+
+def test_path_for_rejects_traversal(tmp_path, monkeypatch):
+    import pytest
+
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    for bad in ["../../../../tmp/PWNED", "/tmp/PWNED", "..", "a/b", "a\\b", "", "x" * 200]:
+        with pytest.raises(ValueError):
+            sessions.path_for(bad)
+
+
+def test_path_for_accepts_real_ids(tmp_path, monkeypatch):
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    # new_id() 的产物、以及更老的不带随机后缀的历史 id，都必须继续可用
+    assert sessions.path_for(sessions.new_id()).parent == tmp_path
+    assert sessions.path_for("20260617-120252").name == "20260617-120252.json"
+    assert sessions.path_for("imp-assistant-1743001").name == "imp-assistant-1743001.json"
+
+
+def test_save_refuses_to_write_outside_the_sessions_dir(tmp_path, monkeypatch):
+    import pytest
+
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    with pytest.raises(ValueError):
+        sessions.save("../escaped", [{"role": "user", "content": "x"}])
+    assert not (tmp_path.parent / "escaped.json").exists()
+
+
+def test_load_and_delete_treat_bad_ids_as_missing(tmp_path, monkeypatch):
+    """查询语义：非法 id 等同"查无此会话"，不该把异常甩给调用方。"""
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    assert sessions.load("../../etc/passwd") is None
+    assert sessions.delete("../../etc/passwd") is False

--- a/tests/test_context_sessions.py
+++ b/tests/test_context_sessions.py
@@ -292,3 +292,65 @@ def test_only_exact_device_names_are_reserved(tmp_path, monkeypatch):
     monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
     for name in ["CONSOLE", "NULL", "com10", "COM", "LPT", "nul-1", "imp-brain-con"]:
         assert sessions.is_safe_id(name) is True, name
+
+
+def test_temp_file_name_is_unique_per_writer(tmp_path, monkeypatch):
+    """临时文件名不能是固定的 `<id>.json.tmp`。
+
+    两个**进程**同时写同一条会话（工作台的 serve + 一个 `ivyea chat`）会写进同一个
+    临时文件，互相踩出半截 JSON —— 进程内的会话锁管不到跨进程。
+    """
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    seen = []
+    real_write = sessions.Path.write_text
+
+    def spy(self, *a, **k):
+        if self.suffix == ".tmp":
+            seen.append(self.name)
+        return real_write(self, *a, **k)
+
+    monkeypatch.setattr(sessions.Path, "write_text", spy)
+    for _ in range(3):
+        sessions.save("20260808-000000-000-aaaa", [{"role": "user", "content": "x"}])
+    assert len(set(seen)) == 3, seen                       # 每次都不同
+    assert not list(tmp_path.glob("*.tmp"))                # 也没留下垃圾
+
+
+def test_save_retries_when_windows_holds_the_target_open(tmp_path, monkeypatch):
+    """Windows 上 os.replace 会在别的进程正开着目标文件时抛 PermissionError
+    （POSIX 从不会）。目标恰恰是会被并发读的会话文件，而 Windows 是主要用户环境
+    —— 不重试的话，赶上一次就是这一轮的回答没落盘。"""
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    monkeypatch.setattr(sessions.time, "sleep", lambda _s: None)
+    calls = {"n": 0}
+    real_replace = sessions.Path.replace
+
+    def flaky(self, target):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise PermissionError(13, "被占用")
+        return real_replace(self, target)
+
+    monkeypatch.setattr(sessions.Path, "replace", flaky)
+    sessions.save("20260808-000000-000-aaaa", [{"role": "user", "content": "撑过去了"}])
+    assert calls["n"] == 3
+    assert sessions.load("20260808-000000-000-aaaa")["messages"][0]["content"] == "撑过去了"
+
+
+def test_save_gives_up_cleanly_if_the_file_stays_locked(tmp_path, monkeypatch):
+    """一直占着就得抛，但别把半截临时文件留在会话目录里。"""
+    import pytest
+
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    monkeypatch.setattr(sessions.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(sessions.Path, "replace",
+                        lambda self, t: (_ for _ in ()).throw(PermissionError(13, "一直被占用")))
+    with pytest.raises(PermissionError):
+        sessions.save("20260808-000000-000-aaaa", [{"role": "user", "content": "x"}])
+    assert not list(tmp_path.glob("*.tmp"))

--- a/tests/test_context_sessions.py
+++ b/tests/test_context_sessions.py
@@ -188,3 +188,80 @@ def test_load_and_delete_treat_bad_ids_as_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
     assert sessions.load("../../etc/passwd") is None
     assert sessions.delete("../../etc/passwd") is False
+
+
+# ── 并发落盘 ────────────────────────────────────────────────────────────────
+# 一轮的流程是"开始读全部历史 → 跑 → 结束写回全部"。两个标签页同时在一条会话里
+# 发消息，各自读到那一刻的历史，结束时各自写回自己那份 —— 后写的赢，先写的整轮
+# （连问带答）就没了，而且**没有任何报错**。实测复现过。
+
+def test_append_turn_keeps_both_concurrent_turns(tmp_path, monkeypatch):
+    import threading
+
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    sid = "20260808-000000-000-abcd"
+    sessions.save(sid, [{"role": "system", "content": "sys"},
+                        {"role": "user", "content": "第一轮"},
+                        {"role": "assistant", "content": "答一"}])
+
+    start = threading.Barrier(2)
+
+    def turn(tag):
+        # 模拟真实流程：先读历史，再（并发地）写回自己这一轮
+        base = sessions.load(sid)["messages"]
+        start.wait()
+        sessions.append_turn(sid, "sys", [
+            {"role": "user", "content": f"问-{tag}"},
+            {"role": "assistant", "content": f"答-{tag}"},
+        ])
+        return len(base)
+
+    threads = [threading.Thread(target=turn, args=(t,)) for t in ("甲", "乙")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    msgs = sessions.load(sid)["messages"]
+    users = [m["content"] for m in msgs if m["role"] == "user"]
+    # 顺序按落盘先后交错，但**一条都不能少**
+    assert sorted(users) == sorted(["第一轮", "问-甲", "问-乙"]), users
+    assert len([m for m in msgs if m["role"] == "assistant"]) == 3
+    assert msgs[0]["role"] == "system" and len(msgs) == 7
+
+
+def test_append_turn_refreshes_the_system_prompt(tmp_path, monkeypatch):
+    """system 是这一轮的运行时上下文（带着当前技能/知识注入），要用新的那份。"""
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    sid = "20260808-000000-000-abce"
+    sessions.save(sid, [{"role": "system", "content": "旧"},
+                        {"role": "user", "content": "上一轮"}])
+    sessions.append_turn(sid, "新", [{"role": "user", "content": "这一轮"}])
+    msgs = sessions.load(sid)["messages"]
+    assert msgs[0] == {"role": "system", "content": "新"}
+    assert [m["content"] for m in msgs if m["role"] == "user"] == ["上一轮", "这一轮"]
+
+
+def test_append_turn_creates_the_session_when_absent(tmp_path, monkeypatch):
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    sid = "20260808-000000-000-abcf"
+    sessions.append_turn(sid, "sys", [{"role": "user", "content": "第一句"}])
+    msgs = sessions.load(sid)["messages"]
+    assert msgs[0]["role"] == "system" and msgs[1]["content"] == "第一句"
+
+
+def test_append_turn_preserves_the_original_created_time(tmp_path, monkeypatch):
+    """创建时间是会话的身份之一，后续轮次不该把它刷成"刚刚"。"""
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    sid = "20260808-000000-000-abd0"
+    sessions.save(sid, [{"role": "user", "content": "x"}], created=1000.0)
+    sessions.append_turn(sid, "sys", [{"role": "user", "content": "y"}], created=9999.0)
+    assert sessions.load(sid)["created"] == 1000.0

--- a/tests/test_context_sessions.py
+++ b/tests/test_context_sessions.py
@@ -265,3 +265,30 @@ def test_append_turn_preserves_the_original_created_time(tmp_path, monkeypatch):
     sessions.save(sid, [{"role": "user", "content": "x"}], created=1000.0)
     sessions.append_turn(sid, "sys", [{"role": "user", "content": "y"}], created=9999.0)
     assert sessions.load(sid)["created"] == 1000.0
+
+
+def test_windows_reserved_device_names_are_rejected(tmp_path, monkeypatch):
+    """`NUL.json` 在 Windows 上**就是空设备**：会话写进去内容直接消失，还不报错。
+    `CON` 会去开控制台。这些全是合法字符，字符集守卫拦不住。
+
+    无论当前跑在哪个系统都要拒 —— 会话文件会跟着备份/同步挪到 Windows 机器上，
+    daemon 本身也支持 Windows。只在 nt 上拦，等于放任生成一批到了 Windows 才炸的 id。
+    """
+    import pytest
+
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    for name in ["NUL", "CON", "PRN", "AUX", "COM1", "LPT9", "nul", "Con", "com1"]:
+        assert sessions.is_safe_id(name) is False, name
+        with pytest.raises(ValueError):
+            sessions.path_for(name)
+
+
+def test_only_exact_device_names_are_reserved(tmp_path, monkeypatch):
+    """别误伤：只有**整个 id 等于**设备名才算，前缀像的不算。"""
+    from ivyea_agent import sessions
+
+    monkeypatch.setattr(sessions, "_dir", lambda: tmp_path)
+    for name in ["CONSOLE", "NULL", "com10", "COM", "LPT", "nul-1", "imp-brain-con"]:
+        assert sessions.is_safe_id(name) is True, name

--- a/tests/test_progress_reporting.py
+++ b/tests/test_progress_reporting.py
@@ -46,11 +46,11 @@ def test_progress_tool_registered():
 def test_substantive_tool_blocked_until_plan_and_start(tmp_path):
     ctx = ToolContext(workspace=str(tmp_path), progress_required=True)
     call = {"id": "r", "name": "read_file", "arguments": {"path": str(tmp_path / "a.py")}}
-    blocked, _ = agent_loop._run_one(call, ctx)
+    blocked, _, _guarded = agent_loop._run_one(call, ctx)
     assert blocked.ok is False and "todo_write" in blocked.text
 
     _plan(ctx)
-    blocked, _ = agent_loop._run_one(call, ctx)
+    blocked, _, _guarded = agent_loop._run_one(call, ctx)
     assert blocked.ok is False and "progress_update" in blocked.text
 
     assert "开始执行" in _start(ctx)

--- a/tests/test_remote_approval.py
+++ b/tests/test_remote_approval.py
@@ -253,3 +253,126 @@ def test_board_tool_unchanged_when_no_approval_channel(ivyea_home, monkeypatch):
     ctx.ops_bridge = {"base_url": "http://x/api", "token": "t"}
     agent_tools._t_ivyea_ops_call_tool({"name": "lingxing_operate_enable", "arguments": {}}, ctx)
     assert called == ["lingxing_operate_enable"]
+
+
+# ── 工作区目录（ctx.workspace）──────────────────────────────────────────────
+
+def test_file_tools_resolve_relative_paths_against_workspace(tmp_path, monkeypatch):
+    """相对路径要按 ctx.workspace 解，不是按进程 cwd。
+
+    ToolContext.workspace 一直写着"通用工具的工作目录"，但 read_file / list_dir /
+    write_file / edit_file 都是直接 Path(...).resolve()。CLI 下 workspace == cwd
+    所以一直没暴露；嵌进 IvyeaOps 跑时进程 cwd 是 ops 的安装目录，实测
+    list_dir(".") 列出来的是 /root/ivyea-ops 而不是用户绑定的工作区。
+    """
+    from ivyea_agent import tools_general as tg
+    from ivyea_agent.agent_tools import ToolContext
+
+    ws = tmp_path / "myws"
+    ws.mkdir()
+    (ws / "inside.txt").write_text("我在工作区里", encoding="utf-8")
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)                    # 进程 cwd 故意指向别处
+
+    ctx = ToolContext(workspace=str(ws))
+    assert "inside.txt" in tg.t_list_dir({"path": "."}, ctx)
+    assert "我在工作区里" in tg.t_read_file({"path": "inside.txt"}, ctx)
+
+    # 没设 workspace 时保持老行为：按进程 cwd
+    bare = ToolContext()
+    assert "inside.txt" not in tg.t_list_dir({"path": "."}, bare)
+
+
+def test_absolute_paths_are_untouched_by_workspace(tmp_path, monkeypatch):
+    from ivyea_agent import tools_general as tg
+    from ivyea_agent.agent_tools import ToolContext
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    target = tmp_path / "abs.txt"
+    target.write_text("绝对路径", encoding="utf-8")
+    ctx = ToolContext(workspace=str(ws))
+    assert "绝对路径" in tg.t_read_file({"path": str(target)}, ctx)
+
+
+def test_cli_behaviour_unchanged_when_workspace_equals_cwd(tmp_path, monkeypatch):
+    """CLI 把 workspace 设成 os.getcwd()，两者一致 —— 行为必须和以前一模一样。"""
+    from ivyea_agent import tools_general as tg
+    from ivyea_agent.agent_tools import ToolContext
+
+    (tmp_path / "a.txt").write_text("x", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    ctx = ToolContext(workspace=str(tmp_path))
+    assert "a.txt" in tg.t_list_dir({"path": "."}, ctx)
+
+
+def test_declared_workspace_is_never_widened_by_scope_locking(tmp_path, monkeypatch):
+    """显式声明的工作区，范围锁定只能在里面收窄，不能往上放宽。
+
+    task_scope 的 project_root_for 是**向上**找 .git / 项目标记的 —— 对 CLI
+    （cwd 深在仓库里）正好，但嵌入式调用把工作区绑到某个数据目录时，它会一路走到
+    那个"看起来像项目"的祖先去。实测：绑定 /tmp/…/wsdir 被放宽成 /tmp，agent 于是
+    对着 5.5 万个文件找一个相对路径文件，既找不到、扫描面也大得离谱。
+    """
+    from ivyea_agent import task_scope
+    from ivyea_agent.agent_tools import ToolContext
+
+    # 祖先目录伪装成一个"项目"（.git 存在）
+    ancestor = tmp_path / "looks-like-a-repo"
+    (ancestor / ".git").mkdir(parents=True)
+    ws = ancestor / "data" / "myws"
+    ws.mkdir(parents=True)
+
+    ctx = ToolContext(workspace=str(ws), workspace_declared=str(ws))
+    task_scope.prepare_messages(ctx, [
+        {"role": "system", "content": "x"},
+        {"role": "user", "content": "读一下 marker.txt"},
+    ])
+    assert ctx.workspace == str(ws)          # 没被放宽到 ancestor
+
+    # 没声明工作区时保持老行为：允许向上锁到项目根（CLI 就靠这个）
+    ctx2 = ToolContext(workspace=str(ws))
+    task_scope.prepare_messages(ctx2, [
+        {"role": "system", "content": "x"},
+        {"role": "user", "content": "读一下 marker.txt"},
+    ])
+    assert ctx2.workspace == str(ancestor)
+
+
+def test_declared_workspace_still_allows_narrowing_inside(tmp_path):
+    """收窄是允许的 —— 边界只挡"往上"，不挡"往里"。"""
+    from ivyea_agent import task_scope
+    from ivyea_agent.agent_tools import ToolContext
+
+    base = tmp_path / "base"
+    inner = base / "sub"
+    inner.mkdir(parents=True)
+    ctx = ToolContext(workspace=str(base), workspace_declared=str(base))
+    task_scope.apply_to_context(
+        ctx, task_scope.ScopeResolution(root=str(inner), project="sub"))
+    assert ctx.workspace == str(inner)
+
+
+def test_tool_evidence_cannot_widen_past_the_declared_workspace(tmp_path):
+    """读到文件后的"顺势锁定项目根"同样受边界约束。
+
+    少了这道闸，第一次 read_file 之后工作区又被悄悄放宽回祖先目录 ——
+    实测收尾会带一句"[范围已锁定] 后续代码搜索根：/tmp"。
+    """
+    from ivyea_agent import task_scope
+    from ivyea_agent.agent_tools import ToolContext
+
+    ancestor = tmp_path / "repo"
+    (ancestor / ".git").mkdir(parents=True)
+    ws = ancestor / "data"
+    ws.mkdir()
+    (ws / "f.txt").write_text("x", encoding="utf-8")
+
+    ctx = ToolContext(workspace=str(ws), workspace_declared=str(ws))
+    assert task_scope.adopt_project_from_path(ctx, ws / "f.txt") == ""
+    assert ctx.workspace == str(ws)          # 没被放宽
+
+    # 没声明边界时保持老行为
+    ctx2 = ToolContext(workspace=str(ws))
+    assert task_scope.adopt_project_from_path(ctx2, ws / "f.txt") == str(ancestor)

--- a/tests/test_remote_approval.py
+++ b/tests/test_remote_approval.py
@@ -1,0 +1,255 @@
+"""远程人在环审批：把 CLI 的 tui 审批卡投影到网页，并保证永远收敛出一个决策。
+
+这条路的核心风险不是"能不能批准"，而是**会不会把 agent 永久挂在一个没人会回的
+确认上**。所以超时、页面关闭、乱填选项三条路都有用例钉死，方向一律是拒绝。
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+
+def _options():
+    return [("approve", "批准本次"), ("session", "本会话同类都批准"),
+            ("deny", "拒绝"), ("abort", "全部停止")]
+
+
+def test_prompt_blocks_until_decision_arrives():
+    """发出 permission_request 后阻塞；决策一到就返回对应选项。"""
+    from ivyea_agent import service
+
+    sent: list[tuple[str, dict]] = []
+    remote = service.RemoteApproval(lambda ev, data: sent.append((ev, data)), "sid-1")
+
+    result: dict = {}
+
+    def _run():
+        result["choice"] = remote.prompt("需要确认写操作", "降低低效目标预算",
+                                         _options(), {"op_type": "ops_tool_call"})
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+
+    # 等事件发出来（说明已经在等人了）
+    deadline = time.time() + 5
+    while not sent and time.time() < deadline:
+        time.sleep(0.02)
+    assert sent, "没有发出 permission_request"
+    event, data = sent[0]
+    assert event == "permission_request"
+    assert data["session_id"] == "sid-1"
+    assert data["op_type"] == "ops_tool_call"
+    assert data["preview"] == "降低低效目标预算"
+    assert [o["key"] for o in data["options"]] == ["approve", "session", "deny", "abort"]
+    request_id = data["request_id"]
+    assert request_id in service.pending_permissions()
+
+    # 此刻那一步仍卡着 —— 这正是"没点确认就不落写"的机制本身
+    worker.join(timeout=0.3)
+    assert worker.is_alive()
+
+    assert service.resolve_permission(request_id, "approve") is True
+    worker.join(timeout=5)
+    assert result["choice"] == "approve"
+    # 收尾必须摘掉登记，否则重启前会一直堆着
+    assert request_id not in service.pending_permissions()
+
+
+def test_timeout_denies_and_notifies():
+    """没人理 → 拒绝，并且告诉前端这张卡已经失效。"""
+    from ivyea_agent import service
+
+    sent: list[tuple[str, dict]] = []
+    remote = service.RemoteApproval(lambda ev, data: sent.append((ev, data)), "sid-2", timeout=0.05)
+    choice = remote.prompt("需要确认写操作", "开启领星可写开关", _options(), {})
+    assert choice == "deny"
+    assert [ev for ev, _ in sent] == ["permission_request", "permission_timeout"]
+    assert not service.pending_permissions()
+
+
+def test_client_disconnect_denies_without_waiting_out_the_timeout():
+    """页面关了就没人能确认了，别把这一步在服务端干挂十分钟。"""
+    from ivyea_agent import service
+
+    gone = threading.Event()
+    gone.set()
+    remote = service.RemoteApproval(lambda ev, data: None, "sid-3",
+                                    client_gone=gone, timeout=600.0)
+    started = time.time()
+    assert remote.prompt("需要确认写操作", "改价", _options(), {}) == "deny"
+    assert time.time() - started < 5    # 立刻收敛，而不是等满超时
+
+
+def test_unknown_choice_falls_back_to_deny():
+    """前端塞个没发过的选项，不许借此改变语义。"""
+    from ivyea_agent import service
+
+    holder: dict = {}
+    remote = service.RemoteApproval(lambda ev, data: holder.setdefault("id", data.get("request_id")),
+                                    "sid-4", timeout=5.0)
+    out: dict = {}
+    worker = threading.Thread(
+        target=lambda: out.setdefault("choice", remote.prompt("t", "b", _options(), {})),
+        daemon=True)
+    worker.start()
+    deadline = time.time() + 5
+    while "id" not in holder and time.time() < deadline:
+        time.sleep(0.02)
+    assert service.resolve_permission(holder["id"], "yolo") is True
+    worker.join(timeout=5)
+    assert out["choice"] == "deny"
+
+
+def test_resolve_unknown_request_id_is_false():
+    from ivyea_agent import service
+    assert service.resolve_permission("no-such-id", "approve") is False
+
+
+def test_permission_engine_uses_remote_channel_and_skips_edit():
+    """审批引擎认这条通道；远端没法做就地编辑，edit 选项必须先摘掉。"""
+    from ivyea_agent import permission
+
+    seen: dict = {}
+
+    def _prompt(title, body, options, meta):
+        seen["title"] = title
+        seen["options"] = [k for k, _ in options]
+        seen["meta"] = meta
+        return "deny"
+
+    state = permission.PermissionState(prompt_fn=_prompt)
+    decision = permission.request_intent(
+        {"op_type": "mcp_call_tool"}, "调用 MCP 工具 lingxing.update_bid", state,
+        edit_fn=lambda intent, input_fn: None,   # 有 edit 能力，但远端不该看到它
+    )
+    assert decision == permission.DENY
+    assert "edit" not in seen["options"]
+    assert seen["options"] == ["approve", "session", "deny", "abort"]
+    assert seen["meta"]["op_type"] == "mcp_call_tool"
+    assert seen["meta"]["destructive"] is True
+
+
+def test_session_choice_allows_same_op_type_without_asking_again():
+    """「本会话同类都批准」在远程模式下同样生效，不该每步都再弹一次。"""
+    from ivyea_agent import permission
+
+    asked: list[str] = []
+
+    def _prompt(title, body, options, meta):
+        asked.append(meta.get("op_type", ""))
+        return "session"
+
+    state = permission.PermissionState(prompt_fn=_prompt)
+    intent = {"op_type": "ops_tool_call"}
+    assert permission.request_intent(intent, "第一次", state) == permission.APPROVE
+    assert permission.request_intent(intent, "第二次", state) == permission.APPROVE
+    assert asked == ["ops_tool_call"]      # 只问了一次
+
+
+def test_cli_path_untouched_without_prompt_fn(monkeypatch):
+    """没注入 prompt_fn 时仍走 tui.select —— CLI 的交互审批行为一字不变。"""
+    from ivyea_agent import permission, tui
+
+    calls: dict = {}
+
+    def _fake_select(title, body, options, kind="warn", input_fn=None):
+        calls["kind"] = kind
+        calls["options"] = [k for k, _ in options]
+        return "approve"
+
+    monkeypatch.setattr(tui, "select", _fake_select)
+    state = permission.PermissionState()
+    assert permission.request_intent({"op_type": "write_file"}, "写文件", state,
+                                     edit_fn=lambda i, f: None) == permission.APPROVE
+    assert calls["kind"] == "warn"
+    assert "edit" in calls["options"]      # 终端仍然给"改一下"
+
+
+class _BoardToolProvider:
+    """先调一个写类板块能力，再收尾。"""
+
+    def __init__(self):
+        self.calls = 0
+
+    def stream_chat(self, messages, tools=None, temperature=0.3, timeout=120.0):
+        self.calls += 1
+        if self.calls == 1:
+            yield {"type": "final", "content": "", "usage": {}, "tool_calls": [{
+                "id": "b1", "name": "ivyea_ops_call_tool",
+                "arguments": {"name": "lingxing_operate_enable", "arguments": {}},
+            }]}
+        else:
+            yield {"type": "final", "content": "好了", "tool_calls": [], "usage": {}}
+
+
+@pytest.mark.parametrize("decision,expect_called", [("approve", True), ("deny", False)])
+def test_destructive_board_tool_requires_approval(ivyea_home, monkeypatch, decision, expect_called):
+    """写类板块能力（开领星可写开关这种）必须先问过人，拒绝就真的不调。"""
+    from ivyea_agent import agent_loop, agent_tools, permission
+
+    called: list[str] = []
+
+    def _fake_bridge(ctx, path, payload, timeout=80.0):
+        if path == "/tools":
+            return {"ok": True, "tools": [
+                {"name": "lingxing_operate_enable", "title": "开启领星操作开关",
+                 "module": "admin", "destructive": True},
+                {"name": "market_history", "title": "市场调研历史",
+                 "module": "market", "destructive": False},
+            ]}
+        called.append(str(payload.get("name")))
+        return {"ok": True, "result": "done"}
+
+    monkeypatch.setattr(agent_tools, "_ops_bridge_request", _fake_bridge)
+
+    ctx = agent_tools.ToolContext(session_id="sid-board")
+    ctx.ops_bridge = {"base_url": "http://x/api", "token": "t"}
+    ctx.perm.prompt_fn = lambda title, body, options, meta: decision
+
+    msgs = [{"role": "system", "content": "x"}, {"role": "user", "content": "开一下写开关"}]
+    agent_loop.run_turn_stream(_BoardToolProvider(), ctx, msgs,
+                               render=lambda s: None, narrate=lambda s: None)
+    assert (called == ["lingxing_operate_enable"]) is expect_called
+    assert permission  # 引擎确实参与了这条路径
+
+
+def test_readonly_board_tool_is_not_gated(ivyea_home, monkeypatch):
+    """只读板块能力不该被审批打断 —— 否则每查一次历史都要点一次确认。"""
+    from ivyea_agent import agent_tools
+
+    def _fake_bridge(ctx, path, payload, timeout=80.0):
+        if path == "/tools":
+            return {"ok": True, "tools": [
+                {"name": "market_history", "title": "市场调研历史", "destructive": False}]}
+        return {"ok": True, "result": "rows"}
+
+    monkeypatch.setattr(agent_tools, "_ops_bridge_request", _fake_bridge)
+    ctx = agent_tools.ToolContext()
+    ctx.ops_bridge = {"base_url": "http://x/api", "token": "t"}
+    asked: list[str] = []
+    ctx.perm.prompt_fn = lambda *a, **k: asked.append("asked") or "deny"
+
+    out = agent_tools._t_ivyea_ops_call_tool({"name": "market_history", "arguments": {}}, ctx)
+    assert "rows" in out
+    assert asked == []
+
+
+def test_board_tool_unchanged_when_no_approval_channel(ivyea_home, monkeypatch):
+    """没有审批通道时保持既有行为：嵌入式对话一直这么跑的，这次不改它。"""
+    from ivyea_agent import agent_tools
+
+    called: list[str] = []
+
+    def _fake_bridge(ctx, path, payload, timeout=80.0):
+        if path == "/tools":
+            raise AssertionError("没有审批通道时不该去查目录")
+        called.append(str(payload.get("name")))
+        return {"ok": True, "result": "done"}
+
+    monkeypatch.setattr(agent_tools, "_ops_bridge_request", _fake_bridge)
+    ctx = agent_tools.ToolContext()            # perm.prompt_fn 为 None
+    ctx.ops_bridge = {"base_url": "http://x/api", "token": "t"}
+    agent_tools._t_ivyea_ops_call_tool({"name": "lingxing_operate_enable", "arguments": {}}, ctx)
+    assert called == ["lingxing_operate_enable"]

--- a/tests/test_retrieval_service.py
+++ b/tests/test_retrieval_service.py
@@ -836,7 +836,9 @@ def test_local_service_health_and_retrieval(ivyea_home, monkeypatch):
         assert chat["ok"] is True
         assert chat["text"] == "hello"
 
-        monkeypatch.setattr(service, "chat_stream", lambda body, send: send("final", {"ok": True, "text": "stream"}))
+        # **_kw：handler 会额外传 client_gone（远程审批用它判断"页面还在不在"）。
+        monkeypatch.setattr(service, "chat_stream",
+                            lambda body, send, **_kw: send("final", {"ok": True, "text": "stream"}))
         req = urllib.request.Request(
             f"http://{host}:{port}/v1/chat/stream",
             data=json.dumps({"message": "hello"}).encode("utf-8"),

--- a/tests/test_stream_json.py
+++ b/tests/test_stream_json.py
@@ -21,7 +21,13 @@ class _ToolThenTextProvider:
 
 
 def test_emit_event_sequence(ivyea_home):
-    """事件序列：assistant(tool_use) → tool_result(id 配对) → assistant(text)。"""
+    """事件序列：assistant(tool_use) → tool_result(id 配对) → assistant(text)。
+
+    step 事件是后加的、供 UI 画执行时间线用；已有消费方（IvyeaOps 的
+    runners.IvyeaStreamJsonParser、agents 板块的 ivyea_driver）只认
+    system/assistant/user/result，会忽略它。所以这里刻意**滤掉 step 之后**再断言
+    骨架，把"老消费方看到的东西一个字没变"这条契约钉死。
+    """
     from ivyea_agent import agent_loop, agent_tools
     ctx = agent_tools.ToolContext(session_id="sid-sj")
     events = []
@@ -30,16 +36,99 @@ def test_emit_event_sequence(ivyea_home):
                                      render=lambda s: None, narrate=lambda s: None,
                                      emit=events.append)
     assert out["text"] == "结论"
-    assert [e["type"] for e in events] == ["assistant", "user", "assistant"]
-    tool_use = events[0]["message"]["content"][0]
+    backbone = [e for e in events if e["type"] != "step"]
+    assert [e["type"] for e in backbone] == ["assistant", "user", "assistant"]
+    tool_use = backbone[0]["message"]["content"][0]
     assert tool_use["type"] == "tool_use" and tool_use["name"] == "recall"
     assert tool_use["input"] == {"query": "放量"}
-    tr = events[1]["message"]["content"][0]
+    tr = backbone[1]["message"]["content"][0]
     assert tr["type"] == "tool_result" and tr["tool_use_id"] == tool_use["id"] == "c1"
     assert isinstance(tr["is_error"], bool)
-    final = events[2]["message"]["content"]
+    final = backbone[2]["message"]["content"]
     assert final == [{"type": "text", "text": "结论"}]
     assert all(e["session_id"] == "sid-sj" for e in events)
+
+
+def test_step_events_pair_and_carry_duration(ivyea_home):
+    """step 事件：每个工具一对 running→ok，用 tool_use id 配对，收尾带耗时。"""
+    from ivyea_agent import agent_loop, agent_tools
+    ctx = agent_tools.ToolContext(session_id="sid-step", turn_id="t1")
+    events = []
+    msgs = [{"role": "system", "content": "x"}, {"role": "user", "content": "回忆放量"}]
+    agent_loop.run_turn_stream(_ToolThenTextProvider(), ctx, msgs,
+                               render=lambda s: None, narrate=lambda s: None,
+                               emit=events.append)
+    steps = [e for e in events if e["type"] == "step"]
+    assert [s["status"] for s in steps] == ["running", "ok"]
+    assert {s["id"] for s in steps} == {"c1"}
+    assert all(s["name"] == "recall" and s["phase"] == "knowledge" for s in steps)
+    assert all(s["seq"] == 1 for s in steps)
+    assert all(s["turn_id"] == "t1" for s in steps)
+    assert "ms" not in steps[0]                       # 开始时还没有耗时
+    assert isinstance(steps[1]["ms"], int) and steps[1]["ms"] >= 0
+    assert steps[0]["args"] == {"query": "放量"}      # 参数摘要照常带上
+
+
+def test_step_event_unwraps_mcp_and_board_tools():
+    """MCP / 板块能力的真实工具藏在参数里，事件必须提到顶层，UI 才能显示人话。"""
+    from ivyea_agent import stream_json
+    mcp = stream_json.step_event(
+        "s", "t", "c1", 1, "mcp_call_tool",
+        {"server": "sorftime", "tool": "keyword_analysis", "arguments": {"keyword": "hose"}},
+        "running")
+    assert mcp["phase"] == "mcp" and mcp["server"] == "sorftime"
+    assert mcp["tool"] == "keyword_analysis" and mcp["args"] == {"keyword": "hose"}
+
+    board = stream_json.step_event(
+        "s", "t", "c2", 2, "ivyea_ops_call_tool",
+        {"name": "market_generate_report", "arguments": {"query": "garden hose", "marketplace": "US"}},
+        "ok", 5210)
+    assert board["phase"] == "board" and board["tool"] == "market_generate_report"
+    assert board["args"] == {"query": "garden hose", "marketplace": "US"}
+    assert board["ms"] == 5210
+
+
+def test_step_event_classifies_planning_calls_apart():
+    """规划/汇报类调用单列一类，UI 才能折起来，不把真正干活的步埋掉。"""
+    from ivyea_agent import stream_json
+    for name in ("todo_write", "progress_update", "self_critique"):
+        assert stream_json.step_event("s", "t", "c", 1, name, {}, "ok", 1)["phase"] == "plan"
+    assert stream_json.step_event("s", "t", "c", 1, "read_file", {}, "ok", 1)["phase"] == "tool"
+
+
+def test_guard_rejection_reports_blocked_not_error(tmp_path):
+    """前置护栏拦下 ≠ 工具失败，状态要分开，否则一次正常的流程纠偏会画成红叉。
+
+    直接驱动 _dispatch_tool_calls：走完整 run_turn_stream 的话，进场准备会按用户
+    问题重算 progress_required，把这里刻意摆好的护栏条件冲掉。
+    """
+    from ivyea_agent import agent_loop
+    from ivyea_agent.agent_tools import ToolContext
+
+    ctx = ToolContext(workspace=str(tmp_path), progress_required=True, session_id="sid-guard")
+    events = []
+    status = agent_loop.TurnStatus(max_steps=10)
+    call = {"id": "g1", "name": "read_file", "arguments": {"path": str(tmp_path / "a.py")}}
+    agent_loop._dispatch_tool_calls(ctx, [], status, [call], 0, 10,
+                                    lambda _s: None, emit=events.append)
+    steps = [e for e in events if e["type"] == "step"]
+    assert [s["status"] for s in steps] == ["running", "blocked"]
+
+    # 对照：护栏放行后同一个工具就是普通的 ok/error，不再是 blocked
+    ctx2 = ToolContext(workspace=str(tmp_path), session_id="sid-guard2")
+    events2 = []
+    agent_loop._dispatch_tool_calls(ctx2, [], agent_loop.TurnStatus(max_steps=10), [call],
+                                    0, 10, lambda _s: None, emit=events2.append)
+    assert [e["status"] for e in events2 if e["type"] == "step"][-1] != "blocked"
+
+
+def test_step_event_drops_bulky_arguments():
+    """事件是给 UI 画一行芯片的，别把整个文件内容塞进流里。"""
+    from ivyea_agent import stream_json
+    ev = stream_json.step_event("s", "t", "c1", 1, "write_file",
+                                {"path": "/root/a.py", "content": "x" * 50000}, "ok", 3)
+    assert ev["args"] == {"path": "/root/a.py"}
+    assert len(json.dumps(ev)) < 400
 
 
 class _ParallelToolsProvider:


### PR DESCRIPTION
配合 IvyeaOps 工作台改造做的 serve 侧能力，外加这一轮审出来的几个真问题。

## 新能力

- **结构化步骤事件**：把工具/MCP/板块能力调用拆成 `step` 事件（含 `mcp_call_tool` → 服务器+工具名、`ivyea_ops_call_tool` → 板块工具的解包），前端不必再从自由文本里猜发生了什么。
- **远程人在环审批**：写操作发 `permission_request`、阻塞等决策，新增 `POST /v1/chat/permission` 回送。客户端断开就尽早收摊，不把那一步在服务端干挂十分钟。
- **工作区真的生效**：`ctx.workspace` 此前四个文件类工具都没用上，相对路径落到进程 cwd。同时补上任务范围锁定的边界 —— 声明的工作区只能被收窄，不能被放宽。

## 修的几个真问题

**任意文件写入（安全）** — `sessions.path_for` 把调用方给的 id 直接拼成文件名，零校验。`delete()` 早防了穿越，`save()` 没防 —— 守卫加错了地方。实测对运行中的 daemon POST `{"id": "../../../<路径>/PWNED"}`，会话目录之外真的写出了文件；daemon 常以 root 跑。修在咽喉处（`path_for` 校验 + service 入口拒绝 + 两个端点映射 400）。164 个历史会话 id 全部符合新字符集。

**同一会话并发发消息会静默吃掉一整轮** — 一轮的流程是"开始读全部历史 → 跑 → 结束写回全部"。两个标签页同时发，各自写回自己那份整表，后写的赢。两边界面都正常出字，只有刷新才发现少了一轮。改成只追加本轮增量（`sessions.append_turn`，会话锁内重读磁盘再接上），两轮都留得下来，也不用把并发轮次排队等着。

**Windows 保留设备名** — `CON`/`NUL`/`COM1-9` 全是合法字符，字符集守卫拦不住。`NUL.json` 在 Windows 上就是空设备，会话写进去内容直接消失且不报错。只拒整个 id 等于设备名的，`CONSOLE`/`NULL`/`com10` 照常放行。

**落盘对 Windows 不够硬** — 临时文件名固定成 `<id>.json.tmp`，跨进程同写会互相踩出半截 JSON；`os.replace` 在 Windows 上遇到别人开着目标文件会抛 `PermissionError`（POSIX 永远不会）。改成唯一临时名 + 退避重试。

## 验证

742 项测试全绿（含用 Barrier 卡时序的并发用例、路径穿越守卫、Windows 保留名）。CI 覆盖 ubuntu/macos/windows × py3.9/3.11/3.12。

安全修复在真机上验过：重启后重打同一发穿越 → 两个端点都 400，正常建会话仍 200，目录外零文件。并发那条复跑此前失败的脚本 → 用户轮次从 2 条变成 3 条，两轮都在。

🤖 Generated with [Claude Code](https://claude.com/claude-code)