### PR TITLE
视觉三档降级链：主脑没视觉不再等于功能死掉

### DIFF
--- a/docs/使用与操作文档.md
+++ b/docs/使用与操作文档.md
@@ -570,7 +570,44 @@ ivyea eval
 - **用户 Skill**：`skill create/audit/status/export-lock` 支持在 `~/.ivyea/skills/` 下创建个人 skill，审计触发词、正文和关联知识卡，查看用户覆盖/版本差异，并导出当前生效 skill lockfile。
 - **生命周期管理**：`self status/backup/upgrade/uninstall` 识别安装方式、备份用户数据、输出升级/卸载计划；真实执行需要 `--execute` 并经过审批。
 - **通用视觉**：`vision` 面向截图、UI、报表等通用视觉任务；`image vision` 继续作为 Listing 图片专用入口。默认只生成请求包，显式 `--call` 才会调用外部多模态模型。
-- **图片视觉诊断**：`image audit` 先做本地资产预检查，并可导出多模态大模型审核 prompt；`image ocr` 可选调用本机 tesseract 识别图片文字；`image vision` 默认生成 OpenAI/Claude/Gemini 请求包，显式 `--call` 时才真实调用外部多模态 API。
+- **图片视觉诊断**：`image audit` 先做本地资产预检查，并可导出多模态大模型审核 prompt；`image ocr` 识别图片文字（RapidOCR 优先，缺失时退 tesseract）；`image vision` 默认生成 OpenAI/Claude/Gemini 请求包，显式 `--call` 时才真实调用外部多模态 API。
+
+### 带图对话的三档降级链
+
+给对话附图（`@图片路径`，或 IvyeaOps 网页上传）时，Ivyea **不要求主脑支持图片**。
+它按下面三档自动降级，并在每轮明确告诉你走的是哪一档：
+
+| 档 | 触发条件 | 实际行为 | 能做什么 |
+|---|---|---|---|
+| T1 主脑直读 | 当前主脑模型自带视觉（gpt-4o / claude / gemini / *-vl 等） | 图片直接进主脑上下文 | 全部 |
+| T2 视觉旁路 | 主脑不支持图片，但配了视觉模型 | 由视觉模型代读成文字，回灌主脑 | 全部 |
+| T3 本地量化 | 两者都没有 | 本地 CV + OCR 把图片量化成读数，回灌主脑 | 可测量的部分 |
+
+T3 具体产出：尺寸/比例/分辨率、白底合规判定、主体占比与居中偏移、是否触边、
+k-means 主色板、高频区（疑似文字）占比、感知哈希查重、OCR 文本与文字版面分布。
+**全程本机运行，图片不出网。** 注入主脑的文本自带约束，明确要求模型区分"读数"与
+"推断"，答不了的问题必须直说需要视觉模型——所以 T3 不会拿读数编造画面内容。
+
+T3 做不到的是语义类判断：这是什么产品、版式意图、审美好坏、有没有穿帮。
+需要这些就配一个视觉模型升到 T2。
+
+配置 T2 的视觉模型（三选一）：
+
+```bash
+# 1) 完整视觉槽（推荐；自建网关/私有模型也用这个）
+ivyea config set vision_slot '{"provider":"siliconflow","model":"Qwen/Qwen3-VL-30B-A3B-Instruct","base_url":"https://api.siliconflow.cn/v1","api_key":"sk-..."}'
+
+# 2) 指定 provider 或模型，key 走环境变量
+ivyea config set vision_model gemini
+
+# 3) 什么都不配：只要任一 provider 配了 key 且目录里有视觉模型，会自动选中
+```
+
+IvyeaOps 用户不需要在这里配——在「系统配置 → AI 服务 → 视觉模型」配一次，
+会自动下推给 agent，网页和 CLI 共用同一个视觉模型。
+
+模型名判不准时（自建网关常见），用 `ivyea config set vision_capable_override true|false|auto`
+手动覆盖"主脑是否支持图片"的判定。
 - **运行时间线**：`trace` 记录工具调用、耗时、失败，Scorecard 会汇总。
 - **业务 Eval**：`ivyea eval` 固化广告决策 golden、知识召回、skill 召回和安全脱敏，避免迭代后质量退化。
 

--- a/docs/使用与操作文档.md
+++ b/docs/使用与操作文档.md
@@ -570,7 +570,7 @@ ivyea eval
 - **用户 Skill**：`skill create/audit/status/export-lock` 支持在 `~/.ivyea/skills/` 下创建个人 skill，审计触发词、正文和关联知识卡，查看用户覆盖/版本差异，并导出当前生效 skill lockfile。
 - **生命周期管理**：`self status/backup/upgrade/uninstall` 识别安装方式、备份用户数据、输出升级/卸载计划；真实执行需要 `--execute` 并经过审批。
 - **通用视觉**：`vision` 面向截图、UI、报表等通用视觉任务；`image vision` 继续作为 Listing 图片专用入口。默认只生成请求包，显式 `--call` 才会调用外部多模态模型。
-- **图片视觉诊断**：`image audit` 先做本地资产预检查，并可导出多模态大模型审核 prompt；`image ocr` 识别图片文字（RapidOCR 优先，缺失时退 tesseract）；`image vision` 默认生成 OpenAI/Claude/Gemini 请求包，显式 `--call` 时才真实调用外部多模态 API。
+- **图片视觉诊断**：`image audit` 先做本地资产预检查，并可导出多模态大模型审核 prompt；`image ocr` 识别图片文字（RapidOCR 优先，缺失时退 tesseract）；`image local` 跑本地 CV+OCR 量化并可用 `--prompt` 看到注入主脑的原文（就是下面 T3 那一档用的东西，纯本机、图片不出网）；`image vision` 默认生成 OpenAI/Claude/Gemini 请求包，显式 `--call` 时才真实调用外部多模态 API。
 
 ### 带图对话的三档降级链
 

--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"

--- a/ivyea_agent/agent_tools.py
+++ b/ivyea_agent/agent_tools.py
@@ -71,6 +71,11 @@ class ToolContext:
     knowledge_retrieval_expected: bool = False                              # 命中亚马逊检索路由
     knowledge_risk: str = "none"                                           # none/low/medium/high
     knowledge_query: str = ""
+    # 本轮带图请求实际走了视觉三档中的哪一档（见 vision.route_images）。
+    # 必须一路回传到前端/IvyeaOps：降级本身不是问题，**降级了却不说**才是——
+    # 此前正是因为没人知道降级发生过，Listing 的图片分析静默空转了很久。
+    vision_tier: dict[str, Any] = field(default_factory=dict)
+    vision_notes: list[str] = field(default_factory=list)
 
 
 # OpenAI function-calling schema

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -1967,7 +1967,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         if _mention_imgs:
             narrate(ui.message("muted", "已引用图片: " + ", ".join(os.path.basename(p) for p in _mention_imgs)))
             from . import vision as _vision_mod   # 主脑无视觉时 sidecar 代读、文本回灌
-            user_content, _mention_imgs = _vision_mod.route_images(
+            user_content, _mention_imgs, _vision_tier = _vision_mod.route_images(
                 user_content, _mention_imgs, cfg.get_model_config(), narrate)
         if scope_note:
             user_content += "\n\n" + scope_note
@@ -2143,7 +2143,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
             if _mention_imgs:
                 print(ui.message("muted", "已引用图片: " + ", ".join(os.path.basename(p) for p in _mention_imgs)))
                 from . import vision as _vision_mod   # 主脑无视觉时 sidecar 代读、文本回灌
-                user_content, _mention_imgs = _vision_mod.route_images(
+                user_content, _mention_imgs, _vision_tier = _vision_mod.route_images(
                     user_content, _mention_imgs, cfg.get_model_config(), print)
             if scope_note:
                 user_content += "\n\n" + scope_note

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -3338,7 +3338,18 @@ def _cmd_policy(args: argparse.Namespace) -> int:
 
 
 def _cmd_image(args: argparse.Namespace) -> int:
-    from . import image_audit, ocr, vision
+    from . import image_audit, local_vision, ocr, vision
+    if args.action == "local":
+        # 让用户能直接看到 T3 到底"读"到了什么。没有这个出口时，本地视觉是个
+        # 只在带图对话里间接生效的黑盒——降级结果对不对没法自己核。
+        result = local_vision.analyze(args.paths or [], recursive=not args.no_recursive,
+                                      max_images=args.max_images)
+        text = local_vision.render(result)
+        if args.prompt:
+            text += "\n## 注入主脑的文本\n\n" + local_vision.render_for_text_model(
+                result, question=args.context or "") + "\n"
+        print(text)
+        return 0
     if args.action == "ocr":
         print(ocr.render(ocr.run(args.paths or [], lang=args.lang or "eng", recursive=not args.no_recursive)))
         return 0
@@ -3943,8 +3954,9 @@ def build_parser() -> argparse.ArgumentParser:
     pvis.add_argument("--timeout", type=float, default=120.0)
     pvis.set_defaults(func=_cmd_vision)
 
-    pimg = sub.add_parser("image", help="Listing 图片资产诊断：audit / ocr / vision")
-    pimg.add_argument("action", choices=["audit", "ocr", "vision"])
+    pimg = sub.add_parser("image", help="Listing 图片资产诊断：audit / ocr / vision / local")
+    pimg.add_argument("action", choices=["audit", "ocr", "vision", "local"],
+                      help="local = 本地 CV+OCR 量化（视觉降级链 T3 用的就是它，纯本机、图片不出网）")
     pimg.add_argument("paths", nargs="+", help="图片文件或目录")
     pimg.add_argument("--no-recursive", action="store_true", help="目录扫描不递归")
     pimg.add_argument("--prompt", action="store_true", help="输出多模态大模型审核 prompt")

--- a/ivyea_agent/local_vision.py
+++ b/ivyea_agent/local_vision.py
@@ -1,0 +1,476 @@
+"""T3 本地视觉：没有任何视觉模型时，把"看图"降级成"量图"。
+
+**为什么要有它**：主脑常年是 DeepSeek 这类纯文本模型，用户又不一定配得起第二个
+视觉模型。此前这种情况下带图请求直接 `main_brain_no_vision` 报错，Listing 的
+图片分析整块跳过——功能不是降级，是死掉。
+
+**思路**（方案 D）：视觉识别的语义部分（"这是个什么产品"）确实非多模态模型不可，
+但 Listing 真正在用的视觉判断里有很大一块是**可测量的**：主图白底合规、产品占比、
+比例、分辨率、配色、文字覆盖率、图上写了什么字。这些用确定性 CV + OCR 就能拿到
+硬数字，渲染成结构化描述文本后，纯文本主脑照样能做复核、判合规、写修改建议。
+
+于是这里只做两件事：`analyze()` 出指标，`render_for_text_model()` 把指标写成给
+文本模型读的段落。**不做**语义推断——不猜产品品类、不编版式意图，那是 T1/T2 的活。
+
+依赖只有 Pillow + numpy（numpy 本来就是硬依赖）。OCR 走 `ocr.py` 的引擎调度，
+拿不到 OCR 也能出全部几何/色彩指标，绝不因为缺 OCR 就整体失败。
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+from . import image_audit
+
+# 判"接近纯白"的阈值。亚马逊主图要求纯白 RGB(255,255,255)，但 JPEG 压缩和
+# 相机白平衡会让实际像素落在 250 上下，卡死 255 会把合规图全判成不合规。
+WHITE_MIN = 246
+# 主体掩膜：与背景色的通道差超过这个值才算前景。太小会把 JPEG 噪点当主体
+# （实测纯白底图会"检出"占比 3% 的假主体），太大会吃掉浅色产品的边缘。
+FOREGROUND_DELTA = 18
+# 分析前统一缩到这个长边。指标全是比例量，缩图不影响结论，但能把 4000px 大图的
+# 耗时从秒级压到毫秒级——套图动辄七八张，这个差别是用户能感知到的。
+WORK_SIZE = 512
+# 文字热区网格。8×8 在 512px 工作图上每格 64px，正好是电商图一行标题的量级。
+TEXT_GRID = 8
+
+
+def available() -> tuple[bool, str]:
+    """本地 CV 能不能跑。缺 Pillow 时明确说，不要在调用点炸出 ImportError。"""
+    try:
+        from PIL import Image  # noqa: F401
+    except Exception as e:  # noqa: BLE001
+        return False, f"缺少 Pillow，本地视觉不可用：{e}"
+    try:
+        import numpy  # noqa: F401
+    except Exception as e:  # noqa: BLE001
+        return False, f"缺少 numpy，本地视觉不可用：{e}"
+    return True, "Pillow + numpy"
+
+
+def _load_rgb(path: str):
+    """读成 RGB 工作图 + alpha 通道（没有 alpha 回 None）。
+
+    统一转 RGB 是必须的：调色板 PNG（mode="P"）和灰度图直接取 array 会是 2 维，
+    后面所有按 (h, w, 3) 写的运算会静默错位。
+    """
+    from PIL import Image
+    import numpy as np
+
+    with Image.open(path) as im:
+        im.load()
+        alpha = None
+        if im.mode in ("RGBA", "LA") or (im.mode == "P" and "transparency" in im.info):
+            rgba = im.convert("RGBA")
+            rgba.thumbnail((WORK_SIZE, WORK_SIZE), Image.LANCZOS)
+            arr = np.asarray(rgba, dtype=np.uint8)
+            return arr[:, :, :3].copy(), arr[:, :, 3].copy()
+        rgb = im.convert("RGB")
+        rgb.thumbnail((WORK_SIZE, WORK_SIZE), Image.LANCZOS)
+        return np.asarray(rgb, dtype=np.uint8).copy(), alpha
+
+
+def _border_stats(rgb) -> dict[str, Any]:
+    """边框采样：判背景色和白底合规。
+
+    只采**边框带**而不是四个角：角点会被圆角/水印/角标骗过去，而边框带对
+    "产品顶到边"这种真问题反而更敏感。
+    """
+    import numpy as np
+
+    h, w = rgb.shape[:2]
+    band = max(2, min(h, w) // 25)
+    strips = [rgb[:band, :, :], rgb[-band:, :, :], rgb[:, :band, :], rgb[:, -band:, :]]
+    border = np.concatenate([s.reshape(-1, 3) for s in strips], axis=0)
+    white_mask = np.all(border >= WHITE_MIN, axis=1)
+    return {
+        "border_mean_rgb": [int(v) for v in border.mean(axis=0).round()],
+        "border_median_rgb": [int(v) for v in np.median(border, axis=0).round()],
+        "white_border_ratio": round(float(white_mask.mean()), 4),
+    }
+
+
+def _foreground(rgb, alpha, bg_rgb) -> dict[str, Any]:
+    """主体掩膜 → bbox / 占比 / 居中偏移。
+
+    有 alpha 通道时直接用它当掩膜——那是设计稿导出的**真**主体边界，比任何颜色
+    阈值都准。没有才退回"与背景色的差异"。
+    """
+    import numpy as np
+
+    h, w = rgb.shape[:2]
+    if alpha is not None and alpha.min() < 250:
+        mask = alpha > 32
+        source = "alpha"
+    else:
+        diff = np.abs(rgb.astype(np.int16) - np.asarray(bg_rgb, dtype=np.int16))
+        mask = diff.max(axis=2) > FOREGROUND_DELTA
+        source = "color_delta"
+
+    coverage = float(mask.mean())
+    if not mask.any():
+        return {"mask_source": source, "coverage_ratio": 0.0, "bbox": None,
+                "center_offset_x": None, "center_offset_y": None, "touches_edge": False}
+
+    rows = np.where(mask.any(axis=1))[0]
+    cols = np.where(mask.any(axis=0))[0]
+    top, bottom = int(rows[0]), int(rows[-1])
+    left, right = int(cols[0]), int(cols[-1])
+    cx = (left + right) / 2.0
+    cy = (top + bottom) / 2.0
+    return {
+        "mask_source": source,
+        # 占比按**掩膜像素数**算，不是 bbox 面积——L 形/镂空产品的 bbox 会
+        # 严重高估占比，而卖家真正关心的是"画面被产品填了多少"。
+        "coverage_ratio": round(coverage, 4),
+        "bbox_ratio": [round(left / w, 4), round(top / h, 4),
+                       round((right + 1) / w, 4), round((bottom + 1) / h, 4)],
+        "bbox_area_ratio": round(((right - left + 1) * (bottom - top + 1)) / float(w * h), 4),
+        "center_offset_x": round((cx - w / 2.0) / (w / 2.0), 4),
+        "center_offset_y": round((cy - h / 2.0) / (h / 2.0), 4),
+        "touches_edge": bool(top == 0 or left == 0 or bottom == h - 1 or right == w - 1),
+    }
+
+
+def _palette(rgb, k: int = 5, iters: int = 12) -> list[dict[str, Any]]:
+    """主色板：numpy 手写 k-means。
+
+    不引 sklearn/scipy——为了 5 个色号拖一个几十 MB 的科学计算栈不划算，而
+    k-means 在 512px 缩图上就是十几行矩阵运算。
+
+    **播种用确定性最远点（k-means++ 的去随机版），不能用亮度分位数**：电商图
+    绝大多数是白底，像素分布极度偏斜，按亮度分位取初始质心会让 5 个质心全落在
+    白色附近，最后塌成 "#FFFFFF 100%" 一个色——实测就是这么塌的，而产品配色
+    恰恰是这个色板唯一有价值的输出。最远点播种保证每个质心落在不同色簇上，
+    且从全局均值起步，同一张图每次跑给同一组色号（prompt 不能每次都抖）。
+    """
+    import numpy as np
+
+    pixels = rgb.reshape(-1, 3).astype(np.float32)
+    if len(pixels) > 20000:
+        pixels = pixels[:: max(1, len(pixels) // 20000)]
+    if len(pixels) < k:
+        k = max(1, len(pixels))
+
+    first = pixels[np.argmin(((pixels - pixels.mean(axis=0)) ** 2).sum(axis=1))]
+    centers = [first]
+    dist = ((pixels - first) ** 2).sum(axis=1)
+    for _ in range(k - 1):
+        nxt = pixels[int(dist.argmax())]
+        centers.append(nxt)
+        dist = np.minimum(dist, ((pixels - nxt) ** 2).sum(axis=1))
+    centers = np.stack(centers)
+
+    labels = np.zeros(len(pixels), dtype=np.int64)
+    for _ in range(iters):
+        d = ((pixels[:, None, :] - centers[None, :, :]) ** 2).sum(axis=2)
+        new_labels = d.argmin(axis=1)
+        if np.array_equal(new_labels, labels):
+            break
+        labels = new_labels
+        for i in range(k):
+            hit = pixels[labels == i]
+            if len(hit):
+                centers[i] = hit.mean(axis=0)
+
+    out = []
+    for i in range(k):
+        share = float((labels == i).mean())
+        if share <= 0:
+            continue
+        r, g, b = (int(round(v)) for v in centers[i])
+        out.append({"hex": f"#{r:02X}{g:02X}{b:02X}", "rgb": [r, g, b], "share": round(share, 4)})
+    return sorted(out, key=lambda c: c["share"], reverse=True)
+
+
+def _text_density(rgb) -> dict[str, Any]:
+    """文字/图形密集区估计：Sobel 梯度能量分块统计。
+
+    这是**估计**不是识别——高频区可能是文字，也可能是产品纹理，所以对外的字段名
+    和渲染文案都要说"高频区/疑似文字"，不能说"文字覆盖 X%"。真要读字看 OCR 那段。
+    """
+    import numpy as np
+
+    gray = rgb.astype(np.float32) @ np.array([0.299, 0.587, 0.114], dtype=np.float32)
+    gx = np.abs(np.diff(gray, axis=1, prepend=gray[:, :1]))
+    gy = np.abs(np.diff(gray, axis=0, prepend=gray[:1, :]))
+    energy = gx + gy
+    thresh = max(24.0, float(np.percentile(energy, 92)))
+    busy = energy > thresh
+
+    h, w = busy.shape
+    grid = []
+    for r in range(TEXT_GRID):
+        row = []
+        for c in range(TEXT_GRID):
+            cell = busy[r * h // TEXT_GRID:(r + 1) * h // TEXT_GRID,
+                        c * w // TEXT_GRID:(c + 1) * w // TEXT_GRID]
+            row.append(round(float(cell.mean()), 3) if cell.size else 0.0)
+        grid.append(row)
+    return {"busy_ratio": round(float(busy.mean()), 4), "grid": grid}
+
+
+def _dhash(rgb) -> str:
+    """感知哈希（dHash 64bit），用于整套图查重 / 与竞品图比相似度。"""
+    from PIL import Image
+    import numpy as np
+
+    img = Image.fromarray(rgb).convert("L").resize((9, 8), Image.LANCZOS)
+    arr = np.asarray(img, dtype=np.int16)
+    bits = (arr[:, 1:] > arr[:, :-1]).flatten()
+    value = 0
+    for bit in bits:
+        value = (value << 1) | int(bit)
+    return f"{value:016x}"
+
+
+def hamming(a: str, b: str) -> int:
+    """两个 dhash 的汉明距离。<=5 基本可以认为是同一张图的不同压缩/缩放版本。"""
+    try:
+        return bin(int(a, 16) ^ int(b, 16)).count("1")
+    except (TypeError, ValueError):
+        return 64
+
+
+def _layout_from_ocr(boxes: list[dict[str, Any]], w: int, h: int) -> dict[str, Any]:
+    """OCR 文本块坐标 → 版面骨架（上/中/下 × 左/中/右 的文字分布）。
+
+    只有 OCR 给出**带坐标**的结果时才有这一段；tesseract 的纯文本模式没有坐标，
+    这时返回空，渲染时就不提版面，别拿没有的东西编。
+    """
+    if not boxes or not w or not h:
+        return {}
+    bands = {"top": 0.0, "middle": 0.0, "bottom": 0.0}
+    cols = {"left": 0.0, "center": 0.0, "right": 0.0}
+    for box in boxes:
+        x0, y0, x1, y1 = box.get("bbox") or (0, 0, 0, 0)
+        area = max(0.0, (x1 - x0)) * max(0.0, (y1 - y0)) / float(w * h)
+        cy = (y0 + y1) / 2.0 / h
+        cx = (x0 + x1) / 2.0 / w
+        bands["top" if cy < 1 / 3 else "middle" if cy < 2 / 3 else "bottom"] += area
+        cols["left" if cx < 1 / 3 else "center" if cx < 2 / 3 else "right"] += area
+    total = sum(bands.values())
+    return {
+        "text_area_ratio": round(total, 4),
+        "vertical": {k: round(v, 4) for k, v in bands.items()},
+        "horizontal": {k: round(v, 4) for k, v in cols.items()},
+        "dominant_band": max(bands, key=lambda k: bands[k]) if total > 0 else "",
+    }
+
+
+def analyze_one(path: str, meta: dict[str, Any], ocr_row: dict[str, Any] | None = None) -> dict[str, Any]:
+    """单张图的全部本地指标。任何一步失败都只影响该图，不炸整批。"""
+    out: dict[str, Any] = {
+        "path": path,
+        "name": meta.get("name") or Path(path).name,
+        "width": meta.get("width") or 0,
+        "height": meta.get("height") or 0,
+        "aspect": meta.get("aspect"),
+        "bytes": meta.get("bytes") or 0,
+        "role": meta.get("role") or "unknown",
+    }
+    try:
+        rgb, alpha = _load_rgb(path)
+    except Exception as e:  # noqa: BLE001
+        out["error"] = f"读取失败：{e}"
+        return out
+
+    border = _border_stats(rgb)
+    out.update(border)
+    out["has_alpha"] = alpha is not None
+    out["is_white_background"] = border["white_border_ratio"] >= 0.9
+    out["foreground"] = _foreground(rgb, alpha, border["border_median_rgb"])
+    out["palette"] = _palette(rgb)
+    out["texture"] = _text_density(rgb)
+    out["dhash"] = _dhash(rgb)
+
+    if ocr_row and ocr_row.get("ok"):
+        out["ocr_text"] = ocr_row.get("text") or ""
+        boxes = ocr_row.get("boxes") or []
+        if boxes:
+            layout = _layout_from_ocr(boxes, ocr_row.get("image_width") or 0,
+                                      ocr_row.get("image_height") or 0)
+            if layout:
+                out["layout"] = layout
+    return out
+
+
+def analyze(paths: list[str], *, recursive: bool = True, with_ocr: bool = True,
+            max_images: int = 12) -> dict[str, Any]:
+    """整批分析。返回 {available, engine, ocr_engine, images, duplicates, risks}。"""
+    ok, detail = available()
+    metas = image_audit.scan(paths, recursive=recursive)[:max_images]
+    if not ok:
+        return {"available": False, "engine": detail, "ocr_engine": "",
+                "images": [], "duplicates": [], "risks": []}
+
+    ocr_rows: dict[str, dict[str, Any]] = {}
+    ocr_engine = ""
+    if with_ocr and metas:
+        from . import ocr as ocr_mod
+        try:
+            got = ocr_mod.run([m["path"] for m in metas], recursive=False)
+            ocr_engine = str(got.get("engine") or "")
+            for row in got.get("results") or []:
+                ocr_rows[str(row.get("path"))] = row
+        except Exception:  # noqa: BLE001 — OCR 是增强项，坏了不许拖垮几何指标
+            ocr_engine = ""
+
+    images = [analyze_one(m["path"], m, ocr_rows.get(m["path"])) for m in metas]
+
+    # 套图查重：卖家常把同一张图重复上传或只改了尺寸，这在本地就能查出来。
+    duplicates = []
+    for i in range(len(images)):
+        for j in range(i + 1, len(images)):
+            a, b = images[i].get("dhash"), images[j].get("dhash")
+            if not a or not b:
+                continue
+            dist = hamming(a, b)
+            if dist <= 5:
+                duplicates.append({"a": images[i]["name"], "b": images[j]["name"], "distance": dist})
+
+    return {
+        "available": True,
+        "engine": detail,
+        "ocr_engine": ocr_engine,
+        "images": images,
+        "duplicates": duplicates,
+        "risks": _risks(images, duplicates),
+    }
+
+
+def _risks(images: list[dict[str, Any]], duplicates: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """只报**度量能证实**的问题。审美、卖点、版式意图一概不碰。"""
+    risks: list[dict[str, str]] = []
+    for img in images:
+        name = img.get("name", "?")
+        if img.get("error"):
+            risks.append({"level": "medium", "area": "read", "reason": f"{name} {img['error']}"})
+            continue
+        w, h = img.get("width") or 0, img.get("height") or 0
+        if w and h and (w < 1000 or h < 1000):
+            risks.append({"level": "medium", "area": "resolution",
+                          "reason": f"{name} {w}x{h} 低于亚马逊建议的 1000px 缩放门槛。"})
+        fg = img.get("foreground") or {}
+        cov = fg.get("coverage_ratio")
+        if img.get("role") == "main":
+            if not img.get("is_white_background"):
+                risks.append({"level": "high", "area": "main_white_bg",
+                              "reason": f"{name} 边框白底占比仅 {img.get('white_border_ratio')}，主图白底可能不合规。"})
+            if isinstance(cov, float) and cov < 0.6:
+                risks.append({"level": "medium", "area": "main_fill",
+                              "reason": f"{name} 主体占比 {cov:.0%}，低于主图建议的 85%，产品在缩略图里会偏小。"})
+        if fg.get("touches_edge") and img.get("role") == "main":
+            risks.append({"level": "medium", "area": "main_bleed",
+                          "reason": f"{name} 主体触到画布边缘，主图要求四周留白。"})
+        offx, offy = fg.get("center_offset_x"), fg.get("center_offset_y")
+        if isinstance(offx, float) and isinstance(offy, float) and math.hypot(offx, offy) > 0.25:
+            risks.append({"level": "info", "area": "centering",
+                          "reason": f"{name} 主体明显偏心（x={offx:+.2f} y={offy:+.2f}）。"})
+        if (img.get("bytes") or 0) > 8 * 1024 * 1024:
+            risks.append({"level": "info", "area": "file_size", "reason": f"{name} 超过 8MB。"})
+    for dup in duplicates:
+        risks.append({"level": "medium", "area": "duplicate",
+                      "reason": f"{dup['a']} 与 {dup['b']} 视觉上几乎相同（汉明距离 {dup['distance']}），套图存在重复位。"})
+    return risks
+
+
+def render_for_text_model(result: dict[str, Any], *, question: str = "") -> str:
+    """把指标写成给**纯文本主脑**读的段落——方案 D 的落点。
+
+    两条硬约束写进正文，因为这是本地视觉最容易被误用的地方：
+      1. 明说这些是仪器读数不是"看到的画面"，禁止据此编造画面内容；
+      2. 明说哪些问题它答不了，让模型主动说"需要视觉模型"而不是硬答。
+    """
+    images = result.get("images") or []
+    lines = [
+        "[本地视觉度量：当前没有可用的视觉模型，图片由本地 CV + OCR 量化后以文本提供]",
+        "",
+        "重要约束：以下是对图片的**客观测量读数**，不是对画面内容的描述。",
+        "- 只能依据这些读数和 OCR 文本作判断，**禁止**据此想象或编造画面里有什么物体、场景、人物。",
+        "- 读数答不了的问题（产品是什么、版式意图、审美好坏、有没有穿帮），"
+        "必须直说「这需要视觉模型才能判断」，不要猜。",
+        "- 「高频区占比」是纹理/文字的粗略估计，不等于文字面积；要引用文字请用 OCR 文本。",
+    ]
+    if question:
+        lines += ["", f"用户的问题：{question}"]
+
+    lines += ["", f"图片数：{len(images)}　OCR 引擎：{result.get('ocr_engine') or '无（本次未做文字识别）'}"]
+
+    for idx, img in enumerate(images, 1):
+        lines += ["", f"## 图 {idx}：{img.get('name')}（角色推断：{img.get('role')}）"]
+        if img.get("error"):
+            lines.append(f"- 读取失败：{img['error']}")
+            continue
+        lines.append(f"- 尺寸 {img.get('width')}×{img.get('height')}，比例 {img.get('aspect')}，"
+                     f"{round((img.get('bytes') or 0) / 1024)}KB"
+                     + ("，含透明通道" if img.get("has_alpha") else ""))
+        lines.append(f"- 边框白底占比 {img.get('white_border_ratio')}"
+                     f"（判定：{'接近纯白底' if img.get('is_white_background') else '非白底'}），"
+                     f"背景中位色 RGB{img.get('border_median_rgb')}")
+        fg = img.get("foreground") or {}
+        if fg.get("coverage_ratio") is not None:
+            lines.append(
+                f"- 主体占画面 {fg.get('coverage_ratio')}，包围盒占比 {fg.get('bbox_area_ratio')}，"
+                f"中心偏移 x={fg.get('center_offset_x')} y={fg.get('center_offset_y')}，"
+                f"{'触边' if fg.get('touches_edge') else '四周有留白'}"
+                f"（掩膜来源：{fg.get('mask_source')}）"
+            )
+        pal = img.get("palette") or []
+        if pal:
+            lines.append("- 主色：" + "，".join(f"{c['hex']} {c['share']:.0%}" for c in pal))
+        tex = img.get("texture") or {}
+        if tex:
+            lines.append(f"- 高频区（疑似文字/密集纹理）占比 {tex.get('busy_ratio')}")
+        layout = img.get("layout") or {}
+        if layout:
+            lines.append(f"- 文字分布：主要在{ {'top': '上', 'middle': '中', 'bottom': '下'}.get(layout.get('dominant_band'), '?') }部，"
+                         f"文字面积占比 {layout.get('text_area_ratio')}，"
+                         f"纵向 {layout.get('vertical')}，横向 {layout.get('horizontal')}")
+        text = (img.get("ocr_text") or "").strip()
+        if text:
+            lines.append(f"- OCR 文本：{text[:600]}")
+        elif result.get("ocr_engine"):
+            lines.append("- OCR 未识别到文字")
+
+    if result.get("duplicates"):
+        lines += ["", "## 套图查重"]
+        for d in result["duplicates"]:
+            lines.append(f"- {d['a']} ≈ {d['b']}（汉明距离 {d['distance']}）")
+
+    if result.get("risks"):
+        lines += ["", "## 本地度量已证实的问题"]
+        for r in result["risks"]:
+            lines.append(f"- [{r['level']}] {r['area']}：{r['reason']}")
+
+    return "\n".join(lines)
+
+
+def render(result: dict[str, Any]) -> str:
+    """给人看的 CLI 报告（`ivyea image local` 用）。"""
+    if not result.get("available"):
+        return f"# 本地视觉\n\n不可用：{result.get('engine')}\n"
+    lines = ["# 本地视觉度量", "",
+             f"- 引擎：{result.get('engine')}",
+             f"- OCR：{result.get('ocr_engine') or '无'}",
+             f"- 图片数：{len(result.get('images') or [])}", ""]
+    for img in result.get("images") or []:
+        if img.get("error"):
+            lines.append(f"## {img.get('name')}\n- 读取失败：{img['error']}\n")
+            continue
+        fg = img.get("foreground") or {}
+        lines += [
+            f"## {img.get('name')}",
+            f"- {img.get('width')}×{img.get('height')} · {img.get('role')} · "
+            f"{'白底' if img.get('is_white_background') else '非白底'}",
+            f"- 主体占比 {fg.get('coverage_ratio')} · 偏心 x={fg.get('center_offset_x')} y={fg.get('center_offset_y')}",
+            "- 主色 " + "，".join(c["hex"] for c in (img.get("palette") or [])[:5]),
+            "",
+        ]
+    if result.get("risks"):
+        lines.append("## 风险")
+        for r in result["risks"]:
+            lines.append(f"- [{r['level']}] {r['area']}：{r['reason']}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/ivyea_agent/mentions.py
+++ b/ivyea_agent/mentions.py
@@ -62,14 +62,21 @@ def build_user_content(text: str, image_paths: list[str]):
     """构造一条 user 消息的 content：无图返回纯文本 str；有图返回 OpenAI 多模态
     list-content（[{type:text},{type:image_url,image_url:{url:data:...}}]）。
     各 provider 适配器把 image_url 转成自身格式（codex/anthropic/gemini），
-    不支持多模态的 provider 会安全拍平只取文本。"""
+    不支持多模态的 provider 会安全拍平只取文本。
+
+    **每一项既可以是本地文件路径，也可以是 data URI。** 两种都要收：CLI 那条路
+    传的是 `@图片` 展开出来的文件路径，而 serve（IvyeaOps 网页上传）传的是
+    data URI。曾经只按文件路径处理，data URI 会在 read_bytes 上抛异常、被下面
+    那个 except 静默吞掉——模型一张图都没收到却照常作答，于是凭空编出画面内容。
+    """
     if not image_paths:
         return text
     from . import image_audit
     parts: list = [{"type": "text", "text": text}]
     for p in image_paths:
         try:
-            parts.append({"type": "image_url", "image_url": {"url": image_audit.data_url(p)}})
+            url = p if isinstance(p, str) and p.startswith("data:image/") else image_audit.data_url(p)
+            parts.append({"type": "image_url", "image_url": {"url": url}})
         except Exception:
             pass   # 单张编码失败(过大/损坏)跳过，不阻塞整轮
     return parts

--- a/ivyea_agent/models.py
+++ b/ivyea_agent/models.py
@@ -493,6 +493,87 @@ def key_status(provider: dict[str, Any], *, environ: dict[str, str] | None = Non
     return "configured" if env.get(key_env) else f"missing:{key_env}"
 
 
+# ── 视觉能力判定 ──────────────────────────────────────────────────────────
+# 这里刻意分成两个层级，别再把它们混成一个开关（历史上就是混了才出的事）：
+#
+#   provider 级 `capabilities["vision"]` = "这家**有**视觉可选模型"，只喂 UI 徽标。
+#   模型级 `model_has_vision(mcfg)`      = "**当前选中的这个模型**能吃图"，
+#                                          视觉降级链（T1/T2）只认它。
+#
+# 旧实现只有 provider 级，而且是硬编码厂商白名单 {openai, anthropic, gemini,
+# openai-codex}。后果：硅基流动/DashScope/智谱/OpenRouter/Ollama 上的 Qwen-VL、
+# GLM-4V、本地 VLM 即使配好 key 也永远选不中——而这些恰恰是国内用户唯一配得起
+# 的视觉模型。判定改成"传输格式能装图 AND 模型名是视觉模型"。
+
+# 能在请求体里装图片的传输格式。绝大多数 provider 是 kind=openai /
+# api_mode=chat_completions，OpenAI 的 image_url content block 通吃。
+VISION_TRANSPORTS = {
+    "chat_completions",
+    "anthropic_messages",
+    "anthropic_oauth",
+    "gemini_native",
+    "gemini_code_assist",
+    "copilot_chat_completions",
+    "codex_responses",
+    "bedrock_converse",
+}
+
+# 模型名里出现即视为多模态。全部小写子串匹配，覆盖 provider 前缀写法
+# （openrouter 的 "qwen/qwen3-vl-235b"、bedrock 的 "us.anthropic.claude-..."）。
+VISION_MODEL_MARKERS = (
+    "-vl", "vl-", "vision", "-v-", "multimodal", "omni",
+    "gpt-4o", "gpt-4.1", "gpt-4-turbo", "gpt-5", "o3", "o4-mini",
+    "claude", "gemini", "grok-4", "grok-2-vision",
+    "glm-4v", "glm-5", "step-1v", "yi-vision", "ernie-4.5",
+    "llava", "pixtral", "internvl", "minicpm-v", "moondream", "florence",
+)
+
+# 明确**没有**视觉的模型，优先于上面的 marker 判定。
+# 存在的意义：marker 是子串匹配，难免误伤——例如 "deepseek-vl" 是真视觉模型，
+# 但 "glm-5-air-text" 之类带 glm-5 前缀的纯文本变体不是。命中这里直接判无视觉。
+VISION_MODEL_DENY = (
+    "-text", "text-only", "embed", "rerank", "whisper", "tts", "audio",
+    "deepseek-chat", "deepseek-reasoner", "deepseek-coder", "deepseek-r1",
+    "qwen3-coder", "kimi-k2", "-code-fast",
+)
+
+
+def model_name_has_vision(model: str) -> Optional[bool]:
+    """只看模型名的视觉判定。True/False 是确信，None 是"看不出来"。
+
+    分三态而不是两态：调用方对"看不出来"和"确定没有"要给不同待遇——前者可以
+    乐观试一把（T1 失败再降级），后者直接跳过 T1 省一次必失败的请求。
+    """
+    low = (model or "").strip().lower()
+    if not low:
+        return None
+    if any(bad in low for bad in VISION_MODEL_DENY):
+        return False
+    if any(good in low for good in VISION_MODEL_MARKERS):
+        return True
+    return None
+
+
+def model_has_vision(mcfg: dict[str, Any], *, environ: dict[str, str] | None = None) -> bool:
+    """当前选中的模型能不能直接吃图。视觉降级链判 T1 就看这个。
+
+    用户覆盖 > 模型名判定 > 保守判否。覆盖项是给判错时的逃生门：模型名千变万化，
+    不可能穷举，所以必须留一个用户说了算的开关。
+    """
+    from . import config
+    override = str(config.get_setting("vision_capable_override", "auto") or "auto").strip().lower()
+    if override in ("true", "yes", "1", "on"):
+        return True
+    if override in ("false", "no", "0", "off"):
+        return False
+
+    api_mode = str(mcfg.get("api_mode") or "")
+    if api_mode and api_mode not in VISION_TRANSPORTS:
+        return False
+    verdict = model_name_has_vision(str(mcfg.get("model") or ""))
+    return verdict is True
+
+
 def provider_capabilities(provider: dict[str, Any]) -> dict[str, Any]:
     """Return stable, product-facing provider capabilities.
 
@@ -533,9 +614,15 @@ def provider_capabilities(provider: dict[str, Any]) -> dict[str, Any]:
         "chat": provider.get("status", "usable") == "usable",
         "tools": api_mode in tool_modes,
         "streaming": api_mode in stream_modes,
-        # openai-codex（Responses API）适配器已支持 input_image 多模态，GPT-5 系自带视觉
-        "vision": pid in {"openai", "anthropic", "anthropic-oauth", "gemini", "openai-codex"}
-        or api_mode in {"gemini_native", "codex_responses"},
+        # provider 级视觉 = "这家有视觉可选模型"（UI 徽标语义）。
+        # **不要**拿它判"当前模型能不能吃图"——那是 model_has_vision() 的活。
+        # 判据：传输格式装得下图 且（列出的模型里有视觉模型 或 是开放目录的聚合/
+        # 自定义端点——后者模型随用户填，不能一口咬定没有）。
+        "vision": api_mode in VISION_TRANSPORTS and (
+            any(model_name_has_vision(m) for m in (provider.get("models") or []))
+            or bool(provider.get("models_url"))
+            or pid in {"custom", "azure-foundry", "ollama"}
+        ),
         "oauth": auth in {"oauth_external", "oauth_device_code", "copilot"},
         "api_key": auth == "api_key",
         "local": auth == "none" or base.startswith(("http://localhost", "http://127.0.0.1")),

--- a/ivyea_agent/ocr.py
+++ b/ivyea_agent/ocr.py
@@ -1,4 +1,18 @@
-"""Optional local OCR support via the Tesseract CLI."""
+"""本地 OCR：RapidOCR（ONNX）优先，tesseract 兜底，都没有就明说没有。
+
+**为什么换掉纯 tesseract**：tesseract 对电商图（艺术字、低对比描边、中英混排）
+识别率一般，而 T3 本地视觉恰恰最需要读出图上的字。RapidOCR 是 PP-OCR 系模型的
+ONNX 封装，中英电商图明显更强，模型内置在 wheel 里（14.9MB），且本仓已经依赖
+`onnxruntime`（见 onnx_embedding.py 那条"自带小模型"的路子）。
+
+**为什么 tesseract 不删**：RapidOCR 拖 opencv-python，精简 Linux 镜像常缺
+`libGL.so.1`，`import cv2` 会直接炸。那种环境下还有 tesseract 可用就不至于
+整条 T3 断掉——所以引擎探测必须是运行时的，不能在 import 阶段决定。
+
+对外契约保持不变：`run()` 仍返回 {available, detail, images, results}，
+只是多了 `engine` 字段，且 RapidOCR 路径下每个 result 多带 `boxes`
+（文本块坐标，local_vision 用它推版面骨架）。
+"""
 from __future__ import annotations
 
 import shutil
@@ -7,26 +21,94 @@ from typing import Any
 
 from . import image_audit, security
 
+_RAPID_CACHE: Any = None
+_RAPID_FAILED = ""
+
+
+def _rapidocr():
+    """惰性加载 RapidOCR，失败原因记下来只报一次。
+
+    必须惰性：模型初始化要几百毫秒，而绝大多数请求根本不看图；更要紧的是
+    `import cv2` 在缺 libGL 的机器上会抛，放在模块顶层会让整个 ocr 模块不可导入。
+    """
+    global _RAPID_CACHE, _RAPID_FAILED
+    if _RAPID_CACHE is not None or _RAPID_FAILED:
+        return _RAPID_CACHE
+    try:
+        from rapidocr_onnxruntime import RapidOCR
+        _RAPID_CACHE = RapidOCR()
+    except Exception as e:  # noqa: BLE001 — 缺包/缺 libGL/模型损坏都走同一条降级路
+        _RAPID_FAILED = str(e)
+        return None
+    return _RAPID_CACHE
+
+
+def _tesseract() -> str:
+    return shutil.which("tesseract") or ""
+
 
 def available() -> tuple[bool, str]:
-    exe = shutil.which("tesseract")
-    if not exe:
-        return False, "未找到 tesseract，可安装系统包后重试。"
-    try:
-        proc = subprocess.run([exe, "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                              text=True, encoding="utf-8", errors="replace", timeout=5)
-    except Exception as e:  # noqa: BLE001
-        return False, f"tesseract 不可用：{e}"
-    first = (proc.stdout or "").splitlines()[0] if proc.stdout else exe
-    return True, first
+    """(能否 OCR, 引擎描述)。描述里带引擎名，调用方直接透传给用户看。"""
+    if _rapidocr() is not None:
+        # 版本从包元数据取：rapidocr_onnxruntime 并不导出 __version__，
+        # 按属性拿只会一直显示 "?"。
+        try:
+            from importlib.metadata import version as _pkg_version
+            ver = _pkg_version("rapidocr-onnxruntime")
+        except Exception:  # noqa: BLE001
+            ver = "?"
+        return True, f"RapidOCR (ONNX) {ver}"
+    exe = _tesseract()
+    if exe:
+        try:
+            proc = subprocess.run([exe, "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                  text=True, encoding="utf-8", errors="replace", timeout=5)
+            first = (proc.stdout or "").splitlines()[0] if proc.stdout else exe
+            return True, first
+        except Exception as e:  # noqa: BLE001
+            return False, f"tesseract 不可用：{e}"
+    detail = "未找到 OCR 引擎：建议 pip install rapidocr-onnxruntime，或安装系统包 tesseract。"
+    if _RAPID_FAILED:
+        detail += f"（RapidOCR 加载失败：{_RAPID_FAILED}）"
+    return False, detail
 
 
-def run(paths: list[str], *, lang: str = "eng", recursive: bool = True, timeout: int = 30) -> dict[str, Any]:
+def engine_name() -> str:
     ok, detail = available()
-    images = image_audit.scan(paths, recursive=recursive)
-    if not ok:
-        return {"available": False, "detail": detail, "images": images, "results": []}
-    exe = shutil.which("tesseract") or "tesseract"
+    return detail if ok else ""
+
+
+def _run_rapidocr(engine, images: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    results = []
+    for img in images:
+        try:
+            out, _elapse = engine(img["path"])
+            boxes: list[dict[str, Any]] = []
+            texts: list[str] = []
+            for item in out or []:
+                # RapidOCR 单条结果是 [四点坐标, 文本, 置信度]
+                pts, text, score = item[0], str(item[1]), float(item[2])
+                xs = [float(p[0]) for p in pts]
+                ys = [float(p[1]) for p in pts]
+                texts.append(text)
+                boxes.append({"text": security.redact_text(text),
+                              "score": round(score, 3),
+                              "bbox": [min(xs), min(ys), max(xs), max(ys)]})
+            results.append({
+                "path": img["path"], "name": img["name"], "ok": True,
+                "text": security.redact_text("\n".join(texts)).strip(),
+                "boxes": boxes,
+                "image_width": img.get("width") or 0,
+                "image_height": img.get("height") or 0,
+                "error": "",
+            })
+        except Exception as e:  # noqa: BLE001
+            results.append({"path": img["path"], "name": img["name"], "ok": False,
+                            "text": "", "boxes": [], "error": str(e)})
+    return results
+
+
+def _run_tesseract(exe: str, images: list[dict[str, Any]], lang: str, timeout: int) -> list[dict[str, Any]]:
     results = []
     for img in images:
         try:
@@ -45,20 +127,42 @@ def run(paths: list[str], *, lang: str = "eng", recursive: bool = True, timeout:
                 "name": img["name"],
                 "ok": proc.returncode == 0,
                 "text": text,
+                # tesseract 的纯文本模式没有坐标。这里给空表而不是编造坐标——
+                # local_vision 看到空 boxes 就不推版面骨架。
+                "boxes": [],
                 "error": "" if proc.returncode == 0 else text[:500],
             })
         except subprocess.TimeoutExpired:
-            results.append({"path": img["path"], "name": img["name"], "ok": False, "text": "", "error": "OCR 超时"})
+            results.append({"path": img["path"], "name": img["name"], "ok": False,
+                            "text": "", "boxes": [], "error": "OCR 超时"})
         except Exception as e:  # noqa: BLE001
-            results.append({"path": img["path"], "name": img["name"], "ok": False, "text": "", "error": str(e)})
-    return {"available": True, "detail": detail, "images": images, "results": results}
+            results.append({"path": img["path"], "name": img["name"], "ok": False,
+                            "text": "", "boxes": [], "error": str(e)})
+    return results
+
+
+def run(paths: list[str], *, lang: str = "eng", recursive: bool = True, timeout: int = 30) -> dict[str, Any]:
+    ok, detail = available()
+    images = image_audit.scan(paths, recursive=recursive)
+    if not ok:
+        return {"available": False, "engine": "", "detail": detail, "images": images, "results": []}
+
+    engine = _rapidocr()
+    if engine is not None:
+        # RapidOCR 自带中英双语模型，不吃 lang 参数——这里刻意忽略它而不是报错，
+        # 因为调用方传 lang 是为了 tesseract，换引擎不该让老调用失败。
+        results = _run_rapidocr(engine, images)
+    else:
+        results = _run_tesseract(_tesseract(), images, lang, timeout)
+    return {"available": True, "engine": detail, "detail": detail, "images": images, "results": results}
 
 
 def render(result: dict[str, Any]) -> str:
     lines = ["# 图片 OCR", "", f"- OCR 引擎：{result['detail']}", f"- 图片数：{len(result.get('images') or [])}", ""]
     if not result.get("available"):
         lines.append("## 状态")
-        lines.append("OCR 不可用。可先用 `ivyea image audit` 做本地资产诊断，或安装 tesseract 后重试。")
+        lines.append("OCR 不可用。可先用 `ivyea image audit` 做本地资产诊断，"
+                     "或 `pip install rapidocr-onnxruntime` / 安装 tesseract 后重试。")
         return "\n".join(lines) + "\n"
     lines.append("## 识别结果")
     rows = result.get("results") or []

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -150,7 +150,21 @@ def health() -> dict[str, Any]:
             "user_cards": len(knowledge.list_user_cards()),
         },
         "retrieval": retrieval.capabilities(),
+        # 视觉三档链的实时状态。IvyeaOps 判"agent 能不能接带图任务"要看
+        # vision_chain.effective，**不要**再看 model.capabilities.vision——
+        # 后者只说明主脑本身，主脑没视觉不等于这条链没视觉（还有 T2/T3）。
+        "vision_chain": _vision_chain_status(),
     }
+
+
+def _vision_chain_status() -> dict[str, Any]:
+    """/health 里的视觉链快照。绝不能因为它出错而让整个 /health 挂掉——
+    ops 的自动启动、状态卡、模型同步全靠 /health 活着。"""
+    try:
+        from . import vision
+        return vision.chain_status()
+    except Exception as exc:  # noqa: BLE001
+        return {"tier": 0, "effective": False, "error": str(exc)}
 
 
 def manifest() -> dict[str, Any]:
@@ -208,6 +222,8 @@ def manifest() -> dict[str, Any]:
             {"method": "GET", "path": "/v1/model/providers/{id}/models", "description": "live/cache/builtin model catalog for one provider"},
             {"method": "POST", "path": "/v1/model/providers/{id}/probe", "description": "minimal provider connectivity probe without returning secrets"},
             {"method": "POST", "path": "/v1/model/configure", "description": "configure the active IvyeaAgent model without returning secrets"},
+            {"method": "GET", "path": "/v1/config/vision", "description": "vision fallback chain status (tier 1 main brain / 2 sidecar / 3 local CV)"},
+            {"method": "POST", "path": "/v1/config/vision", "description": "configure the tier-2 sidecar vision model without returning secrets"},
             {"method": "GET", "path": "/v1/mcp/self-config", "description": "stdio MCP server config for local clients"},
             {"method": "GET", "path": "/v1/system/status", "description": "install/runtime status for IvyeaOps diagnostics"},
             {"method": "GET", "path": "/v1/system/doctor", "description": "install/runtime doctor checks"},
@@ -475,6 +491,55 @@ def model_configure(payload: dict[str, Any]) -> dict[str, Any]:
             "key_configured": bool(isinstance(api_key, str) and api_key) or bool(config.get_active_key()),
         },
     }
+
+
+def vision_configure(payload: dict[str, Any]) -> dict[str, Any]:
+    """配置 T2 的 sidecar 视觉模型（IvyeaOps 的"独立视觉槽"下推到这里）。
+
+    存进 config 的 `vision_slot`，`vision.pick_vision_model()` 最优先读它。
+    key 落 `~/.ivyea/.env`（复用 model_configure 同一套 set_env_key），不回显。
+
+    为什么要下推而不是让 agent 自己配一遍：同一个视觉模型在 IvyeaOps 界面配一次
+    就该同时对网页和 CLI 生效，两边各配一份必然长期不一致。
+
+    空 model 视为**清除**视觉槽——这样"取消配置"有确定路径，否则用户只能去手改
+    配置文件。
+    """
+    provider = str(payload.get("provider") or "").strip().lower()
+    model = str(payload.get("model") or "").strip()
+    base_url = str(payload.get("base_url") or "").strip()
+    api_key = str(payload.get("api_key") or "").strip()
+
+    if not model:
+        config.set_setting("vision_slot", {})
+        return {"ok": True, "cleared": True, "vision_chain": _vision_chain_status()}
+
+    entry = models.provider_by_id(provider) if provider else None
+    if entry is None and not base_url:
+        return {"ok": False, "error": "unknown_provider_requires_base_url",
+                "detail": f"provider={provider or '(空)'} 不在内置目录里，必须同时提供 base_url。"}
+
+    slot = {
+        "provider": provider or "custom",
+        "model": model,
+        "base_url": base_url or str((entry or {}).get("base") or ""),
+    }
+    # key 有两条落法：内置 provider 有 key_env 就写进 .env（与主脑同一套密钥管理），
+    # 自定义端点没有 key_env，就只能连同槽位一起存 —— 后者由 config 文件权限保护。
+    key_env = str((entry or {}).get("key_env") or "").strip()
+    if api_key and key_env:
+        config.set_env_key(key_env, api_key)
+    elif api_key:
+        slot["api_key"] = api_key
+    config.set_setting("vision_slot", slot)
+
+    public = {k: v for k, v in slot.items() if k != "api_key"}
+    public["key_configured"] = bool(api_key or (key_env and os.environ.get(key_env)))
+    return {"ok": True, "configured": public, "vision_chain": _vision_chain_status()}
+
+
+def vision_status() -> dict[str, Any]:
+    return {"ok": True, "vision_chain": _vision_chain_status()}
 
 
 def task_detail(task_id: str) -> dict[str, Any]:
@@ -1141,6 +1206,10 @@ def chat_run(payload: dict[str, Any], provider: Any | None = None) -> dict[str, 
     def narrate(text: str) -> None:
         events.append({"type": "event", "text": security.redact_text(str(text))})
 
+    # 视觉降级发生在 _chat_messages 里（那时 narrate 还没定义），这里补发它的说明。
+    for note in (ctx.vision_notes or []):
+        narrate(note)
+
     try:
         provider = provider or build_chain(model_cfg, api_key, narrate=narrate)
         text = agent_loop.run_turn(provider, ctx, messages, max_steps=(_int(payload.get("max_steps"), 0) or None),
@@ -1159,6 +1228,8 @@ def chat_run(payload: dict[str, Any], provider: Any | None = None) -> dict[str, 
         "todos": list(ctx.todos or []),
         "progress": progress_reporting.public_state(ctx),
     }
+    if ctx.vision_tier:
+        result["vision_tier"] = dict(ctx.vision_tier)
     if ctx.task_id:
         try:
             result["task"] = task_runner.load(ctx.task_id)
@@ -1246,6 +1317,13 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
     def narrate(text: str) -> None:
         send("event", {"type": "event", "text": security.redact_text(str(text))})
 
+    # 视觉降级发生在 _chat_messages 里（narrate 尚未定义），这里补发说明并单发一个
+    # vision_tier 事件——前端要靠它画"本轮走了哪一档"的徽标。
+    for note in (ctx.vision_notes or []):
+        narrate(note)
+    if ctx.vision_tier:
+        send("vision_tier", dict(ctx.vision_tier))
+
     # 本轮的执行步骤，按 call_id 收口成"每个调用只留最终态"（running → ok/error 合并，
     # 与前端 mergeStep 同一语义）。轮次收尾时落盘 —— 此前它们只流给前端就扔了，
     # 于是刷新之后"它刚才干了什么"一片空白。
@@ -1324,6 +1402,8 @@ def chat_stream(payload: dict[str, Any], send: Any, provider: Any | None = None,
         "todos": list(ctx.todos or []),
         "progress": progress_reporting.public_state(ctx),
     }
+    if ctx.vision_tier:
+        data["vision_tier"] = dict(ctx.vision_tier)
     send("final", data)
     return data
 
@@ -1441,7 +1521,11 @@ class _Handler(BaseHTTPRequestHandler):
             self._json(200, openapi_spec())
             return
         if parsed.path == "/v1/capabilities":
-            self._json(200, {"ok": True, "retrieval": retrieval.capabilities()})
+            self._json(200, {"ok": True, "retrieval": retrieval.capabilities(),
+                             "vision_chain": _vision_chain_status()})
+            return
+        if parsed.path == "/v1/config/vision":
+            self._json(200, vision_status())
             return
         if parsed.path == "/v1/model":
             self._json(200, {"ok": True, "model": health()["model"]})
@@ -1813,6 +1897,9 @@ class _Handler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/model/configure":
             self._json(200, model_configure(body))
             return
+        if parsed.path == "/v1/config/vision":
+            self._json(200, vision_configure(body))
+            return
         if parsed.path == "/v1/system/service/start":
             self._json(200, system_service_start(body))
             return
@@ -2124,7 +2211,7 @@ def _chat_messages(message: str, payload: dict[str, Any],
     # 本轮起点：这之前都是历史，这之后（含这条 user 和后续工具/回答）才是本轮新增。
     # 落盘时只写这一段，见 sessions.append_turn —— 整份覆盖会吃掉并发的另一轮。
     base = len(messages)
-    messages.append({"role": "user", "content": _with_payload_images(user_content, payload)})
+    messages.append({"role": "user", "content": _with_payload_images(user_content, payload, ctx)})
     return messages, created_at, base
 
 
@@ -2178,23 +2265,39 @@ def _auto_skill_context(message: str, messages: list) -> list[dict[str, Any]]:
     return out
 
 
-def _with_payload_images(user_content: str, payload: dict[str, Any]):
-    """可选多模态：payload["images"] 为 data URI 列表时，把 user 消息升级成
-    OpenAI 多模态 list-content（provider 适配器各自转换，codex→input_image、
-    anthropic→image block）。主脑无视觉能力时显式报错——复核/看图类调用
-    不允许静默丢图后瞎编结论。"""
+def _with_payload_images(user_content: str, payload: dict[str, Any], ctx: Any = None):
+    """可选多模态：payload["images"] 为 data URI 列表时，走**与 CLI 同一条**视觉
+    三档降级链（vision.route_images）。
+
+    此前这里是 `raise main_brain_no_vision` —— serve 自己拦掉了带图请求，于是
+    IvyeaOps（唯一走 serve 的调用方）在主脑无视觉时整块功能死掉，而同一台机器上
+    的 CLI 却有旁路可走。两边必须共用一条链，不要在这里另写降级逻辑。
+
+    T1 返回多模态 list-content（provider 适配器各自转换，codex→input_image、
+    anthropic→image block）；T2/T3 返回已注入视觉文本的纯字符串。
+    档位写进 ctx.vision_tier，由调用方在 narrate 可用之后发事件并回传。
+    """
     images = payload.get("images")
     if not isinstance(images, list) or not images:
         return user_content
     uris = [str(u) for u in images if isinstance(u, str) and u.startswith("data:image/")][:4]
     if not uris:
         return user_content
+
     from . import config as _config
-    from .vision import main_has_vision
-    if not main_has_vision(_config.get_model_config()):
-        raise ValueError("main_brain_no_vision: 当前主脑不支持图片输入，无法处理带图请求")
-    parts: list[dict[str, Any]] = [{"type": "text", "text": user_content}]
-    for uri in uris:
+    from . import vision as _vision
+
+    notes: list[str] = []
+    content, kept, tier = _vision.route_images(
+        user_content, uris, _config.get_model_config(), notes.append)
+    if ctx is not None:
+        ctx.vision_tier = tier
+        ctx.vision_notes = notes
+
+    if not kept:
+        return content
+    parts: list[dict[str, Any]] = [{"type": "text", "text": content}]
+    for uri in kept:
         parts.append({"type": "image_url", "image_url": {"url": uri}})
     return parts
 

--- a/ivyea_agent/vision.py
+++ b/ivyea_agent/vision.py
@@ -333,12 +333,28 @@ SIDECAR_PROMPT = (
 
 
 def main_has_vision(mcfg: dict) -> bool:
-    """主脑是否自带视觉能力（按 provider 能力位判定，离线保守）。"""
+    """主脑**当前选中的模型**能否直接吃图。
+
+    从"按 provider 白名单"改成"按模型判定"（见 models.model_has_vision）：
+    provider 级只说明"这家有视觉模型"，而主脑走 T1 与否取决于用户到底选了哪个
+    模型——同一个 OpenRouter，选 claude 能看图，选 deepseek-chat 就不能。
+    """
     from . import models
-    prov = models.provider_by_id(str(mcfg.get("provider_id") or mcfg.get("provider") or ""))
-    if not prov:
-        return False
-    return bool(models.provider_capabilities(prov).get("vision"))
+    return models.model_has_vision(mcfg)
+
+
+def _vision_model_of(provider: dict) -> str:
+    """从 provider 的模型列表里挑一个**视觉**模型。
+
+    不能用 default_model：绝大多数 provider 的默认模型是文本旗舰
+    （deepseek-chat、qwen3-coder…），拿它当 sidecar 必然 400。挑不出来就返回空，
+    让上层跳过这家。
+    """
+    from . import models
+    for m in provider.get("models") or []:
+        if models.model_name_has_vision(m) is True:
+            return str(m)
+    return ""
 
 
 def pick_vision_model() -> dict | None:
@@ -352,14 +368,35 @@ def pick_vision_model() -> dict | None:
         if not models.provider_capabilities(p).get("vision"):
             return None
         key = os.environ.get(str(p.get("key_env") or ""), "")
-        if not key:
+        if not key and str(p.get("auth_type") or "") != "none":
             return None
-        model = p.get("default_model") or next(iter(p.get("models") or []), "")
+        model = _vision_model_of(p)
+        if not model:
+            return None
         cfg2 = {"kind": p.get("kind"), "provider_id": p.get("id"),
                 "api_mode": p.get("api_mode", ""), "auth_type": p.get("auth_type", "api_key"),
                 "model": model, "base": p.get("base", ""), "base_url": p.get("base", ""),
                 "key_env": p.get("key_env", ""), "label": p.get("label") or p.get("id")}
         return {"cfg": cfg2, "key": key, "label": f"{cfg2['label']} · {model}"}
+
+    # 显式视觉槽最优先。它由 IvyeaOps 通过 POST /v1/config/vision 下推
+    # （provider / model / base_url / api_key 四件套），也可以本地
+    # `ivyea config set vision_slot '{...}'`。有它就不再猜——用户配的就是权威，
+    # 连模型名视觉判定都不复核（自建网关的模型名可能完全不带视觉特征词）。
+    slot = config.get_setting("vision_slot", None)
+    if isinstance(slot, dict) and str(slot.get("model") or "").strip():
+        pid = str(slot.get("provider") or "custom").strip() or "custom"
+        prov = models.provider_by_id(pid) or {}
+        key = str(slot.get("api_key") or "").strip() or os.environ.get(str(prov.get("key_env") or ""), "")
+        base = str(slot.get("base_url") or "").strip() or str(prov.get("base") or "")
+        if key or str(prov.get("auth_type") or "") == "none":
+            cfg2 = {"kind": prov.get("kind", "openai"), "provider_id": pid,
+                    "api_mode": prov.get("api_mode", "chat_completions"),
+                    "auth_type": prov.get("auth_type", "api_key"),
+                    "model": str(slot["model"]).strip(), "base": base, "base_url": base,
+                    "key_env": prov.get("key_env", ""),
+                    "label": prov.get("label") or pid}
+            return {"cfg": cfg2, "key": key, "label": f"{cfg2['label']} · {cfg2['model']}"}
 
     prefer = str(config.get_setting("vision_model", "") or "").strip()
     if prefer:
@@ -390,36 +427,179 @@ def sidecar_describe(images: list[str], question: str, picked: dict) -> str:
     """用选定的视觉模型代读图片，返回分析文本。异常向上抛，由 route_images 兜底。"""
     from . import mentions
     from .providers import from_settings
+
+    content = mentions.build_user_content(
+        f"用户的问题：{question or '（无文字，仅图片）'}", images)
+    # 一张图都没挂上就绝不发出去。build_user_content 对单张编码失败是静默跳过的
+    # （损坏/过大图不该拖垮整轮），但全部失败还照发，视觉模型就会对着纯文字
+    # **编造画面**——实测编出过一整张不存在的柱状图，数字有名有姓。
+    # 这里抛出去，route_images 会接住并降到 T3 本地度量：读数不好看，但是真的。
+    attached = sum(1 for part in content if isinstance(part, dict) and part.get("type") == "image_url") \
+        if isinstance(content, list) else 0
+    if attached == 0:
+        raise ValueError(f"视觉旁路未能附上任何图片（收到 {len(images)} 项，全部编码失败）")
+
     provider = from_settings(picked["cfg"], picked["key"])
     msg = provider.chat([
         {"role": "system", "content": SIDECAR_PROMPT},
-        {"role": "user", "content": mentions.build_user_content(
-            f"用户的问题：{question or '（无文字，仅图片）'}", images)},
+        {"role": "user", "content": content},
     ], tools=None)
     return (msg.get("content") or "").strip()
 
 
-def route_images(user_content: str, images: list[str], mcfg: dict, narrate) -> tuple[str, list[str]]:
-    """视觉旁路总入口：主脑有 vision 或本轮无图 → 原样返回；
-    否则 sidecar 分析注入文本、剥掉图片；无可用视觉模型/出错 → warn 后忽略图片继续（fail-open）。"""
-    from . import ui
-    if not images or main_has_vision(mcfg):
-        return user_content, images
-    picked = pick_vision_model()
-    if not picked:
-        narrate(ui.message("warn", "主脑不支持图片且没有可用的视觉模型（配 OPENAI/ANTHROPIC/GEMINI key，"
-                                   "或 ivyea config set vision_model <provider>），本轮忽略图片仅按文字继续。"))
-        return user_content, []
+# ── 三档降级链 ────────────────────────────────────────────────────────────
+#
+#   T1 主脑自带视觉        → 图片原样进主脑上下文
+#   T2 主脑无视觉 + 配了视觉模型 → sidecar 代读，文本回灌主脑
+#   T3 两者都没有          → 本地 CV + OCR 量化成文本回灌主脑（local_vision）
+#
+# 三档实现在这一个函数里，CLI 和 serve 都走它——**不要**在 serve 里另写一套，
+# 历史上 serve 就是因为自己 raise 了 main_brain_no_vision 而完全没有降级。
+
+TIER_MAIN = 1
+TIER_SIDECAR = 2
+TIER_LOCAL_CV = 3
+
+
+def local_data_urls_to_paths(images: list[str]) -> tuple[list[str], list[str]]:
+    """把 data URI 落成临时文件供本地 CV 读取，返回 (临时路径, 待清理路径)。
+
+    T3 全程在本机跑，图片不出网。落临时文件是因为 Pillow/OCR 都按路径吃图。
+    """
+    import base64
+    import tempfile
+
+    paths: list[str] = []
+    tmp: list[str] = []
+    for uri in images:
+        if not isinstance(uri, str):
+            continue
+        if not uri.startswith("data:image/"):
+            if Path(uri).is_file():
+                paths.append(uri)
+            continue
+        try:
+            header, b64 = uri.split(",", 1)
+            ext = header.split(";")[0].split("/")[-1].lower()
+            ext = {"jpeg": ".jpg"}.get(ext, "." + ext)
+            if ext not in image_audit.IMAGE_EXTS:
+                ext = ".png"
+            fd = tempfile.NamedTemporaryFile(prefix="ivyea-vision-", suffix=ext, delete=False)
+            fd.write(base64.b64decode(b64))
+            fd.close()
+            paths.append(fd.name)
+            tmp.append(fd.name)
+        except Exception:  # noqa: BLE001 — 单张解不开不该拖垮整批
+            continue
+    return paths, tmp
+
+
+def local_cv_describe(images: list[str], question: str) -> tuple[str, str]:
+    """T3：本地量化图片，返回 (注入文本, OCR 引擎名)。失败返回 ("", "")。"""
+    import os as _os
+    from . import local_vision
+
+    paths, tmp = local_data_urls_to_paths(images)
     try:
-        analysis = sidecar_describe(images, user_content, picked)
-    except Exception as e:  # noqa: BLE001
-        narrate(ui.message("warn", f"视觉旁路调用失败（{e}），本轮忽略图片仅按文字继续。"))
-        return user_content, []
-    if not analysis:
-        narrate(ui.message("warn", "视觉模型未返回内容，本轮忽略图片仅按文字继续。"))
-        return user_content, []
-    narrate(ui.message("info", f"主脑不支持图片，已由 {picked['label']} 视觉旁路代读 {len(images)} 张图"))
-    injected = (user_content
-                + f"\n\n[图片内容（主脑不支持图片，已由视觉模型 {picked['label']} 代读，共 {len(images)} 张）]\n"
-                + analysis)
-    return injected, []
+        if not paths:
+            return "", ""
+        result = local_vision.analyze(paths, recursive=False)
+        if not result.get("available"):
+            return "", ""
+        return local_vision.render_for_text_model(result, question=question), str(result.get("ocr_engine") or "")
+    finally:
+        for p in tmp:
+            try:
+                _os.unlink(p)
+            except OSError:
+                pass
+
+
+def route_images(user_content: str, images: list[str], mcfg: dict, narrate) -> tuple[str, list[str], dict]:
+    """视觉三档降级总入口。
+
+    返回 (注入后的 user 内容, 仍要随请求发出的图片, 档位信息)。第三个返回值是
+    新增的——调用方要把它回传给前端/ops，否则用户永远不知道自己拿到的是哪一档的
+    结果（这正是此前"功能静默死掉"的根源）。
+    """
+    from . import ui
+
+    if not images:
+        return user_content, images, {"tier": 0, "label": "无图片", "images": 0}
+
+    if main_has_vision(mcfg):
+        return user_content, images, {
+            "tier": TIER_MAIN,
+            "label": f"主脑直读 · {mcfg.get('model') or mcfg.get('label') or '主脑'}",
+            "images": len(images),
+        }
+
+    picked = pick_vision_model()
+    if picked:
+        try:
+            analysis = sidecar_describe(images, user_content, picked)
+        except Exception as e:  # noqa: BLE001
+            narrate(ui.message("warn", f"视觉旁路调用失败（{e}），改用本地视觉度量。"))
+            analysis = ""
+        if analysis:
+            narrate(ui.message("info", f"主脑不支持图片，已由 {picked['label']} 视觉旁路代读 {len(images)} 张图"))
+            injected = (user_content
+                        + f"\n\n[图片内容（主脑不支持图片，已由视觉模型 {picked['label']} 代读，共 {len(images)} 张）]\n"
+                        + analysis)
+            return injected, [], {"tier": TIER_SIDECAR, "label": f"视觉旁路 · {picked['label']}",
+                                  "images": len(images), "model": picked["cfg"].get("model", "")}
+        narrate(ui.message("warn", "视觉模型未返回内容，改用本地视觉度量。"))
+
+    # T3：本地 CV + OCR。注意这里**不再** fail-open 丢图——丢图会让模型对着
+    # 空气编结论，那比降级更糟。
+    text, ocr_engine = local_cv_describe(images, user_content)
+    if text:
+        narrate(ui.message("info",
+                           f"未配置视觉模型，已用本地 CV{('+' + ocr_engine) if ocr_engine else ''} "
+                           f"量化 {len(images)} 张图（可测量项照常分析，语义/审美判断需配视觉模型）"))
+        return user_content + "\n\n" + text, [], {
+            "tier": TIER_LOCAL_CV,
+            "label": f"本地 CV{('+' + ocr_engine) if ocr_engine else ''}",
+            "images": len(images),
+            "ocr_engine": ocr_engine,
+        }
+
+    narrate(ui.message("warn", "主脑不支持图片，且视觉模型与本地视觉都不可用（本地视觉需要 Pillow），"
+                               "本轮忽略图片仅按文字继续。"))
+    return user_content, [], {"tier": 0, "label": "不可用", "images": len(images)}
+
+
+def chain_status(mcfg: dict | None = None) -> dict:
+    """当前视觉链的状态快照，供 /health 暴露给 IvyeaOps 判定。
+
+    ops 此前只看主脑 caps.vision，主脑无视觉就整块判 agent 不可用；改看这里的
+    `effective` 之后，T2/T3 也算"能处理带图请求"。
+    """
+    from . import config, local_vision
+
+    mcfg = mcfg if mcfg is not None else config.get_model_config()
+    main = main_has_vision(mcfg)
+    picked = None if main else pick_vision_model()
+    cv_ok, cv_detail = local_vision.available()
+    ocr_engine = ""
+    if not main and not picked and cv_ok:
+        from . import ocr as ocr_mod
+        ocr_engine = ocr_mod.engine_name()
+
+    if main:
+        tier = TIER_MAIN
+    elif picked:
+        tier = TIER_SIDECAR
+    elif cv_ok:
+        tier = TIER_LOCAL_CV
+    else:
+        tier = 0
+    return {
+        "tier": tier,
+        "effective": tier > 0,
+        "main": {"vision": main, "model": mcfg.get("model", "")},
+        "sidecar": {"available": bool(picked), "label": picked["label"] if picked else "",
+                    "model": picked["cfg"].get("model", "") if picked else ""},
+        "local_cv": {"available": cv_ok, "detail": cv_detail, "ocr_engine": ocr_engine},
+        "labels": {1: "主脑直读", 2: "视觉旁路", 3: "本地 CV 度量", 0: "不可用"},
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,16 @@ dependencies = [
     # 纯 CPU 轮子约 19MB，Linux/Windows/macOS 都有——**刻意不是 torch**：
     # pip 默认会给 Linux 拉 GB 级的 CUDA 版，小内存机器直接被 OOM 杀掉。
     "onnxruntime>=1.16",
+    # T3 本地视觉（local_vision）的图像解码。纯 wheel、约 3MB，各平台都有。
+    "Pillow>=10.0",
+    # T3 的 OCR 引擎（PP-OCR 系模型的 ONNX 封装，模型内置在 wheel 里，中英电商图
+    # 明显强于 tesseract）。onnxruntime 上面已经有了，这里主要多出 opencv-python。
+    #
+    # **精简 Linux 镜像的坑**：opencv-python 依赖 libGL.so.1，slim/alpine 基础镜像
+    # 默认没有，`import cv2` 会直接抛。ocr.py 的引擎探测是**运行时**做的，抛了会
+    # 自动落到 tesseract、再落到"无 OCR"，T3 的几何/色彩度量不受影响。要修就装
+    # 系统包 mesa-libGL（RHEL 系）/ libgl1（Debian 系）。
+    "rapidocr-onnxruntime>=1.4",
     "openpyxl>=3.1",
     "httpx>=0.27",
     "prompt_toolkit>=3.0",

--- a/tests/test_local_vision.py
+++ b/tests/test_local_vision.py
@@ -157,6 +157,28 @@ def test_layout_from_ocr_boxes():
     assert local_vision._layout_from_ocr([], 1000, 1000) == {}
 
 
+def test_image_local_cli(tmp_path, capsys):
+    """`ivyea image local` —— 让用户能直接核 T3 到底读到了什么。
+
+    没有这个出口时本地视觉是个只在带图对话里间接生效的黑盒，降级结果对不对
+    用户没法自己验。
+    """
+    from ivyea_agent.cli import main
+
+    _canvas(tmp_path / "main.png", 1200, 1200, box=(300, 300, 899, 899))
+    assert main(["image", "local", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert "本地视觉度量" in out
+    assert "1200×1200" in out
+    assert "主体占比" in out
+
+    assert main(["image", "local", str(tmp_path), "--prompt", "--context", "主图合规吗"]) == 0
+    out2 = capsys.readouterr().out
+    assert "注入主脑的文本" in out2
+    assert "主图合规吗" in out2
+    assert "禁止" in out2                      # 约束段必须跟着一起出去
+
+
 def test_broken_file_does_not_kill_the_batch(tmp_path):
     from ivyea_agent import local_vision
 

--- a/tests/test_local_vision.py
+++ b/tests/test_local_vision.py
@@ -1,0 +1,168 @@
+"""T3 本地视觉度量的测试。
+
+合成图而不是抓真实素材：CV 指标要断言**具体数值区间**，只有自己画的图才知道
+正确答案是多少。真实图只能断言"没炸"，那种测试防不住算错。
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PIL")
+
+
+def _canvas(path, w, h, bg=(255, 255, 255), box=None, box_color=(20, 60, 160)):
+    """画一张白底 + 居中色块的图。box 是 (x0,y0,x1,y1) 像素坐标。"""
+    from PIL import Image, ImageDraw
+    im = Image.new("RGB", (w, h), bg)
+    if box:
+        ImageDraw.Draw(im).rectangle(box, fill=box_color)
+    im.save(path)
+    return path
+
+
+def test_white_background_and_coverage(tmp_path):
+    from ivyea_agent import local_vision
+
+    # 1000×1000 白底，正中 500×500 色块 → 主体占比应为 25%
+    p = _canvas(tmp_path / "main.png", 1000, 1000, box=(250, 250, 749, 749))
+    res = local_vision.analyze([str(p)], with_ocr=False)
+
+    assert res["available"] is True
+    img = res["images"][0]
+    assert img["is_white_background"] is True
+    assert img["white_border_ratio"] == pytest.approx(1.0, abs=0.01)
+
+    fg = img["foreground"]
+    assert fg["coverage_ratio"] == pytest.approx(0.25, abs=0.02)
+    assert fg["touches_edge"] is False
+    # 正中放置 → 偏移应接近 0
+    assert abs(fg["center_offset_x"]) < 0.02
+    assert abs(fg["center_offset_y"]) < 0.02
+
+
+def test_non_white_background_is_flagged(tmp_path):
+    from ivyea_agent import local_vision
+
+    p = _canvas(tmp_path / "main.png", 800, 800, bg=(240, 220, 200), box=(100, 100, 699, 699))
+    res = local_vision.analyze([str(p)], with_ocr=False)
+    img = res["images"][0]
+    assert img["is_white_background"] is False
+    # 命名带 main → 角色判定为主图 → 白底不合规必须报 high
+    assert any(r["area"] == "main_white_bg" and r["level"] == "high" for r in res["risks"])
+
+
+def test_off_center_and_edge_bleed(tmp_path):
+    from ivyea_agent import local_vision
+
+    # 色块顶到左上角 → 触边 + 明显偏心
+    p = _canvas(tmp_path / "main.png", 1000, 1000, box=(0, 0, 399, 399))
+    res = local_vision.analyze([str(p)], with_ocr=False)
+    fg = res["images"][0]["foreground"]
+    assert fg["touches_edge"] is True
+    assert fg["center_offset_x"] < -0.4 and fg["center_offset_y"] < -0.4
+    assert any(r["area"] == "main_bleed" for r in res["risks"])
+
+
+def test_palette_finds_the_two_real_colours(tmp_path):
+    from ivyea_agent import local_vision
+
+    p = _canvas(tmp_path / "a.png", 600, 600, box=(0, 0, 299, 599), box_color=(200, 0, 0))
+    res = local_vision.analyze([str(p)], with_ocr=False)
+    palette = res["images"][0]["palette"]
+    hexes = [c["hex"] for c in palette]
+    # 半红半白：两个主色都得在色板里（k-means 会给出近似值，比对通道倾向）
+    assert any(c["rgb"][0] > 150 and c["rgb"][1] < 80 for c in palette), hexes
+    assert any(min(c["rgb"]) > 200 for c in palette), hexes
+    assert sum(c["share"] for c in palette) == pytest.approx(1.0, abs=0.02)
+
+
+def test_palette_survives_a_white_dominated_image(tmp_path):
+    """白底主图（占比 ~88% 白）不许把色板塌成 "#FFFFFF 100%"。
+
+    这是实打实踩过的坑：按亮度分位数播种 k-means，在极度偏斜的白底分布上会让
+    全部质心落进白色簇，产品配色——色板唯一有价值的输出——直接消失。
+    """
+    from ivyea_agent import local_vision
+
+    p = _canvas(tmp_path / "main.png", 1200, 1200, box=(450, 450, 749, 749),
+                box_color=(28, 74, 140))
+    res = local_vision.analyze([str(p)], with_ocr=False)
+    palette = res["images"][0]["palette"]
+
+    assert len(palette) >= 2, palette
+    assert palette[0]["hex"] == "#FFFFFF"                       # 白底仍是第一主色
+    # 产品蓝必须被单独识别出来，且色值贴近真值
+    blue = [c for c in palette if c["rgb"][2] > c["rgb"][0] + 60]
+    assert blue, palette
+    assert abs(blue[0]["rgb"][0] - 28) < 12 and abs(blue[0]["rgb"][2] - 140) < 12
+
+
+def test_alpha_channel_is_used_as_mask(tmp_path):
+    """有 alpha 时用 alpha 当主体掩膜——那是设计稿导出的真边界，比颜色阈值准。"""
+    from PIL import Image
+    from ivyea_agent import local_vision
+
+    im = Image.new("RGBA", (400, 400), (255, 255, 255, 0))
+    im.paste((255, 255, 255, 255), (100, 100, 300, 300))   # 纯白但不透明的主体
+    p = tmp_path / "cut.png"
+    im.save(p)
+
+    res = local_vision.analyze([str(p)], with_ocr=False)
+    fg = res["images"][0]["foreground"]
+    assert res["images"][0]["has_alpha"] is True
+    assert fg["mask_source"] == "alpha"
+    # 纯白主体在纯白背景上，颜色阈值会完全看不见它；alpha 掩膜必须给出 25%
+    assert fg["coverage_ratio"] == pytest.approx(0.25, abs=0.03)
+
+
+def test_duplicate_detection(tmp_path):
+    from ivyea_agent import local_vision
+
+    _canvas(tmp_path / "a.png", 800, 800, box=(200, 200, 599, 599))
+    _canvas(tmp_path / "b.png", 800, 800, box=(200, 200, 599, 599))
+    _canvas(tmp_path / "c.png", 800, 800, box=(0, 0, 199, 199))
+    res = local_vision.analyze([str(tmp_path)], with_ocr=False)
+    pairs = {tuple(sorted((d["a"], d["b"]))) for d in res["duplicates"]}
+    assert ("a.png", "b.png") in pairs
+    assert not any("c.png" in p for p in pairs)
+
+
+def test_render_for_text_model_states_its_limits(tmp_path):
+    """喂给纯文本主脑的那段话必须自带约束，否则模型会照着读数编画面。"""
+    from ivyea_agent import local_vision
+
+    p = _canvas(tmp_path / "main.png", 1500, 1500, box=(300, 300, 1199, 1199))
+    res = local_vision.analyze([str(p)], with_ocr=False)
+    text = local_vision.render_for_text_model(res, question="主图合规吗？")
+
+    assert "主图合规吗？" in text
+    assert "禁止" in text and "编造" in text
+    assert "需要视觉模型才能判断" in text
+    assert "1500×1500" in text
+    assert "主体占画面" in text
+
+
+def test_layout_from_ocr_boxes():
+    from ivyea_agent import local_vision
+
+    boxes = [
+        {"bbox": [10, 10, 500, 80]},      # 顶部横幅
+        {"bbox": [20, 20, 400, 60]},
+    ]
+    layout = local_vision._layout_from_ocr(boxes, 1000, 1000)
+    assert layout["dominant_band"] == "top"
+    assert layout["text_area_ratio"] > 0
+
+    # 没有坐标就不许推版面——tesseract 分支给的就是空 boxes
+    assert local_vision._layout_from_ocr([], 1000, 1000) == {}
+
+
+def test_broken_file_does_not_kill_the_batch(tmp_path):
+    from ivyea_agent import local_vision
+
+    _canvas(tmp_path / "good.png", 600, 600, box=(100, 100, 499, 499))
+    (tmp_path / "bad.png").write_bytes(b"\x89PNG\r\n\x1a\nnot-a-real-png")
+    res = local_vision.analyze([str(tmp_path)], with_ocr=False)
+    names = {i["name"]: i for i in res["images"]}
+    assert "error" in names["bad.png"]
+    assert names["good.png"]["foreground"]["coverage_ratio"] > 0

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -2,11 +2,26 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 from tests.test_image_audit import _png
 
 
-def test_ocr_unavailable(tmp_path, monkeypatch):
+@pytest.fixture
+def no_rapidocr(monkeypatch):
+    """强制 RapidOCR 不可用，把测试固定在 tesseract 分支。
+
+    引擎探测是运行时做的且带模块级缓存，装没装 RapidOCR 的机器会走出两套行为；
+    不钉死这一项，同一份测试在开发机（装了）和 CI（没装）上结论相反。
+    """
     from ivyea_agent import ocr
+    monkeypatch.setattr(ocr, "_RAPID_CACHE", None)
+    monkeypatch.setattr(ocr, "_RAPID_FAILED", "forced-off")
+    return ocr
+
+
+def test_ocr_unavailable(tmp_path, monkeypatch, no_rapidocr):
+    ocr = no_rapidocr
 
     img = tmp_path / "main.png"
     _png(img, 1200, 1200)
@@ -18,7 +33,7 @@ def test_ocr_unavailable(tmp_path, monkeypatch):
     assert "OCR 不可用" in text
 
 
-def test_ocr_available_and_agent_cli(tmp_path, monkeypatch, capsys):
+def test_ocr_available_and_agent_cli(tmp_path, monkeypatch, capsys, no_rapidocr):
     from ivyea_agent.agent_tools import TOOL_SCHEMAS, _DISPATCH, ToolContext
     from ivyea_agent.cli import main
 
@@ -41,3 +56,40 @@ def test_ocr_available_and_agent_cli(tmp_path, monkeypatch, capsys):
     cli_out = capsys.readouterr().out
     assert "图片 OCR" in cli_out
     assert "Waterproof karaoke machine" in cli_out
+
+
+def test_tesseract_rows_carry_empty_boxes(tmp_path, monkeypatch, no_rapidocr):
+    """tesseract 分支必须给出空 boxes 而不是缺字段。
+
+    local_vision 用 `row.get("boxes")` 判断能否推版面骨架；这里若不给字段，
+    换引擎时下游要么 KeyError，要么拿 None 去迭代。
+    """
+    ocr = no_rapidocr
+    _png(tmp_path / "a.png", 800, 800)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/tesseract")
+    monkeypatch.setattr("subprocess.run", lambda cmd, **kw: subprocess.CompletedProcess(
+        cmd, 0, stdout="tesseract 5.0\n" if "--version" in cmd else "HELLO\n"))
+    res = ocr.run([str(tmp_path)])
+    assert res["available"] is True
+    assert res["results"][0]["boxes"] == []
+    assert res["results"][0]["text"] == "HELLO"
+
+
+def test_rapidocr_branch_emits_boxes(tmp_path, monkeypatch):
+    """RapidOCR 分支要把四点坐标压成 bbox，并带上原图尺寸供版面推断。"""
+    from ivyea_agent import ocr
+
+    _png(tmp_path / "b.png", 1000, 500)
+
+    def fake_engine(path):
+        return ([[[[10, 20], [110, 20], [110, 60], [10, 60]], "SALE 50%", 0.97]], 0.01)
+
+    monkeypatch.setattr(ocr, "_RAPID_CACHE", fake_engine)
+    monkeypatch.setattr(ocr, "_RAPID_FAILED", "")
+    res = ocr.run([str(tmp_path)])
+    assert res["available"] is True
+    row = res["results"][0]
+    assert row["ok"] is True
+    assert row["text"] == "SALE 50%"
+    assert row["boxes"][0]["bbox"] == [10.0, 20.0, 110.0, 60.0]
+    assert row["image_width"] == 1000 and row["image_height"] == 500

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -176,13 +176,17 @@ class _SeenProvider:
         return {"content": self.reply, "tool_calls": []}
 
 
-def test_route_images_passthrough_when_main_has_vision(tmp_path, monkeypatch):
+def test_route_images_passthrough_when_main_has_vision(tmp_path, monkeypatch, ivyea_home):
     from ivyea_agent import vision
     img = tmp_path / "a.png"
     _png(img)
-    mcfg = {"provider_id": "openai", "provider": "openai"}
-    content, imgs = vision.route_images("看图", [str(img)], mcfg, lambda s: None)
+    # 判定改成按**模型**而非按 provider：同一个 openai，gpt-4o 能看图、
+    # 老的 text-davinci 不能，所以 mcfg 必须带 model。
+    mcfg = {"provider_id": "openai", "provider": "openai", "model": "gpt-4o",
+            "api_mode": "chat_completions"}
+    content, imgs, tier = vision.route_images("看图", [str(img)], mcfg, lambda s: None)
     assert content == "看图" and imgs == [str(img)]     # 有视觉：原样透传，不剥图
+    assert tier["tier"] == vision.TIER_MAIN
 
 
 def test_route_images_sidecar_injects_and_strips(tmp_path, monkeypatch, ivyea_home):
@@ -194,10 +198,11 @@ def test_route_images_sidecar_injects_and_strips(tmp_path, monkeypatch, ivyea_ho
     monkeypatch.setattr(providers, "from_settings", lambda cfg, key: prov)
     notes = []
     mcfg = {"provider_id": "deepseek", "provider": "deepseek"}   # 主脑无视觉
-    content, imgs = vision.route_images("这图说明什么？", [str(img)], mcfg, notes.append)
+    content, imgs, tier = vision.route_images("这图说明什么？", [str(img)], mcfg, notes.append)
     assert imgs == []                                   # 图已剥掉，主脑只见文本
     assert "销量趋势图" in content and "视觉模型" in content and "这图说明什么？" in content
     assert any("视觉旁路代读" in n for n in notes)
+    assert tier["tier"] == vision.TIER_SIDECAR
     # sidecar 收到的是多模态 content（含 image_url）且带用户问题原文
     user = prov.seen[-1]
     assert isinstance(user["content"], list)
@@ -205,27 +210,67 @@ def test_route_images_sidecar_injects_and_strips(tmp_path, monkeypatch, ivyea_ho
     assert "这图说明什么" in user["content"][0]["text"]
 
 
-def test_route_images_no_vision_provider_available(tmp_path, monkeypatch, ivyea_home):
+def test_route_images_falls_to_local_cv_when_no_vision_model(tmp_path, monkeypatch, ivyea_home):
+    """T3：没有任何视觉模型时**不再丢图**，改用本地 CV 量化回灌。
+
+    旧行为是 warn 一句然后把图片扔掉，模型对着空气编结论——这比降级更糟，
+    也正是 Listing 图片分析长期静默空转的根因。
+    """
+    from ivyea_agent import vision
+    img = tmp_path / "a.png"
+    _png(img, 1200, 1200)
+    monkeypatch.setattr(vision, "pick_vision_model", lambda: None)
+    notes = []
+    content, imgs, tier = vision.route_images("看图", [str(img)], {"provider_id": "deepseek"}, notes.append)
+    assert imgs == []                                   # 图不再随请求发出
+    assert tier["tier"] == vision.TIER_LOCAL_CV
+    assert "看图" in content                            # 原问题保留
+    assert "本地视觉度量" in content                     # CV 读数已注入
+    assert "1200×1200" in content
+    assert any("本地 CV" in n for n in notes)
+
+
+def test_route_images_sidecar_error_degrades_to_local_cv(tmp_path, monkeypatch, ivyea_home):
+    """视觉旁路挂了要继续往下降到 T3，而不是直接放弃图片。"""
+    from ivyea_agent import vision
+    img = tmp_path / "a.png"
+    _png(img, 1000, 1000)
+    monkeypatch.setattr(vision, "pick_vision_model", _fake_pick)
+    monkeypatch.setattr(vision, "sidecar_describe", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("api down")))
+    notes = []
+    content, imgs, tier = vision.route_images("看图", [str(img)], {"provider_id": "deepseek"}, notes.append)
+    assert imgs == []
+    assert tier["tier"] == vision.TIER_LOCAL_CV
+    assert any("视觉旁路调用失败" in n for n in notes)
+
+
+def test_route_images_gives_up_only_when_local_cv_also_dead(tmp_path, monkeypatch, ivyea_home):
+    """三档全灭才回到"忽略图片"，且必须明确 warn。"""
     from ivyea_agent import vision
     img = tmp_path / "a.png"
     _png(img)
     monkeypatch.setattr(vision, "pick_vision_model", lambda: None)
+    monkeypatch.setattr(vision, "local_cv_describe", lambda *a, **k: ("", ""))
     notes = []
-    content, imgs = vision.route_images("看图", [str(img)], {"provider_id": "deepseek"}, notes.append)
-    assert imgs == [] and content == "看图"             # 忽略图片继续文本
-    assert any("没有可用的视觉模型" in n for n in notes)
+    content, imgs, tier = vision.route_images("看图", [str(img)], {"provider_id": "deepseek"}, notes.append)
+    assert imgs == [] and content == "看图" and tier["tier"] == 0
+    assert any("忽略图片" in n for n in notes)
 
 
-def test_route_images_sidecar_error_fail_open(tmp_path, monkeypatch, ivyea_home):
+def test_chain_status_reports_tier(monkeypatch, ivyea_home):
+    """/health 的 vision_chain：ops 靠它判 agent 能不能接带图任务。"""
     from ivyea_agent import vision
-    img = tmp_path / "a.png"
-    _png(img)
-    monkeypatch.setattr(vision, "pick_vision_model", _fake_pick)
-    monkeypatch.setattr(vision, "sidecar_describe", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("api down")))
-    notes = []
-    content, imgs = vision.route_images("看图", [str(img)], {"provider_id": "deepseek"}, notes.append)
-    assert imgs == [] and content == "看图"
-    assert any("视觉旁路调用失败" in n for n in notes)
+    monkeypatch.setattr(vision, "pick_vision_model", lambda: None)
+    st = vision.chain_status({"provider_id": "deepseek", "model": "deepseek-chat",
+                              "api_mode": "chat_completions"})
+    assert st["tier"] == vision.TIER_LOCAL_CV
+    assert st["effective"] is True                      # 主脑没视觉 ≠ 这条链没视觉
+    assert st["main"]["vision"] is False
+    assert st["local_cv"]["available"] is True
+
+    st1 = vision.chain_status({"provider_id": "openai", "model": "gpt-4o",
+                               "api_mode": "chat_completions"})
+    assert st1["tier"] == vision.TIER_MAIN
 
 
 def test_pick_vision_model_prefers_config_key(monkeypatch, ivyea_home):
@@ -238,10 +283,47 @@ def test_pick_vision_model_prefers_config_key(monkeypatch, ivyea_home):
 
 
 def test_pick_vision_model_auto_detects_first_configured(monkeypatch, ivyea_home):
-    from ivyea_agent import vision
-    for env in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"):
-        monkeypatch.delenv(env, raising=False)
+    from ivyea_agent import models, vision
+    # 现在**任何**带视觉模型的 provider 配了 key 都算数（不再是三家白名单），
+    # 所以要清空全部候选的 key_env 才能构造"全未配"。
+    for p in models.providers():
+        env = str(p.get("key_env") or "")
+        if env:
+            monkeypatch.delenv(env, raising=False)
     assert vision.pick_vision_model() is None           # 全未配 → 无可用
     monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
     got = vision.pick_vision_model()
     assert got and got["cfg"]["provider_id"] == "anthropic"
+
+
+def test_pick_vision_model_picks_a_vision_model_not_the_default(monkeypatch, ivyea_home):
+    """选中的必须是该 provider 的**视觉**模型，不能是它的默认文本旗舰。
+
+    旧实现直接取 default_model，于是 OpenRouter 被选中时会拿
+    default_model 去当 sidecar；provider 的默认模型多半是文本模型，必 400。
+    """
+    from ivyea_agent import models, vision
+    for p in models.providers():
+        env = str(p.get("key_env") or "")
+        if env:
+            monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-router")
+    got = vision.pick_vision_model()
+    assert got and got["cfg"]["provider_id"] == "openrouter"
+    assert models.model_name_has_vision(got["cfg"]["model"]) is True
+
+
+def test_vision_slot_overrides_everything(monkeypatch, ivyea_home):
+    """IvyeaOps 下推的显式视觉槽最优先，且不复核模型名。
+
+    自建网关/私有部署的模型名可能完全不带视觉特征词（如 "vlm-prod-v3"），
+    再拿模型名判定一次就会把用户明确配好的槽位否掉。
+    """
+    from ivyea_agent import config, vision
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
+    config.set_setting("vision_slot", {"provider": "custom", "model": "vlm-prod-v3",
+                                       "base_url": "https://gw.internal/v1", "api_key": "k-1"})
+    got = vision.pick_vision_model()
+    assert got["cfg"]["model"] == "vlm-prod-v3"
+    assert got["cfg"]["base_url"] == "https://gw.internal/v1"
+    assert got["key"] == "k-1"

--- a/tests/test_vision_tiers.py
+++ b/tests/test_vision_tiers.py
@@ -1,0 +1,212 @@
+"""视觉能力判定矩阵 + serve 侧三档接线。
+
+这里盯的是两个具体的历史故障：
+  1. 视觉能力按**厂商白名单**判，国内 provider 上的 Qwen-VL/GLM-4V 配了 key 也选不中；
+  2. serve 自己 `raise main_brain_no_vision`，导致 IvyeaOps 在主脑无视觉时整块死掉，
+     而同一台机器上的 CLI 却有旁路可走。
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.test_image_audit import _png
+
+
+# ── 判定矩阵 ──────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("model,expected", [
+    ("gpt-4o", True),
+    ("claude-sonnet-4-6", True),
+    ("gemini-3-pro-preview", True),
+    ("qwen3-vl-235b", True),
+    ("Qwen/Qwen2.5-VL-72B-Instruct", True),      # 硅基流动的大小写混写
+    ("glm-4v-plus", True),
+    ("minicpm-v-2.6", True),
+    ("llava:13b", True),                          # ollama 本地 VLM
+    ("anthropic/claude-sonnet-4.6", True),        # openrouter 带前缀
+    ("deepseek-chat", False),
+    ("deepseek-reasoner", False),
+    ("qwen3-coder", False),
+    ("text-embedding-3-large", False),
+    ("some-unknown-model", None),                 # 看不出来 ≠ 确定没有
+])
+def test_model_name_vision_matrix(model, expected):
+    from ivyea_agent import models
+    assert models.model_name_has_vision(model) is expected
+
+
+def test_model_has_vision_requires_a_capable_transport(ivyea_home):
+    from ivyea_agent import models
+    # 模型名像视觉模型，但传输格式装不下图 → 判否
+    assert models.model_has_vision({"model": "gpt-4o", "api_mode": "some_text_only_mode"}) is False
+    assert models.model_has_vision({"model": "gpt-4o", "api_mode": "chat_completions"}) is True
+    # "看不出来"保守判否（真能看图的话用户可以用 override 打开）
+    assert models.model_has_vision({"model": "vlm-prod-v3", "api_mode": "chat_completions"}) is False
+
+
+def test_vision_capable_override_wins(ivyea_home):
+    """自建网关的模型名不带任何视觉特征词，必须有一个用户说了算的开关。"""
+    from ivyea_agent import config, models
+    mcfg = {"model": "vlm-prod-v3", "api_mode": "chat_completions"}
+    config.set_setting("vision_capable_override", "true")
+    assert models.model_has_vision(mcfg) is True
+    config.set_setting("vision_capable_override", "false")
+    assert models.model_has_vision({"model": "gpt-4o", "api_mode": "chat_completions"}) is False
+
+
+def test_provider_level_vision_is_broader_than_the_old_whitelist():
+    """provider 级 vision 是 UI 徽标语义："这家有视觉可选模型"。
+
+    老实现硬编码 {openai, anthropic, gemini, openai-codex} 四家，国内 provider
+    和聚合网关全被挡在外面。
+    """
+    from ivyea_agent import models
+    caps = {p["id"]: models.provider_capabilities(p).get("vision") for p in models.providers()}
+    assert caps.get("openrouter") is True        # 聚合网关：开放目录
+    assert caps.get("ollama") is True            # 本地 VLM：模型随用户拉
+    assert caps.get("deepseek") is False         # 目录里确实一个视觉模型都没有
+
+
+# ── serve 接线 ────────────────────────────────────────────────────────────
+
+def _data_url(path) -> str:
+    from ivyea_agent import image_audit
+    return image_audit.data_url(path)
+
+
+def test_serve_no_longer_raises_on_images_without_main_vision(tmp_path, monkeypatch, ivyea_home):
+    """核心回归：serve 收到带图请求且主脑无视觉，必须降级而不是抛异常。"""
+    from ivyea_agent import service, vision
+    from ivyea_agent.agent_tools import ToolContext
+
+    img = tmp_path / "main.png"
+    _png(img, 1200, 1200)
+    monkeypatch.setattr(vision, "pick_vision_model", lambda: None)   # 无 T2
+    monkeypatch.setattr("ivyea_agent.config.get_model_config",
+                        lambda: {"provider_id": "deepseek", "model": "deepseek-chat",
+                                 "api_mode": "chat_completions"})
+
+    ctx = ToolContext()
+    out = service._with_payload_images("这套图有问题吗？", {"images": [_data_url(img)]}, ctx)
+
+    assert isinstance(out, str)                        # T3 回纯文本，不是多模态 list
+    assert "这套图有问题吗？" in out
+    assert "本地视觉度量" in out
+    assert ctx.vision_tier["tier"] == vision.TIER_LOCAL_CV
+    assert ctx.vision_notes                            # 降级说明要留给调用方去 narrate
+
+
+def test_serve_passes_images_through_when_main_has_vision(tmp_path, monkeypatch, ivyea_home):
+    from ivyea_agent import service, vision
+    from ivyea_agent.agent_tools import ToolContext
+
+    img = tmp_path / "a.png"
+    _png(img)
+    monkeypatch.setattr("ivyea_agent.config.get_model_config",
+                        lambda: {"provider_id": "openai", "model": "gpt-4o",
+                                 "api_mode": "chat_completions"})
+    ctx = ToolContext()
+    out = service._with_payload_images("看图", {"images": [_data_url(img)]}, ctx)
+
+    assert isinstance(out, list)
+    assert out[0]["text"] == "看图"
+    assert any(part.get("type") == "image_url" for part in out)
+    assert ctx.vision_tier["tier"] == vision.TIER_MAIN
+
+
+def test_sidecar_accepts_data_uris_not_just_file_paths(tmp_path, monkeypatch, ivyea_home):
+    """serve（网页上传）传的是 data URI，CLI 传的是文件路径，两种都得收。
+
+    实测故障：只按文件路径处理时，data URI 在 read_bytes 上抛异常并被静默吞掉，
+    视觉模型一张图没收到却照常作答——编出过一整张不存在的柱状图，数字有名有姓。
+    """
+    from ivyea_agent import mentions, vision, providers
+
+    img = tmp_path / "a.png"
+    _png(img, 800, 800)
+    uri = _data_url(img)
+
+    seen = {}
+
+    class _P:
+        def chat(self, messages, tools=None, **kw):
+            seen["content"] = messages[-1]["content"]
+            return {"content": "图里是一个蓝色方块。", "tool_calls": []}
+
+    monkeypatch.setattr(providers, "from_settings", lambda cfg, key: _P())
+    picked = {"cfg": {"model": "qwen-vl", "provider_id": "custom"}, "key": "k", "label": "vl"}
+
+    # data URI 输入
+    assert vision.sidecar_describe([uri], "这是什么", picked)
+    parts = seen["content"]
+    assert isinstance(parts, list)
+    assert [p for p in parts if p.get("type") == "image_url"], parts
+    assert parts[-1]["image_url"]["url"].startswith("data:image/")
+
+    # 文件路径输入（CLI 那条路）同样成立
+    assert vision.sidecar_describe([str(img)], "这是什么", picked)
+    assert [p for p in seen["content"] if p.get("type") == "image_url"]
+
+    # build_user_content 本身也要两种都吃
+    both = mentions.build_user_content("t", [uri, str(img)])
+    assert len([p for p in both if p.get("type") == "image_url"]) == 2
+
+
+def test_sidecar_refuses_to_answer_with_zero_images(monkeypatch, ivyea_home):
+    """全部图片都挂不上时必须抛错降 T3，绝不能对着纯文字让视觉模型硬答。"""
+    from ivyea_agent import vision, providers
+
+    called = []
+    monkeypatch.setattr(providers, "from_settings",
+                        lambda cfg, key: called.append(1) or (_ for _ in ()).throw(AssertionError("不该发出请求")))
+    picked = {"cfg": {"model": "qwen-vl"}, "key": "k", "label": "vl"}
+
+    with pytest.raises(ValueError, match="未能附上任何图片"):
+        vision.sidecar_describe(["/does/not/exist.png"], "这是什么", picked)
+    assert not called
+
+
+def test_route_images_degrades_when_sidecar_cannot_attach(tmp_path, monkeypatch, ivyea_home):
+    """接上上一条：这种失败要走到 T3，而不是把编造的描述当成结果。"""
+    from ivyea_agent import vision, providers
+
+    img = tmp_path / "main.png"
+    _png(img, 1000, 1000)
+    monkeypatch.setattr(vision, "pick_vision_model",
+                        lambda: {"cfg": {"model": "qwen-vl"}, "key": "k", "label": "vl"})
+    monkeypatch.setattr(providers, "from_settings",
+                        lambda cfg, key: (_ for _ in ()).throw(AssertionError("不该发出请求")))
+    # 传一个既不是路径也不是 data URI 的东西 → 一张都挂不上
+    notes = []
+    content, kept, tier = vision.route_images(
+        "看图", ["https://example.com/not-a-local-image.png"],
+        {"provider_id": "deepseek", "model": "deepseek-chat", "api_mode": "chat_completions"},
+        notes.append)
+    assert tier["tier"] == vision.TIER_LOCAL_CV or tier["tier"] == 0
+    assert kept == []
+
+
+def test_health_exposes_vision_chain(monkeypatch, ivyea_home):
+    """IvyeaOps 判 agent 能不能接带图任务，读的就是这个字段。"""
+    from ivyea_agent import service
+    chain = service.health()["vision_chain"]
+    assert "tier" in chain and "effective" in chain
+    assert "local_cv" in chain and "sidecar" in chain
+
+
+def test_vision_configure_roundtrip(ivyea_home):
+    """ops 下推视觉槽 → 立刻变成 T2，且响应里不回显 key。"""
+    from ivyea_agent import service, vision
+
+    res = service.vision_configure({"provider": "custom", "model": "qwen2.5-vl-72b",
+                                    "base_url": "https://gw.internal/v1", "api_key": "sk-secret"})
+    assert res["ok"] is True
+    assert res["configured"]["model"] == "qwen2.5-vl-72b"
+    assert "api_key" not in res["configured"]
+    assert "sk-secret" not in str(res)
+
+    picked = vision.pick_vision_model()
+    assert picked and picked["cfg"]["model"] == "qwen2.5-vl-72b"
+
+    cleared = service.vision_configure({"model": ""})
+    assert cleared["cleared"] is True


### PR DESCRIPTION
## 问题

serve 收到带图请求时，主脑不支持图片就直接 `raise main_brain_no_vision` —— 而 IvyeaOps 走的正是 serve 这条路。于是用户主脑一配 DeepSeek 这类纯文本模型，Listing 的图片分析就整块空转，而同一台机器上的 CLI 却有旁路可走。

## 改法

三档统一在 `vision.route_images` 里，CLI 和 serve 共用：

| 档 | 条件 | 行为 |
|---|---|---|
| T1 主脑直读 | 主脑自带视觉 | 图片原样进上下文 |
| T2 视觉旁路 | 配了视觉模型 | 代读成文字回灌主脑（原有能力，这次接进 serve） |
| T3 本地量化 | 都没有 | 本地 CV + OCR 量化成读数回灌（新增） |

T3 新增 `local_vision.py`：白底合规、主体占比/居中偏移/触边、k-means 主色板、高频区占比、dHash 查重、OCR 文本与版面分布。全程本机跑，图片不出网。注入主脑的文本自带约束，要求区分「读数」与「推断」、答不了就直说需要视觉模型。

## 顺带修掉的三个真问题

- **视觉能力判定从厂商白名单改成「传输格式 + 模型名」**。旧的 `{openai, anthropic, gemini, openai-codex}` 四家硬编码，把硅基流动/DashScope/智谱/OpenRouter/Ollama 上的 Qwen-VL、GLM-4V、本地 VLM 全挡在外面——而那恰恰是国内用户配得起的那些。判定同时从 provider 级下沉到模型级：同一个 OpenRouter，选 claude 能看图、选 deepseek-chat 不能。留 `vision_capable_override` 作逃生门。
- **`pick_vision_model` 不再拿 provider 的 `default_model` 当 sidecar**。默认模型多半是文本旗舰（deepseek-chat、qwen3-coder…），选中即 400。
- **`build_user_content` 只认文件路径，data URI 会在 `read_bytes` 抛异常后被静默吞掉**。serve 传的正是 data URI —— 视觉模型一张图没收到却照常作答，实测编出过一整张不存在的柱状图，数字有名有姓。现在两种输入都收，且 sidecar 在零附件时硬失败降到 T3。

## 其他

- OCR 引擎升级为 RapidOCR（ONNX，模型内置），tesseract 降为兜底。`import cv2` 在缺 libGL 的精简镜像会炸，所以引擎探测放在运行时，炸了自动往下退，不拖垮 T3。
- 新增 `POST /v1/config/vision` 接收 IvyeaOps 下推的视觉槽；`/health` 增加 `vision_chain`，让 ops 判「能不能接带图任务」时看整条链而不是只看主脑。
- 新增 `ivyea image local`，让 T3 的读数能被直接核对。

## 验证

- `pytest -m 'not slow'`：**1062 passed, 1 skipped**
- **三档都做了真跑**（不是只跑单测）：
  - T3 — 纯文本主脑 DeepSeek 靠本地读数正确判出主图带 "SALE 50% OFF" 的合规风险，且严格区分了读数与推断，没有编造画面；
  - T2 — 走硅基流动 Qwen3-VL 正确描述画面；
  - T1 — 用临时 cfg 验证多模态直读，未改动任何用户配置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)