### PR TITLE
feat: 思考流推给网页、纯 LLM 耗时，历史详情按轮分页 + 执行过程落盘

### DIFF
--- a/ivyea_agent/agent_loop.py
+++ b/ivyea_agent/agent_loop.py
@@ -516,7 +516,11 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
     render = render or (lambda s: print(s, end="", flush=True))
     render_reasoning = render_reasoning or (lambda s: None)
     cancel_check = cancel_check or (lambda: False)
-    total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "prompt_cache_hit_tokens": 0}
+    # llm_ms：**只**覆盖模型流式窗口（下面那圈 provider.stream_chat）。工具执行在窗口之外，
+    # 所以这个数回答的是"这一轮里有多少时间真的花在模型上"——一轮 20 分钟里模型只占 40 秒
+    # 和占 18 分钟，要做的优化完全不是一回事，而此前调用方只拿得到一个总时长。
+    total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "prompt_cache_hit_tokens": 0,
+                   "llm_ms": 0}
 
     # 正文的"稿"边界。发通知的时刻是**新一稿的第一个字**——在那之前谁也不知道
     # 模型还会不会再写一遍，提前发就会把还在用的那一稿误清。
@@ -563,6 +567,7 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
             )
             or (defer_citation_text and bool(getattr(ctx, "knowledge_citations", [])))
         )
+        llm_started = time.monotonic()
         for ev in provider.stream_chat(messages, tools=tool_schemas):
             if cancel_check():
                 raise KeyboardInterrupt
@@ -575,6 +580,9 @@ def run_turn_stream(provider: LLMProvider, ctx: ToolContext, messages: list,
                 render_reasoning(ev.get("text") or "")
             elif ev["type"] == "final":
                 final = ev
+        # 渲染回调（终端打印 / serve 推 SSE）落在这个窗口里，因为它们本来就是边收边发的
+        # 一部分，拆不开也不该拆——窗口量的是"模型这一步从开口到闭嘴用了多久"。
+        total_usage["llm_ms"] += int((time.monotonic() - llm_started) * 1000)
         if printed_any and not defer_text:
             render("\n")
         _accum(final.get("usage") or {})

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1262,6 +1262,15 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
             # 只累加 token、不认 final 的调用方（IvyeaOps 的报告合成）传 true：
             # 引证门会让模型带着 [K#] 把整篇重写一遍，不 defer 就会收到两份报告。
             defer_citation_text=payload.get("defer_citation_text") is True,
+            # 思考流：**必须调用方显式要**，默认一个字都不发。
+            #
+            # 不是保守，是兼容性硬约束：客户端的事件分发最后一条是"未知事件 → 当成老
+            # agent 的自由文本叙述渲染"。默认开的话，装着旧版前端的用户一升级 agent，
+            # 满屏就全是模型的思考碎片，而且他没有任何开关能关掉。
+            # 与 defer_citation_text 同一路数：新行为 opt-in，老调用方一字不变。
+            render_reasoning=(
+                (lambda t: send("reasoning", {"text": security.redact_text(str(t))}))
+                if payload.get("stream_reasoning") is True else None),
             # 一轮里正文可能被吐好几遍（工具前的开场白、门禁打回后的整篇重写）。
             # 终端叠着看没问题，网页把 token 拼进同一个气泡就成了"同一张表连出
             # 三遍"。这条事件告诉前端：前面那一稿作废，从下一个 token 重新开始。

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -46,6 +46,15 @@ _PENDING_APPROVALS: dict[str, "queue.Queue[str]"] = {}
 _APPROVALS_LOCK = threading.Lock()
 DEFAULT_APPROVAL_TIMEOUT = 600.0   # 10 分钟没人理 = 拒绝
 
+# ── 历史会话详情 ────────────────────────────────────────────────────────────
+# 一页几轮。按**轮**而不是按条：一次提问能产生几十条消息（本机实测 2 次提问 → 62 条），
+# 按条切必然把用户自己发的那句话挤出窗口。
+_DETAIL_TURNS_DEFAULT = 8
+_DETAIL_TURNS_MAX = 100
+# 详情里 tool 结果的单条上限。它从来没被界面渲染过（前端只留 user/assistant），
+# 但本机最大那个会话里它占了 278KB —— 全量拖回去只是让每次打开会话更慢。
+_DETAIL_TOOL_CONTENT_MAX = 1000
+
 
 def resolve_permission(request_id: str, choice: str) -> bool:
     """回送一个审批决策，解开阻塞中的那一步。未知/已过期的 request_id 返回 False。"""
@@ -1237,6 +1246,12 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
     def narrate(text: str) -> None:
         send("event", {"type": "event", "text": security.redact_text(str(text))})
 
+    # 本轮的执行步骤，按 call_id 收口成"每个调用只留最终态"（running → ok/error 合并，
+    # 与前端 mergeStep 同一语义）。轮次收尾时落盘 —— 此前它们只流给前端就扔了，
+    # 于是刷新之后"它刚才干了什么"一片空白。
+    turn_steps: dict[str, dict] = {}
+    turn_skills: list[dict] = []
+
     def emit(ev: dict) -> None:
         # run_turn_stream 的结构化事件通道原本只喂 CLI 的 stream-json。这里只放行
         # 步骤类事件：assistant/tool_result 的内容前端已经能从 token/final 拿到，
@@ -1244,6 +1259,10 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
         kind = str(ev.get("type") or "")
         if kind in ("step", "skill_match", "file_change"):
             send(kind, ev)
+        if kind == "step" and ev.get("id"):
+            turn_steps[str(ev["id"])] = dict(ev)
+        elif kind == "skill_match" and ev.get("skills"):
+            turn_skills.append(dict(ev))
 
     try:
         provider = provider or build_chain(model_cfg, api_key, narrate=narrate)
@@ -1283,11 +1302,18 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
         return data
 
     if payload.get("persist", True):
+        steps = list(turn_steps.values())
+        # 技能命中锚在本轮第一个 call_id 上 —— 详情按轮分页时靠它认出"这批技能属于哪一轮"。
+        # 一轮里一个工具都没调时它没有锚点，也就没有执行过程可显示，技能行随之省略。
+        anchor = steps[0].get("id") if steps else ""
+        skill_rows = ([{"anchor": anchor, "skills": turn_skills[-1].get("skills") or []}]
+                      if steps and turn_skills else [])
         sessions.append_turn(
             ctx.session_id,
             str(messages[0].get("content") or "") if messages else "",
             messages[turn_base:],
-            model=model_cfg.get("model", ""), usage={}, created=created_at)
+            model=model_cfg.get("model", ""), usage={}, created=created_at,
+            steps=steps, skill_matches=skill_rows)
     data = {
         "ok": True,
         "session_id": ctx.session_id,
@@ -1306,11 +1332,12 @@ def chat_session_list(limit: int = 20) -> dict[str, Any]:
     return {"ok": True, "sessions": [_public_session(row) for row in sessions.listing(limit=limit)]}
 
 
-def chat_session_detail(session_id: str) -> dict[str, Any]:
+def chat_session_detail(session_id: str, *, turns: int = _DETAIL_TURNS_DEFAULT,
+                        before: int | None = None) -> dict[str, Any]:
     data = sessions.load(session_id)
     if not data:
         raise FileNotFoundError(f"会话不存在：{session_id}")
-    return {"ok": True, "session": _public_session_detail(data)}
+    return {"ok": True, "session": _public_session_detail(data, turns=turns, before=before)}
 
 
 def chat_session_delete(session_id: str) -> dict[str, Any]:
@@ -1453,8 +1480,14 @@ class _Handler(BaseHTTPRequestHandler):
             return
         if parsed.path.startswith("/v1/chat/sessions/"):
             session_id = parsed.path.rsplit("/", 1)[-1]
+            # turns/before：按轮分页。不带参数 = 最后几轮，老调用方照常能用，
+            # 而且比改动前（末 30 条消息）拿到的提问只多不少。
+            before_raw = _first(qs, "before")
             try:
-                self._json(200, chat_session_detail(session_id))
+                self._json(200, chat_session_detail(
+                    session_id,
+                    turns=_int(_first(qs, "turns"), _DETAIL_TURNS_DEFAULT),
+                    before=(_int(before_raw, 0) if before_raw not in (None, "") else None)))
             except FileNotFoundError as exc:
                 self._json(404, {"ok": False, "error": str(exc)})
             return
@@ -2196,14 +2229,62 @@ def _public_session(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _public_session_detail(data: dict[str, Any]) -> dict[str, Any]:
+def _detail_message(msg: dict[str, Any]) -> dict[str, Any]:
+    """详情里的一条消息。比 live 回包多留两样东西：`tool_calls` 的 id/name 与
+    `tool_call_id` —— 它们是把落盘的执行步骤挂回对应轮次的锚点（靠 call_id 对齐，
+    不靠下标，所以压缩过、导入过的会话都不会错位）。"""
+    role = str(msg.get("role") or "")
+    content = msg.get("content")
+    if isinstance(content, list):       # 多模态：只回显文本，不吐 base64
+        texts = [str(p.get("text") or "") for p in content
+                 if isinstance(p, dict) and p.get("type") == "text"]
+        imgs = sum(1 for p in content if isinstance(p, dict) and p.get("type") == "image_url")
+        content = "\n".join(t for t in texts if t) + (f"\n[附图 {imgs} 张]" if imgs else "")
+    text = security.redact_text(str(content if content is not None else ""))
+    if role == "tool" and len(text) > _DETAIL_TOOL_CONTENT_MAX:
+        text = text[:_DETAIL_TOOL_CONTENT_MAX] + "…（已截断）"
+    row: dict[str, Any] = {"role": role, "content": text}
+    calls = msg.get("tool_calls") or []
+    if role == "assistant" and calls:
+        row["tool_calls"] = [
+            {"id": str(c.get("id") or ""),
+             "name": str((c.get("function") or {}).get("name") or c.get("name") or "")}
+            for c in calls if isinstance(c, dict)
+        ]
+    if role == "tool" and msg.get("tool_call_id"):
+        row["tool_call_id"] = str(msg.get("tool_call_id"))
+    return row
+
+
+def _public_session_detail(data: dict[str, Any], *, turns: int = _DETAIL_TURNS_DEFAULT,
+                           before: int | None = None) -> dict[str, Any]:
+    kept = transcript.strip_injected(data.get("messages") or [])
+    slices = transcript.turn_slices(kept)
+    total = len(slices)
+    end_turn = total if before is None else max(0, min(int(before), total))
+    size = max(1, min(int(turns or _DETAIL_TURNS_DEFAULT), _DETAIL_TURNS_MAX))
+    start_turn = max(0, end_turn - size)
+    picked = slices[start_turn:end_turn]
+    rows = [_detail_message(m) for a, b in picked for m in kept[a:b]
+            if m.get("role") in ("user", "assistant", "tool")]
+
+    # 只回本页涉及的步骤。锚点是 call_id：本页的 assistant 消息里出现过的那些。
+    call_ids = {c["id"] for r in rows for c in r.get("tool_calls") or [] if c.get("id")}
+    steps = [s for s in (data.get("steps") or []) if str(s.get("id") or "") in call_ids]
+    skills = [s for s in (data.get("skill_matches") or [])
+              if str(s.get("anchor") or "") in call_ids]
+
     return {
         "id": data.get("id", ""),
         "created": data.get("created"),
         "updated": data.get("updated"),
         "model": data.get("model", ""),
         "usage": data.get("usage") or {},
-        "messages": _public_messages(data.get("messages") or []),
+        "messages": rows,
+        "steps": steps,
+        "skill_matches": skills,
+        "turns": {"total": total, "from": start_turn, "to": end_turn,
+                  "has_more": start_turn > 0},
     }
 
 

--- a/ivyea_agent/sessions.py
+++ b/ivyea_agent/sessions.py
@@ -80,6 +80,12 @@ def _lock_for(sid: str) -> threading.RLock:
         return lock
 
 
+# 一条会话最多留多少步执行记录。步骤是给人复盘用的，不参与模型上下文，所以可以封顶；
+# 每条经 stream_json._slim_args 裁过，2000 条约几百 KB 量级。
+_STEPS_MAX = 2000
+_SKILL_MATCH_MAX = 200
+
+
 def save(sid: str, messages: list[dict], *, model: str = "", usage: Optional[dict] = None,
          created: Optional[float] = None) -> None:
     with _lock_for(sid):
@@ -87,10 +93,23 @@ def save(sid: str, messages: list[dict], *, model: str = "", usage: Optional[dic
 
 
 def _save(sid: str, messages: list[dict], *, model: str = "", usage: Optional[dict] = None,
-          created: Optional[float] = None) -> None:
+          created: Optional[float] = None, steps: Optional[list[dict]] = None,
+          skill_matches: Optional[list[dict]] = None) -> None:
     p = path_for(sid)
+    # steps/skill_matches 没传时**沿用盘上那份**，不能当成"清空"：`save()` 是整份覆盖
+    # 语义（CLI 每轮就这么写），它不知道也不关心步骤，但不该顺手把它们抹掉。
+    if steps is None or skill_matches is None:
+        prev = load(sid) or {}
+        if steps is None:
+            steps = list(prev.get("steps") or [])
+        if skill_matches is None:
+            skill_matches = list(prev.get("skill_matches") or [])
     data = {"id": sid, "created": created or time.time(), "updated": time.time(),
-            "model": model, "messages": messages, "usage": usage or {}}
+            "model": model, "messages": messages, "usage": usage or {},
+            # 执行过程与消息平行存放，**绝不塞进 messages 里的消息 dict**：
+            # 那些 dict 会原样回灌给模型 API，多一个自定义键就有被 provider 拒的风险。
+            "steps": list(steps)[-_STEPS_MAX:],
+            "skill_matches": list(skill_matches)[-_SKILL_MATCH_MAX:]}
     # 临时文件名带进程号和随机后缀。固定成 `<id>.json.tmp` 的话，两个**进程**同时
     # 写同一条会话（比如工作台的 serve 和一个 `ivyea chat`）会写进同一个临时文件，
     # 互相踩出半截 JSON。进程内的会话锁管不到跨进程。
@@ -111,7 +130,9 @@ def _save(sid: str, messages: list[dict], *, model: str = "", usage: Optional[di
 
 
 def append_turn(sid: str, system: str, new_messages: list[dict], *, model: str = "",
-                usage: Optional[dict] = None, created: Optional[float] = None) -> None:
+                usage: Optional[dict] = None, created: Optional[float] = None,
+                steps: Optional[list[dict]] = None,
+                skill_matches: Optional[list[dict]] = None) -> None:
     """把**这一轮新增的**消息并进磁盘上那份，而不是拿内存里的整份覆盖。
 
     为什么不能整份覆盖：一轮的流程是"开始时读全部历史 → 跑 → 结束时写回全部"。
@@ -131,8 +152,12 @@ def append_turn(sid: str, system: str, new_messages: list[dict], *, model: str =
         else:
             msgs.insert(0, {"role": "system", "content": system})
         msgs.extend(new_messages)
+        # 步骤同样只追加增量 —— 理由和消息一模一样（两个标签页并发收尾时，
+        # 整份覆盖会让先写的那一轮连人带步骤一起消失）。
         _save(sid, msgs, model=model, usage=usage,
-              created=cur.get("created") or created)
+              created=cur.get("created") or created,
+              steps=list(cur.get("steps") or []) + list(steps or []),
+              skill_matches=list(cur.get("skill_matches") or []) + list(skill_matches or []))
 
 
 def load(sid: str) -> Optional[dict[str, Any]]:

--- a/ivyea_agent/transcript.py
+++ b/ivyea_agent/transcript.py
@@ -90,6 +90,26 @@ def strip_injected(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return out
 
 
+def turn_slices(messages: list[dict[str, Any]]) -> list[tuple[int, int]]:
+    """把（已经 strip_injected 过的）消息按轮切成 [start, end) 区间。
+
+    一轮 = 一条真实的用户提问，加上它引出的全部 assistant / tool 消息，直到下一条提问。
+    历史详情按轮分页要靠它 —— 按**消息条数**分页是这次 bug 的成因：一次提问能产生几十条
+    消息，末 N 条里全是工具调用，用户自己发的那句话反而被挤出去了。
+
+    第一条用户消息之前的内容（system、导入进来的开场）归到第 0 轮里，不单独成轮 ——
+    它不是一次提问。
+    """
+    starts = [i for i, m in enumerate(messages) if m.get("role") == "user"]
+    if not starts:
+        return [(0, len(messages))] if messages else []
+    bounds = []
+    for idx, start in enumerate(starts):
+        end = starts[idx + 1] if idx + 1 < len(starts) else len(messages)
+        bounds.append((0 if idx == 0 else start, end))
+    return bounds
+
+
 def visible_turns(messages: list[dict[str, Any]]) -> int:
     """真实的用户轮数。直接数 role=user 会把门禁消息也算成一轮。"""
     return sum(1 for m in messages

--- a/tests/test_reasoning_and_llm_ms.py
+++ b/tests/test_reasoning_and_llm_ms.py
@@ -1,0 +1,133 @@
+"""思考流转发（serve → 网页）与 LLM 纯耗时（usage.llm_ms）。
+
+两件事的动机是同一个：一轮跑了 20 分钟，调用方此前只拿得到一个总时长，说不出
+这 20 分钟是模型在想、还是工具在跑，也说不出模型到底在想什么。
+
+思考流**默认不发**：客户端的事件分发把未知事件当成"老 agent 的自由文本叙述"渲染，
+默认开就等于让装着旧前端的用户一升级 agent 满屏思考碎片，且他关不掉。
+所以这里既钉"要了就得给"，也钉"没要就一个字都不许发"。
+"""
+from __future__ import annotations
+
+import time
+
+
+class _ReasoningProvider:
+    """先吐思考、再吐正文 —— deepseek-reasoner / claude / codex 的真实形状。"""
+
+    def stream_chat(self, messages, tools=None):
+        yield {"type": "reasoning", "text": "先看看库存周转"}
+        yield {"type": "text", "text": "按 IPI 排补货。"}
+        yield {"type": "final", "content": "按 IPI 排补货。", "tool_calls": [], "usage": {}}
+
+
+class _SlowModelThenToolProvider:
+    """第一步慢慢想完去调工具，第二步慢慢想完给答案。每步模型窗口 ~40ms。"""
+
+    def __init__(self):
+        self.calls = 0
+
+    def stream_chat(self, messages, tools=None):
+        self.calls += 1
+        time.sleep(0.04)
+        if self.calls == 1:
+            yield {"type": "final", "content": "", "usage": {},
+                   "tool_calls": [{"id": "c1", "name": "recall", "arguments": {"query": "库存"}}]}
+            return
+        yield {"type": "text", "text": "好了"}
+        yield {"type": "final", "content": "好了", "tool_calls": [], "usage": {}}
+
+
+def test_llm_ms_counts_the_model_window_only(monkeypatch):
+    """llm_ms 必须把工具时间排除在外 —— 否则它和总时长是同一个数，等于什么都没说。"""
+    from ivyea_agent import agent_loop
+    from ivyea_agent.agent_tools import ToolContext
+
+    def _slow_tools(*args, **kwargs):
+        time.sleep(0.3)                      # 工具执行：比两次模型窗口加起来还久
+
+    monkeypatch.setattr(agent_loop, "_dispatch_tool_calls", _slow_tools)
+
+    started = time.monotonic()
+    out = agent_loop.run_turn_stream(
+        _SlowModelThenToolProvider(), ToolContext(), [{"role": "user", "content": "hi"}],
+        max_steps=3, render=lambda _: None, narrate=lambda _: None)
+    wall_ms = (time.monotonic() - started) * 1000
+
+    llm_ms = out["usage"]["llm_ms"]
+    assert llm_ms >= 60                      # 两步模型窗口 ~80ms，留足抖动余量
+    assert llm_ms < 250                      # 300ms 的工具时间没被算进来
+    assert wall_ms > 300                     # 而这一轮真实耗时确实超过了工具那 300ms
+
+
+def test_llm_ms_is_always_present():
+    """没有工具的轮次也要有这个字段 —— 调用方不该为"有时有有时没有"写分支。"""
+    from ivyea_agent import agent_loop
+    from ivyea_agent.agent_tools import ToolContext
+
+    out = agent_loop.run_turn_stream(
+        _ReasoningProvider(), ToolContext(), [{"role": "user", "content": "hi"}],
+        render=lambda _: None, narrate=lambda _: None)
+    assert "llm_ms" in out["usage"] and out["usage"]["llm_ms"] >= 0
+
+
+def test_serve_keeps_quiet_about_thinking_unless_asked(ivyea_home):
+    """**最要紧的一条**：没显式要，SSE 上不许出现 reasoning 事件。
+
+    也不许改道跑到别的事件里去 —— 老前端把未知事件当叙述渲染，混进 event 一样刷屏。
+    """
+    from ivyea_agent import service
+
+    events: list[tuple[str, dict]] = []
+    result = service.chat_stream(
+        {"message": "补货怎么排", "max_steps": 2, "persist": False, "inject_retrieval": False},
+        lambda event, data: events.append((event, data)),
+        provider=_ReasoningProvider(),
+    )
+
+    assert result["ok"] is True
+    assert not [e for e, _ in events if e == "reasoning"]
+    assert "先看看库存周转" not in "".join(str(d) for _, d in events)
+
+
+def test_serve_streams_thinking_when_asked(ivyea_home):
+    from ivyea_agent import service
+
+    events: list[tuple[str, dict]] = []
+    result = service.chat_stream(
+        {"message": "补货怎么排", "max_steps": 2, "persist": False,
+         "inject_retrieval": False, "stream_reasoning": True},
+        lambda event, data: events.append((event, data)),
+        provider=_ReasoningProvider(),
+    )
+
+    assert result["ok"] is True
+    thinking = [d["text"] for e, d in events if e == "reasoning"]
+    assert thinking == ["先看看库存周转"]
+    # 思考不许混进正文：气泡里只能有回答
+    assert "先看看库存周转" not in result["text"]
+    names = [e for e, _ in events if e in ("reasoning", "token")]
+    assert names[0] == "reasoning"                   # 想在前、说在后
+
+
+def test_thinking_is_redacted_like_everything_else(ivyea_home):
+    """模型思考里复述了密钥同样要打码 —— 它和 narrate/token 走的是同一条链路。"""
+    from ivyea_agent import service
+
+    class _LeakyProvider:
+        def stream_chat(self, messages, tools=None):
+            yield {"type": "reasoning", "text": "用 sk-abcdefghijklmnopqrstuvwxyz 这个键"}
+            yield {"type": "text", "text": "好"}
+            yield {"type": "final", "content": "好", "tool_calls": [], "usage": {}}
+
+    events: list[tuple[str, dict]] = []
+    service.chat_stream(
+        {"message": "hi", "max_steps": 2, "persist": False,
+         "inject_retrieval": False, "stream_reasoning": True},
+        lambda event, data: events.append((event, data)),
+        provider=_LeakyProvider(),
+    )
+
+    thinking = "".join(d["text"] for e, d in events if e == "reasoning")
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in thinking
+    assert "REDACTED" in thinking

--- a/tests/test_session_detail_paging.py
+++ b/tests/test_session_detail_paging.py
@@ -1,0 +1,196 @@
+"""历史会话详情：按轮分页 + 执行步骤落盘。
+
+这两件事修的是同一个投诉："刷新之后再点开历史会话，自己发的一部分指令和整个执行
+过程都不见了"。
+
+根因不是偶发：详情此前和 live 回包共用一个投影，末尾 `rows[-30:]`。一次提问能产生
+几十条消息（本机实测 2 次提问 → 62 条，其中 31 条是 tool），工具调用把名额吃光，
+用户自己那句话被挤出窗口。本机最惨的一条会话：413 条消息、15 次提问，刷新后只剩 1 条。
+
+所以这里钉的是**按轮**分页 —— 按条切多少条都会重蹈覆辙。
+"""
+from __future__ import annotations
+
+import json
+
+from ivyea_agent import service, sessions, transcript
+
+
+def _turn(idx: int, with_tool: bool = True) -> list[dict]:
+    """一轮：提问 →（可选）调一次工具 → 回答。"""
+    rows: list[dict] = [{"role": "user", "content": f"第 {idx} 个问题"}]
+    if with_tool:
+        rows += [
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": f"call-{idx}", "type": "function",
+                             "function": {"name": "run_command", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": f"call-{idx}", "content": "x" * 5000},
+        ]
+    rows.append({"role": "assistant", "content": f"第 {idx} 个回答"})
+    return rows
+
+
+def _session(turns: int = 12) -> dict:
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(turns):
+        msgs += _turn(i)
+    steps = [{"type": "step", "id": f"call-{i}", "seq": i, "phase": "tool",
+              "name": "run_command", "status": "ok", "ms": 12, "args": {"command": "ls"}}
+             for i in range(turns)]
+    return {"id": "s", "messages": msgs, "steps": steps,
+            "skill_matches": [{"anchor": "call-3", "skills": [{"id": "k", "title": "技能"}]}]}
+
+
+def test_every_question_is_reachable_by_paging():
+    """**这条是主诉**：一页一页翻下去，12 个提问一个都不能少。"""
+    data = _session(12)
+    seen, before, pages = [], None, 0
+    while True:
+        page = service._public_session_detail(data, turns=5, before=before)
+        seen = [m["content"] for m in page["messages"] if m["role"] == "user"] + seen
+        pages += 1
+        if not page["turns"]["has_more"]:
+            break
+        before = page["turns"]["from"]
+    assert seen == [f"第 {i} 个问题" for i in range(12)]
+    assert pages == 3                                   # 5 + 5 + 2
+
+
+def test_first_page_is_the_latest_turns():
+    page = service._public_session_detail(_session(12), turns=4)
+    assert page["turns"] == {"total": 12, "from": 8, "to": 12, "has_more": True}
+    assert [m["content"] for m in page["messages"] if m["role"] == "user"] == \
+        [f"第 {i} 个问题" for i in (8, 9, 10, 11)]
+
+
+def test_gate_messages_do_not_count_as_a_turn():
+    """门禁注回的伪 user 消息不是一次提问 —— 算成一轮的话，分页就会切出空轮，
+    而且"总共几轮"这个数会比用户记得的多出一截。"""
+    msgs = [{"role": "user", "content": "真提问"},
+            {"role": "assistant", "content": "草稿"},
+            {"role": "user", "content": transcript.gate_text(transcript.VERIFY_GATE, "：补上自验证")},
+            {"role": "assistant", "content": "终稿"}]
+    page = service._public_session_detail({"id": "s", "messages": msgs})
+    assert page["turns"]["total"] == 1
+    users = [m["content"] for m in page["messages"] if m["role"] == "user"]
+    assert users == ["真提问"]
+
+
+def test_steps_come_back_with_the_turns_they_belong_to():
+    """步骤靠 call_id 挂回轮次，不靠下标 —— 压缩过、导入过的会话都不会错位。"""
+    page = service._public_session_detail(_session(12), turns=3)      # 第 9/10/11 轮
+    assert [s["id"] for s in page["steps"]] == ["call-9", "call-10", "call-11"]
+    # 技能锚在第 3 轮，不该混进这一页
+    assert page["skill_matches"] == []
+    early = service._public_session_detail(_session(12), turns=3, before=5)   # 第 2/3/4 轮
+    assert [s["anchor"] for s in early["skill_matches"]] == ["call-3"]
+
+
+def test_tool_output_is_trimmed_but_conversation_is_not():
+    """工具返回界面从来不渲染（本机最大会话里它占 278KB），截断；
+    对话正文一个字都不许动 —— 那正是用户要回看的东西。"""
+    page = service._public_session_detail(_session(3), turns=99)
+    tool_rows = [m for m in page["messages"] if m["role"] == "tool"]
+    assert tool_rows and all(len(m["content"]) < 1200 for m in tool_rows)
+    assert all(m["content"].endswith("（已截断）") for m in tool_rows)
+    assert [m["content"] for m in page["messages"] if m["role"] == "user"] == \
+        ["第 0 个问题", "第 1 个问题", "第 2 个问题"]
+
+
+def test_call_ids_are_exposed_so_the_ui_can_join_steps():
+    page = service._public_session_detail(_session(2), turns=99)
+    assistant_calls = [m for m in page["messages"] if m.get("tool_calls")]
+    assert [c["id"] for m in assistant_calls for c in m["tool_calls"]] == ["call-0", "call-1"]
+    assert [c["name"] for m in assistant_calls for c in m["tool_calls"]] == ["run_command"] * 2
+    assert [m["tool_call_id"] for m in page["messages"] if m["role"] == "tool"] == \
+        ["call-0", "call-1"]
+
+
+def test_sessions_without_steps_still_open():
+    """改动之前落盘的会话没有 steps 字段 —— 打开时只是没有执行过程，不能炸。"""
+    page = service._public_session_detail({"id": "s", "messages": _turn(0)})
+    assert page["steps"] == [] and page["skill_matches"] == []
+    assert page["turns"]["total"] == 1
+
+
+def test_turnless_session_does_not_blow_up():
+    assert service._public_session_detail({"id": "s", "messages": []})["turns"]["total"] == 0
+
+
+# ── 落盘 ────────────────────────────────────────────────────────────────────
+
+def test_steps_are_appended_not_overwritten(ivyea_home):
+    """并发收尾时整份覆盖会让先写的那一轮消失 —— 消息早就是追加语义，步骤同理。"""
+    sid = sessions.new_id()
+    sessions.append_turn(sid, "sys", _turn(0), steps=[{"id": "call-0", "status": "ok"}])
+    sessions.append_turn(sid, "sys", _turn(1), steps=[{"id": "call-1", "status": "ok"}])
+    got = sessions.load(sid)
+    assert [s["id"] for s in got["steps"]] == ["call-0", "call-1"]
+
+
+def test_plain_save_keeps_the_steps(ivyea_home):
+    """`save()` 是整份覆盖语义（CLI 每轮就这么写），它不认识步骤，
+    但不该顺手把已经落盘的执行过程抹掉。"""
+    sid = sessions.new_id()
+    sessions.append_turn(sid, "sys", _turn(0), steps=[{"id": "call-0", "status": "ok"}])
+    sessions.save(sid, sessions.load(sid)["messages"] + _turn(1))
+    assert [s["id"] for s in sessions.load(sid)["steps"]] == ["call-0"]
+
+
+def test_step_history_is_capped(ivyea_home):
+    """长会话不能让步骤数组无限长下去。"""
+    sid = sessions.new_id()
+    sessions.append_turn(sid, "sys", _turn(0),
+                         steps=[{"id": f"c{i}"} for i in range(sessions._STEPS_MAX + 50)])
+    kept = sessions.load(sid)["steps"]
+    assert len(kept) == sessions._STEPS_MAX
+    assert kept[-1]["id"] == f"c{sessions._STEPS_MAX + 49}"      # 留的是最近的
+
+
+def test_persisted_session_is_still_valid_json_for_the_model(ivyea_home):
+    """步骤必须存在 messages **之外**：messages 里的 dict 会原样回灌给模型 API，
+    多一个自定义键就有被 provider 拒的风险。"""
+    sid = sessions.new_id()
+    sessions.append_turn(sid, "sys", _turn(0), steps=[{"id": "call-0"}])
+    raw = json.loads((sessions.path_for(sid)).read_text(encoding="utf-8"))
+    assert "steps" in raw
+    allowed = {"role", "content", "tool_calls", "tool_call_id", "name"}
+    for msg in raw["messages"]:
+        assert set(msg) <= allowed, f"消息里混进了自定义键：{set(msg) - allowed}"
+
+
+def test_a_real_turn_persists_its_execution_steps(ivyea_home):
+    """端到端：跑一轮带工具的对话，步骤要真的落盘、并能按轮取回来。
+
+    这条才是"刷新之后执行过程还在"的真凭据 —— 上面那些用例喂的是手搓数据。
+    """
+    class _ToolThenDone:
+        def __init__(self):
+            self.calls = 0
+
+        def stream_chat(self, messages, tools=None):
+            self.calls += 1
+            if self.calls == 1:
+                yield {"type": "final", "content": "", "usage": {},
+                       "tool_calls": [{"id": "c1", "name": "list_dir", "arguments": {"path": "."}}]}
+                return
+            yield {"type": "text", "text": "看完了"}
+            yield {"type": "final", "content": "看完了", "tool_calls": [], "usage": {}}
+
+    events: list[tuple[str, dict]] = []
+    out = service.chat_stream(
+        {"message": "看一下目录", "max_steps": 3, "inject_retrieval": False},
+        lambda ev, data: events.append((ev, data)),
+        provider=_ToolThenDone(),
+    )
+    sid = out["session_id"]
+
+    stored = sessions.load(sid)
+    assert [s["name"] for s in stored["steps"]] == ["list_dir"]
+    # 只留最终态：一次调用发了 running 和 ok 两条事件，落盘不该留两份
+    assert stored["steps"][0]["status"] == "ok"
+    assert sum(1 for e, _ in events if e == "step") >= 2
+
+    detail = service.chat_session_detail(sid)["session"]
+    assert [s["name"] for s in detail["steps"]] == ["list_dir"]
+    assert [m["content"] for m in detail["messages"] if m["role"] == "user"] == ["看一下目录"]


### PR DESCRIPTION
两批改动，都是为 IvyeaOps 任务台的一次体验整改服务的。

## 一、思考流 + 纯 LLM 耗时

网页端此前从来收不到"模型在想什么"——`run_turn_stream` 早就有 `render_reasoning`，
但 `serve` 调它时一个参数都没传，思考流只喂了终端。

- `usage.llm_ms`：只覆盖 `provider.stream_chat` 那圈窗口，工具执行在窗口之外，
  所以"总时长 − llm_ms"就是工具花掉的时间。此前调用方只拿得到一个总时长，
  说不出一轮 20 分钟是模型在想还是工具在跑。
- `chat_stream` 新增 `stream_reasoning` 开关（**默认关**）。默认开的话，装着旧版前端的
  用户一升级 agent，满屏就全是思考碎片且关不掉 —— 客户端的事件分发把未知事件当成
  "老 agent 的自由文本叙述"渲染。与 `defer_citation_text` 同一路数：新行为 opt-in。

## 二、历史会话：提问不再被截掉，执行过程能复原

用户投诉"稍微长一点的会话，刷新后再点开，自己发的一部分指令和执行过程全看不到"。
查本机真实数据，是两个独立原因：

1. `_public_messages` 结尾 `rows[-30:]`。一次提问会产生几十条消息（本机实测 2 次提问
   → 62 条，31 条是 tool），提问被挤出窗口。**413 条消息 / 15 次提问的会话刷新后只剩
   1 条提问**，另一条 6 次提问的剩 0 条。改成按**轮**分页
   （`?turns=N&before=<turn_index>`），轮边界在 `strip_injected` 之后按 `role=user` 切。
   按条分页取多少条都会重蹈覆辙。
2. 执行过程只活在 SSE 流里。现在按 call_id 收口成最终态，随轮次 append 进会话文件。
   - 不靠字符串猜状态（`ToolResult.ok` 没落盘，而 `dispatch_result` 明令反对靠文本猜）
   - 不塞进 messages 里的消息 dict（那些会原样回灌给模型 API），存成平行数组
   - 关联靠 call_id 不靠下标（压缩/导入会让下标错位，且不会报错）

## 验证

- 全量 **787 passed**（新增 18 项），`ruff` 干净
- 真实主脑 deepseek-v4-pro：不带开关 0 条 reasoning，带开关 34 条；llm_ms 8.4s / 整轮 8.5s
- 本机老会话（413 条）翻 2 页收回全部 15 条提问；新发一轮带工具的任务，直播
  `list_dir/glob/glob` 三步，走"刷新"那条路读回来名称/状态/耗时完全一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)