### PR TITLE
fix(stream): 正文分段边界，网页不再把同一段吐好几遍

### DIFF
--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -490,7 +490,8 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
                     render_reasoning: Callable[[str], None] = None,
                     emit: Callable[[dict], None] | None = None,
                     tools: list | None = None,
-                    defer_citation_text: bool = True) -> dict:
+                    defer_citation_text: bool = True,
+                    on_answer_reset: Callable[[str], None] | None = None) -> dict:
     """流式跑一轮：token 边出边渲染、工具实时叙述、累计用量。
     返回 {text, usage}（usage 为本轮各步累加）。render(token) 逐字输出助手文本。
 
@@ -502,13 +503,38 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
     tools：受限工具子集（与 run_turn 对齐）；[] = 不挂工具，None = 全量 TOOL_SCHEMAS。
     defer_citation_text：带 [K#] 知识引证时是否把正文压到引证门通过后一次性输出。
     终端（CLI）保持 True——中间草稿打出去收不回来；Web/serve 传 False 边生成边流式，
-    前端以 final 事件的 text 为准整体替换，引证重写不会留下脏文本。"""
+    前端以 final 事件的 text 为准整体替换，引证重写不会留下脏文本。
+
+    on_answer_reset(reason)：**上一段已经渲染出去的正文作废了**，从这里开始的是新
+    一稿。一轮里模型可能把正文吐好几遍——工具前的开场白、门禁打回后的整篇重写
+    （引用校验最多来回 2 次）——终端是一条向下的日志、叠着看没问题，但网页把
+    token 顺序拼进同一个气泡，用户看到的就是同一张表连出三遍。给了这个回调的
+    调用方（serve → 网页）会收到边界，把气泡清空重画；不给（CLI）则一个字都不变。
+    reason: tool_call | gate:verify | gate:progress | gate:citation。"""
     task_scope.prepare_messages(ctx, messages)
     tool_schemas = TOOL_SCHEMAS if tools is None else tools
     render = render or (lambda s: print(s, end="", flush=True))
     render_reasoning = render_reasoning or (lambda s: None)
     cancel_check = cancel_check or (lambda: False)
     total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "prompt_cache_hit_tokens": 0}
+
+    # 正文的"稿"边界。发通知的时刻是**新一稿的第一个字**——在那之前谁也不知道
+    # 模型还会不会再写一遍，提前发就会把还在用的那一稿误清。
+    rendered_any = False        # 本轮已经渲染过正文
+    draft_open = False          # 当前这一步已经开了稿（每步开头复位）
+    superseded_by = ""          # 上一稿是被什么作废的
+
+    def _render_text(chunk: str) -> None:
+        nonlocal rendered_any, draft_open
+        if not draft_open:
+            draft_open = True
+            if rendered_any and on_answer_reset is not None:
+                try:
+                    on_answer_reset(superseded_by or "restart")
+                except Exception:   # noqa: BLE001 — 通知失败绝不能打断正在跑的轮次
+                    pass
+        rendered_any = True
+        render(chunk)
 
     def _accum(u: dict) -> None:
         if not u:
@@ -527,6 +553,7 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
         status.before_model_step(step_idx, narrate)
         final = {"content": "", "tool_calls": [], "usage": {}}
         printed_any = False
+        draft_open = False
         buffered_text: list[str] = []
         defer_text = bool(
             (
@@ -543,7 +570,7 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
                 printed_any = True
                 buffered_text.append(ev["text"])
                 if not defer_text:
-                    render(ev["text"])
+                    _render_text(ev["text"])
             elif ev["type"] == "reasoning":
                 render_reasoning(ev.get("text") or "")
             elif ev["type"] == "final":
@@ -555,18 +582,27 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
         if not tool_calls:
             content = final.get("content", "") or ""
             messages.append({"role": "assistant", "content": content})
+            gate = ""
             fb = _verify_gate_feedback(ctx, status, narrate)
+            if fb is not None:
+                gate = "verify"
             if fb is None:
                 fb = _progress_gate_feedback(ctx, narrate)
+                if fb is not None:
+                    gate = "progress"
             if fb is None:
                 fb = _citation_gate_feedback(ctx, content, status, narrate)
+                if fb is not None:
+                    gate = "citation"
             if fb is not None:
                 messages.append({"role": "user", "content": fb})
+                # 门禁要求的是**整篇重写**，所以刚吐出去的那一稿到此作废。
+                superseded_by = f"gate:{gate}"
                 continue
             content = _finalize_citations(ctx, content)
             messages[-1]["content"] = content
             if defer_text and content:
-                render(content)
+                _render_text(content)
                 render("\n")
             _emit_safe(emit, stream_json.assistant_event(
                 getattr(ctx, "session_id", ""), content, []))
@@ -575,6 +611,8 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
             raise KeyboardInterrupt
         _emit_safe(emit, stream_json.assistant_event(
             getattr(ctx, "session_id", ""), final.get("content") or "", tool_calls))
+        # 这一步的正文是"工具前的开场白"。它不是答案，等下一稿开始时该让位。
+        superseded_by = "tool_call"
         _append_tool_call_msg(messages, final.get("content"), tool_calls)
         _dispatch_tool_calls(ctx, messages, status, tool_calls, step_idx, max_steps, narrate, emit=emit)
     text = _finalize_limit(ctx, messages, status, max_steps, extra_payload={"usage": total_usage})

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1262,6 +1262,11 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
             # 只累加 token、不认 final 的调用方（IvyeaOps 的报告合成）传 true：
             # 引证门会让模型带着 [K#] 把整篇重写一遍，不 defer 就会收到两份报告。
             defer_citation_text=payload.get("defer_citation_text") is True,
+            # 一轮里正文可能被吐好几遍（工具前的开场白、门禁打回后的整篇重写）。
+            # 终端叠着看没问题，网页把 token 拼进同一个气泡就成了"同一张表连出
+            # 三遍"。这条事件告诉前端：前面那一稿作废，从下一个 token 重新开始。
+            on_answer_reset=lambda reason: send(
+                "answer_reset", {"reason": str(reason), "session_id": ctx.session_id}),
         )
     except LLMError as exc:
         data = {"ok": False, "error": "model_error", "detail": str(exc)}

--- a/tests/test_answer_draft_reset.py
+++ b/tests/test_answer_draft_reset.py
@@ -1,0 +1,163 @@
+"""正文"草稿作废"边界（on_answer_reset）。
+
+一轮里模型会把正文吐好几遍：工具前的开场白、门禁打回后的整篇重写。终端是一条
+向下的日志，叠着看没问题；网页把 token 顺序拼进同一个气泡，用户看到的就是同一
+张表连出三遍。run_turn_stream 在**新一稿的第一个字**上通知调用方作废上一稿。
+
+CLI 不传这个回调 —— 所以这里也要钉死"不传时渲染序列一个字都不变"。
+"""
+from __future__ import annotations
+
+
+def _citation():
+    return {
+        "key": "K1",
+        "id": "seller_registration.registration_and_identity_verification",
+        "title": "Seller registration and identity verification baseline",
+        "url": "https://sell.amazon.com/sell/registration-guide",
+        "authority_tier": "primary",
+        "freshness": "current",
+    }
+
+
+class _GateProvider:
+    """第一稿不带 [K#]（会被引用门禁打回），第二稿合规。"""
+
+    def __init__(self):
+        self.calls = 0
+
+    def stream_chat(self, messages, tools=None):
+        self.calls += 1
+        content = ("库存周转要盯着补货节奏。" if self.calls == 1
+                   else "官方口径下补货节奏按 IPI 走。[K1]")
+        # 分片吐，和真实 provider 一样：reset 必须发在这一稿的第一片上
+        for piece in (content[:6], content[6:]):
+            yield {"type": "text", "text": piece}
+        yield {"type": "final", "content": content, "tool_calls": [], "usage": {}}
+
+
+def _web_ctx():
+    """网页/serve 的形状：defer 关掉，边生成边流式。"""
+    from ivyea_agent.agent_tools import ToolContext
+    return ToolContext(knowledge_citations=[_citation()],
+                       knowledge_retrieval_expected=True, knowledge_risk="high")
+
+
+def test_gate_rewrite_reports_answer_reset_once():
+    from ivyea_agent import agent_loop
+
+    rendered: list[str] = []
+    resets: list[str] = []
+    provider = _GateProvider()
+    out = agent_loop.run_turn_stream(
+        provider, _web_ctx(), [{"role": "user", "content": "补货怎么排"}], max_steps=3,
+        render=rendered.append, narrate=lambda _: None,
+        defer_citation_text=False, on_answer_reset=resets.append,
+    )
+
+    assert provider.calls == 2                      # 确实被门禁打回重写了一遍
+    assert resets == ["gate:citation"]              # 且只在第二稿开头作废一次
+
+    # 前端按 reset 切段后，留在气泡里的只有最后一稿 —— 一份，不是两份。
+    segments = "".join(rendered).split("库存周转要盯着补货节奏。")
+    assert len(segments) == 2                       # 第一稿在流里出现过 1 次
+    kept = "".join(rendered).split("官方口径下补货节奏按 IPI 走。")[-1]
+    assert "库存周转" not in kept                    # 作废点之后不再有旧稿内容
+    assert "[K1]" in out["text"]
+
+
+def test_tool_preamble_is_superseded_by_the_answer(ivyea_home):
+    from ivyea_agent import agent_loop
+    from ivyea_agent.agent_tools import ToolContext
+
+    class Provider:
+        def __init__(self):
+            self.calls = 0
+
+        def stream_chat(self, messages, tools=None):
+            self.calls += 1
+            if self.calls == 1:
+                yield {"type": "text", "text": "我先查一下历史结论。"}
+                yield {"type": "final", "content": "我先查一下历史结论。", "usage": {},
+                       "tool_calls": [{"id": "c1", "name": "recall", "arguments": {"query": "放量"}}]}
+                return
+            yield {"type": "text", "text": "结论：先放量再看转化。"}
+            yield {"type": "final", "content": "结论：先放量再看转化。", "tool_calls": [], "usage": {}}
+
+    resets: list[str] = []
+    agent_loop.run_turn_stream(
+        Provider(), ToolContext(), [{"role": "user", "content": "要不要放量"}], max_steps=4,
+        render=lambda _: None, narrate=lambda _: None,
+        defer_citation_text=False, on_answer_reset=resets.append,
+    )
+    assert resets == ["tool_call"]                  # 开场白让位给正式答案
+
+
+def test_render_sequence_unchanged_without_callback():
+    """CLI 路径零回归：不传 on_answer_reset 时逐字与改动前一致。"""
+    from ivyea_agent import agent_loop
+
+    def run(**extra):
+        rendered: list[str] = []
+        agent_loop.run_turn_stream(
+            _GateProvider(), _web_ctx(), [{"role": "user", "content": "补货怎么排"}],
+            max_steps=3, render=rendered.append, narrate=lambda _: None,
+            defer_citation_text=False, **extra)
+        return rendered
+
+    assert run() == run(on_answer_reset=lambda _: None)
+
+
+def test_reset_callback_failure_never_breaks_the_turn():
+    """通知失败（前端断开、序列化炸了）不许打断正在跑的轮次。"""
+    from ivyea_agent import agent_loop
+
+    def boom(_reason):
+        raise RuntimeError("client gone")
+
+    out = agent_loop.run_turn_stream(
+        _GateProvider(), _web_ctx(), [{"role": "user", "content": "补货怎么排"}],
+        max_steps=3, render=lambda _: None, narrate=lambda _: None,
+        defer_citation_text=False, on_answer_reset=boom)
+    assert "[K1]" in out["text"]
+
+
+def test_service_stream_emits_answer_reset_frame(ivyea_home):
+    """serve 侧：这条边界要真的以 `answer_reset` 事件发到 SSE 上（前端按事件名分流）。
+
+    走真实检索（inject_retrieval 默认开）—— 注意 `inject_retrieval: False` 会**清空**
+    ctx.knowledge_citations，那样引用门禁根本不会触发，这条用例也就测了个寂寞。
+    """
+    from ivyea_agent import service
+
+    events: list[tuple[str, dict]] = []
+    result = service.chat_stream(
+        {"message": "新卖家注册身份验证失败怎么办", "max_steps": 3, "persist": False},
+        lambda event, data: events.append((event, data)),
+        provider=_GateProvider(),
+    )
+
+    assert result["ok"] is True
+    resets = [d for e, d in events if e == "answer_reset"]
+    assert len(resets) == 1
+    assert resets[0]["reason"] == "gate:citation"
+    assert resets[0]["session_id"]                      # 前端要用它对上是哪一轮
+    # 顺序也要对：作废发生在两段正文之间，不能跑到 final 后面去
+    names = [e for e, _ in events]
+    assert names.index("answer_reset") < names.index("final")
+    assert names.index("token") < names.index("answer_reset")
+
+
+def test_deferred_path_also_reports_reset():
+    """defer 模式（CLI 默认）下门禁重写同样要给出边界 —— 只是 CLI 不接。"""
+    from ivyea_agent import agent_loop
+
+    resets: list[str] = []
+    rendered: list[str] = []
+    agent_loop.run_turn_stream(
+        _GateProvider(), _web_ctx(), [{"role": "user", "content": "补货怎么排"}],
+        max_steps=3, render=rendered.append, narrate=lambda _: None,
+        defer_citation_text=True, on_answer_reset=resets.append)
+    # defer 把未过门禁的草稿整段吞掉了，所以根本没有"上一稿"可作废
+    assert resets == []
+    assert "库存周转" not in "".join(rendered)


### PR DESCRIPTION
## 问题

网页端（IvyeaOps 任务台）会看到同一段正文被吐好几遍。

## 修复

分段边界处重置 answer draft：一段正文结束后不再把已发出的内容带进下一段，避免流式输出重复累积。

- `ivyea_agent/agent_loop.py`：分段边界重置 draft
- `ivyea_agent/service.py`：serve 侧跟随
- `tests/test_answer_draft_reset.py`：新增 163 行测试钉住这个契约

配套的 IvyeaOps 前端去重在 IvyeaOps 侧另有 PR —— 这边是根治，那边是防御。

## 验证

本机全量：`python -m pytest -q` → **769 passed**；`ruff check ivyea_agent` → 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)