### PR TITLE
service-stop 谎报成功 + 自更新指向不存在的 PyPI 包

### DIFF
--- a/deploy/systemd/ivyea-agent.service
+++ b/deploy/systemd/ivyea-agent.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=IvyeaAgent serve (local HTTP API on 127.0.0.1:8765)
+Documentation=https://agent.ivyea.com
+After=network.target
+# IvyeaOps 把几乎所有 AI 功能都转给这个服务（对话、知识库、Listing 文案与图片
+# 分析、ASIN 审计、定时任务）。它没起来时 ops 只剩很小一部分直连兜底能用，
+# 所以让 ops 排在它后面启动，省掉开机后那一阵"agent 未连接"。
+Before=ivyea-ops.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/root/ivyea-agent
+# HOME 必须显式给：agent 的配置、知识库、会话、密钥全在 ~/.ivyea 下，
+# systemd 不继承登录 shell 的环境，缺了它会去 / 下面找而静默用一套空配置。
+Environment=HOME=/root
+Environment=PYTHONUNBUFFERED=1
+# 用 `python -m` 而不是 `ivyea serve`：这台机是 editable 安装，`-m` 从
+# WorkingDirectory 解析，改完代码重启即生效，和发版流程一致。
+ExecStart=/usr/bin/python3 -m ivyea_agent.cli serve --host 127.0.0.1 --port 8765
+Restart=always
+RestartSec=3
+
+# 升级流程会先 `ivyea self service-stop`（SIGTERM）再启新进程。这里 Restart=always
+# 会在 3 秒内把它拉回来 —— 拉起来的是**新代码**（WorkingDirectory 就是源码树），
+# 之后 ops 那次 start 探到端口已通就直接返回 already_running，两边不打架。
+KillMode=control-group
+TimeoutStopSec=20
+
+# 别把它挂在别人的 cgroup 命运上：这台机上原先的 serve 是从 ttyd 里手动拉起的，
+# ttyd 一 OOM 或重启就可能连坐带走它（主终端那次故障就是这么来的）。
+OOMPolicy=continue
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/部署指南.md
+++ b/docs/部署指南.md
@@ -128,6 +128,40 @@ curl -s http://127.0.0.1:8765/v1/manifest
 
 `ops-bootstrap` 会输出健康检查 URL、manifest/openapi URL、只读 stdio MCP 配置、安装命令和 systemd/launchd/Windows 自启动模板。IvyeaOps 可以优先读 `/v1/system/bootstrap` 和 `/v1/openapi.json` 做能力发现，不需要在前端硬编码端点。
 
+### 让 serve 常驻（Linux / systemd）
+
+**不要用 `nohup` / `setsid` 手动拉起。**那样起来的进程没有任何托管：机器重启不会自己起、
+崩了不会拉回来，还会挂在拉起它的那个终端（ttyd/tmux）的 cgroup 下——宿主一 OOM 就被连坐带走。
+
+用户级（不需要 root）：
+
+```bash
+ivyea self service-autostart      # 生成 ~/.config/systemd/user/ivyea-agent.service
+systemctl --user daemon-reload
+systemctl --user enable --now ivyea-agent
+```
+
+系统级（服务器上和 IvyeaOps 一起跑，推荐）：仓库里放了一份现成的
+`deploy/systemd/ivyea-agent.service`，按你的路径改 `WorkingDirectory` / `HOME` 后：
+
+```bash
+sudo cp deploy/systemd/ivyea-agent.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now ivyea-agent
+systemctl status ivyea-agent
+```
+
+三个容易漏掉、漏了就出事的字段：
+
+| 字段 | 漏了会怎样 |
+| --- | --- |
+| `WorkingDirectory` | `python -m ivyea_agent.cli` 按 cwd 解析包，源码安装时直接启动失败 |
+| `Environment=HOME=…` | systemd 不继承登录 shell 的环境；缺了会去别处找 `~/.ivyea`，**静默用一套空配置**（比启动失败更难查） |
+| `OOMPolicy=continue` | 跟宿主 cgroup 一起被连坐杀掉 |
+
+`Restart=always` 是刻意的：升级流程会先 `ivyea self service-stop`（正常退出，
+`on-failure` 不会拉回来），再由 systemd 用**新代码**重新拉起。
+
 配置文件位置：
 
 | 文件 | 用途 |

--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.13.0"
+__version__ = "1.13.1"

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -2851,7 +2851,7 @@ def _cmd_self(args: argparse.Namespace) -> int:
         print(self_manage.render_service_status(result.get("service") or self_manage.service_status(args.host, args.port)))
         return 0
     if args.action == "service-stop":
-        result = self_manage.service_stop(timeout=args.timeout, force=args.force)
+        result = self_manage.service_stop(timeout=args.timeout, force=args.force, port=args.port)
         print(self_manage.render_service_status(result.get("service") or self_manage.service_status(probe=False)))
         return 0 if result.get("ok") else 1
     if args.action == "service-logs":

--- a/ivyea_agent/self_manage.py
+++ b/ivyea_agent/self_manage.py
@@ -97,6 +97,36 @@ def _pid_cmdline(pid: int) -> list[str]:
     return [part.decode("utf-8", errors="replace") for part in raw.split(b"\0") if part]
 
 
+def _discover_service_pid(port: int) -> int:
+    """在 pidfile 之外，按"谁真的在跑这个 serve"找出 PID。
+
+    **为什么必须有这条兜底**：service_stop 原本只认 pidfile，pidfile 不在或里面是
+    个陈旧 PID 时直接 `return already_stopped=True` —— 可服务明明还在跑。这台机上
+    实测就是这样：pidfile 里躺着一个早就死掉的 PID，health 却是通的，于是
+    `ivyea self service-stop` **谎报停止成功，旧进程原封不动**。IvyeaOps 的升级流程
+    正是先调它再启新进程，结果是"版本号更新了、跑的还是旧代码"，而且毫无报错。
+
+    凡是不经 `self service-start` 拉起的 serve 都会命中这个坑：systemd 托管的、
+    手动 `python -m ivyea_agent.cli serve` 起的、以及 setsid 起的孤儿进程。
+
+    只在 Linux 上按 /proc 扫（能拿到 cmdline 做精确匹配）；其它平台返回 0，
+    交给原有的 pidfile 路径——宁可不动，也不能凭猜杀进程。
+    """
+    if os.name == "nt" or not Path("/proc").exists():
+        return 0
+    try:
+        pids = [int(p) for p in os.listdir("/proc") if p.isdigit()]
+    except OSError:
+        return 0
+    me = os.getpid()
+    for pid in pids:
+        if pid == me:
+            continue
+        if _pid_matches_service(pid, port) and _pid_cmdline(pid):
+            return pid
+    return 0
+
+
 def _pid_matches_service(pid: int, port: int | None = None) -> bool:
     parts = _pid_cmdline(pid)
     if not parts:
@@ -284,15 +314,27 @@ def service_start(
     }
 
 
-def service_stop(timeout: float = 10.0, force: bool = False) -> dict[str, Any]:
-    current = service_status(probe=False)
+def service_stop(timeout: float = 10.0, force: bool = False, port: int = 8765) -> dict[str, Any]:
+    # probe=True：**必须真探一下端口**。只看 pidfile 的话，pidfile 缺失或过期时会
+    # 直接报"已停止"，而服务还在好好地跑（见 _discover_service_pid 的说明）。
+    current = service_status(port=port, probe=True)
     pid = int(current.get("pid") or 0)
+    discovered = 0
     if not pid or not current.get("pid_running"):
-        try:
-            _pid_file().unlink(missing_ok=True)
-        except OSError:
-            pass
-        return {"ok": True, "already_stopped": True, "service": current}
+        # pidfile 不可信 → 按端口找真身。找不到、且健康检查也不通，才算真的停了。
+        discovered = _discover_service_pid(int(port))
+        if not discovered:
+            if current.get("health_running"):
+                return {"ok": False, "error": "service_running_but_pid_unknown",
+                        "detail": f"{port} 端口仍在响应，但找不到对应进程，无法停止。"
+                                  "请手动确认后停止（该端口的监听进程）。",
+                        "service": current}
+            try:
+                _pid_file().unlink(missing_ok=True)
+            except OSError:
+                pass
+            return {"ok": True, "already_stopped": True, "service": current}
+        pid = discovered
 
     if os.name == "nt":
         cmd = ["taskkill", "/PID", str(pid), "/T"]
@@ -318,7 +360,13 @@ def service_stop(timeout: float = 10.0, force: bool = False) -> dict[str, Any]:
             _pid_file().unlink(missing_ok=True)
         except OSError:
             pass
-    return {"ok": stopped, "stopped": stopped, "pid": pid, "service": service_status(probe=False)}
+    # 收尾也要真探端口：systemd 托管时进程被杀会立刻拉起新的，那**不是**失败——
+    # 端口照样通，且跑的是新代码。这里如实报出来，让调用方自己判断。
+    after = service_status(port=port, probe=True)
+    return {"ok": stopped, "stopped": stopped, "pid": pid,
+            "discovered_pid": bool(discovered),
+            "port_still_serving": bool(after.get("health_running")),
+            "service": after}
 
 
 def autostart_files(host: str = "127.0.0.1", port: int = 8765) -> dict[str, Any]:
@@ -360,13 +408,28 @@ def autostart_files(host: str = "127.0.0.1", port: int = 8765) -> dict[str, Any]
         target = Path.home() / ".config" / "systemd" / "user" / "ivyea-agent.service"
         content = "\n".join([
             "[Unit]",
-            "Description=Ivyea Agent local API",
+            "Description=IvyeaAgent serve (local HTTP API)",
+            "After=network.target",
             "",
             "[Service]",
-            "ExecStart=" + " ".join(cmd),
-            "Restart=on-failure",
-            "RestartSec=3",
+            "Type=simple",
+            # 从源码目录起时必须给 WorkingDirectory：`python -m ivyea_agent.cli` 按
+            # cwd 解析包，缺了它 systemd 会在 / 下找不到而直接启动失败。
+            f"WorkingDirectory={Path(__file__).resolve().parent.parent}",
+            # HOME 要显式给：配置、知识库、会话、密钥全在 ~/.ivyea 下，systemd 不
+            # 继承登录 shell 的环境，缺了它会静默用一套空配置（比启动失败更难查）。
+            f"Environment=HOME={Path.home()}",
+            "Environment=PYTHONUNBUFFERED=1",
             f"Environment=IVYEA_HOME={config.IVYEA_DIR}",
+            "ExecStart=" + " ".join(cmd),
+            # always 而不是 on-failure：升级流程会先把它 SIGTERM 掉（正常退出，
+            # on-failure 不会拉回来），再由 systemd 用**新代码**重新拉起。
+            "Restart=always",
+            "RestartSec=3",
+            "TimeoutStopSec=20",
+            # 别跟着别人的 cgroup 一起死：从终端复用器（ttyd/tmux）里手动拉起过的
+            # 实例，宿主一 OOM 就会被连坐带走。
+            "OOMPolicy=continue",
             "",
             "[Install]",
             "WantedBy=default.target",

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -688,6 +688,7 @@ def system_service_stop(payload: dict[str, Any]) -> dict[str, Any]:
     result = self_manage.service_stop(
         timeout=float(payload.get("timeout") or 10),
         force=bool(payload.get("force")),
+        port=int(payload.get("port") or DEFAULT_PORT),
     )
     return {"ok": bool(result.get("ok")), "result": result}
 

--- a/ivyea_agent/updater.py
+++ b/ivyea_agent/updater.py
@@ -96,31 +96,65 @@ def _source_repo() -> Path | None:
         return None
 
 
-def update_commands() -> list[list[str]]:
+REPO_URL = f"https://github.com/{_REPO}.git"
+
+
+def source_url(ref: str) -> str:
+    """pip 能装的源地址。**装 tag，不装 PyPI，也不装 main。**
+
+    `ivyea-agent` 从来没发布到 PyPI（实测 404），旧实现却对 pip/pipx 用户返回
+    `pip install --upgrade ivyea-agent` —— 那条命令必然失败。更麻烦的是这个名字
+    在 PyPI 上是空的，随时可能被人抢注，届时它会给用户装上**别人的包**。
+
+    也不用 `@main`：更新检测比的是 GitHub 最新 **release tag**，装 main 就意味着
+    "提示你更新到 v1.13.0，实际给你装了含未发布代码的 main"。发行流水线
+    (release.yml) 早就刻意拒绝回退 main，这里保持同一策略。
+    """
+    return f"git+{REPO_URL}@{ref}"
+
+
+def update_commands(ref: str = "") -> list[list[str]]:
     """本机的更新命令（跨平台，**不依赖 bash**——Windows 没有 bash，旧版把命令包成
     `bash -lc` 直接 WinError 2）：
-    - 源码仓 → `git pull`（git 跨平台在 PATH）。
-    - pipx 安装 → 直接跑 `pipx upgrade ivyea-agent`（解析 pipx 可执行文件绝对路径，
-      Windows 下即 pipx.exe）。
-    - 其余（venv / ivyea-runtime / unknown）→ 用当前解释器的 pip 升级，无 PATH/shell 依赖。
+    - 源码仓 → `git pull`（开发机；不把开发者硬拽到某个 tag 上）。
+    - pipx 安装 → `pipx install --force <git+...@tag>`（pipx 没有"从 VCS 升级"的
+      子命令，--force 重装是官方做法）。
+    - 其余（venv / ivyea-runtime / unknown）→ 当前解释器的 pip 装同一个 tag。
+
+    `ref` 为空表示调用方没解析出 release tag —— 这时**不返回 pip/pipx 命令**，
+    宁可让上层报"取不到版本"，也不能退回 PyPI 或 main 去装一个来路不明的东西。
     """
     root = _source_repo()
     if root is not None:
         return [["git", "-C", str(root), "pull", "--ff-only"]]
+    if not ref:
+        return []
+    url = source_url(ref)
     try:
         from . import self_manage
         info = self_manage.install_info()
         if info.get("method") == "pipx":
             pipx = shutil.which("pipx") or (info.get("pipx") or "") or "pipx"
-            return [[pipx, "upgrade", "ivyea-agent"]]
+            return [[pipx, "install", "--force", url]]
     except Exception:
         pass
-    return [[sys.executable, "-m", "pip", "install", "--upgrade", "ivyea-agent"]]
+    # 不加 --no-deps：版本之间会新增依赖（1.13.0 就加了 Pillow / rapidocr），
+    # 跳过依赖会让新功能装完即坏，且坏得很安静。
+    return [[sys.executable, "-m", "pip", "install", "--upgrade",
+             "--no-cache-dir", "--force-reinstall", url]]
 
 
 def do_update() -> tuple[bool, str]:
     """执行更新命令，返回 (ok, 合并输出)。"""
-    cmds = update_commands()
+    ref = ""
+    if _source_repo() is None:
+        ref = _fetch_latest(timeout=8.0) or ""
+        if not ref:
+            return False, ("取不到 GitHub 最新 release，已中止更新。\n"
+                           "这里**故意不回退**到 main 或 PyPI —— 前者会装上未发布代码，"
+                           "后者根本不存在这个包。请检查网络后重试，或用 "
+                           "IVYEA_AGENT_REF 指定版本手动安装。")
+    cmds = update_commands(ref)
     if not cmds:
         return False, "没有可用的更新命令。"
     out: list[str] = []

--- a/tests/test_self_manage.py
+++ b/tests/test_self_manage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import types
 import zipfile
@@ -154,3 +155,67 @@ def test_self_cli_dry_run_and_backup(ivyea_home, capsys):
 
     assert main(["self", "backup", "--output", str(ivyea_home / "backup.zip")]) == 0
     assert "backup.zip" in capsys.readouterr().out
+
+
+def test_service_stop_finds_a_serve_it_did_not_start(ivyea_home, monkeypatch):
+    """pidfile 不可信时按端口找真身，绝不谎报"已停止"。
+
+    实测故障：pidfile 里躺着一个早就死掉的 PID，服务却在正常跑（health 通）。
+    旧实现直接 `return already_stopped=True`，于是 `ivyea self service-stop`
+    报成功而旧进程原封不动 —— IvyeaOps 的升级流程正是先调它再启新进程，
+    结果是"版本号更新了、跑的还是旧代码"，且毫无报错。
+
+    凡是不经 `self service-start` 拉起的 serve 都会命中：systemd 托管的、
+    手动起的、setsid 起的孤儿进程。
+    """
+    from ivyea_agent import self_manage
+
+    (ivyea_home / "run").mkdir(parents=True, exist_ok=True)
+    # 陈旧 pidfile：进程早没了
+    (ivyea_home / "run" / "ivyea-agent.pid").write_text(
+        json.dumps({"pid": 999999, "port": 8765}), encoding="utf-8")
+
+    monkeypatch.setattr(self_manage, "_probe_health", lambda h, p: {"ok": True})
+    monkeypatch.setattr(self_manage, "_discover_service_pid", lambda port: 4242)
+
+    killed: list = []
+    alive = {4242: True}      # 陈旧的 999999 从来就不在，4242 被杀之后才消失
+
+    monkeypatch.setattr(self_manage, "_pid_running", lambda pid: bool(alive.get(pid)))
+    if os.name == "nt":
+        monkeypatch.setattr(
+            self_manage.subprocess, "run",
+            lambda cmd, *a, **k: (killed.append(cmd), alive.pop(4242, None),
+                                  types.SimpleNamespace(returncode=0))[-1])
+    else:
+        monkeypatch.setattr(self_manage.os, "kill",
+                            lambda pid, sig: (killed.append(pid), alive.pop(pid, None)))
+
+    res = self_manage.service_stop(timeout=1)
+    assert res["discovered_pid"] is True
+    assert res["pid"] == 4242
+    assert killed, "必须真的去停那个发现出来的进程"
+
+
+def test_service_stop_refuses_to_lie_when_it_cannot_find_the_process(ivyea_home, monkeypatch):
+    """端口还在响应、又找不到进程时，必须报失败而不是"已停止"。"""
+    from ivyea_agent import self_manage
+
+    monkeypatch.setattr(self_manage, "_pid_running", lambda pid: False)
+    monkeypatch.setattr(self_manage, "_probe_health", lambda h, p: {"ok": True})
+    monkeypatch.setattr(self_manage, "_discover_service_pid", lambda port: 0)
+
+    res = self_manage.service_stop(timeout=1)
+    assert res["ok"] is False
+    assert res["error"] == "service_running_but_pid_unknown"
+
+
+def test_service_stop_still_reports_already_stopped_when_truly_down(ivyea_home, monkeypatch):
+    from ivyea_agent import self_manage
+
+    monkeypatch.setattr(self_manage, "_pid_running", lambda pid: False)
+    monkeypatch.setattr(self_manage, "_probe_health", lambda h, p: {"ok": False})
+    monkeypatch.setattr(self_manage, "_discover_service_pid", lambda port: 0)
+
+    res = self_manage.service_stop(timeout=1)
+    assert res["ok"] is True and res["already_stopped"] is True

--- a/tests/test_tools_general.py
+++ b/tests/test_tools_general.py
@@ -56,13 +56,16 @@ def test_run_command_background_and_output(tmp_path):
     r = tg.t_run_command({"command": "echo hello-bg", "run_in_background": True}, ctx)
     assert "bash_id=" in r
     bid = re.search(r"bash_id=(bg-\d+)", r).group(1)
-    out = ""
+    # t_bash_output 是**增量**的：读过的不再返回。所以必须累加，不能只留最后一次——
+    # 机器一忙，"hello-bg" 和 "已结束" 就会落在两次轮询里，只看最后一次必然漏掉输出，
+    # 于是这条用例在负载高时随机变红（实测撞到过）。
+    seen = ""
     for _ in range(50):
-        out = tg.t_bash_output({"bash_id": bid}, ctx)
-        if "已结束" in out:
+        seen += tg.t_bash_output({"bash_id": bid}, ctx)
+        if "已结束" in seen:
             break
         time.sleep(0.1)
-    assert "hello-bg" in out and "已结束" in out       # 轮询到输出 + 退出状态
+    assert "hello-bg" in seen and "已结束" in seen     # 轮询到输出 + 退出状态
 
 
 def test_kill_bash(tmp_path):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import time
+import types
 
 
 def test_norm_and_has_update():
@@ -40,3 +41,58 @@ def test_update_commands_source_repo():
     from ivyea_agent import updater
     cmds = updater.update_commands()          # 本仓即源码仓 → git pull
     assert cmds and cmds[0][0] == "git" and "pull" in cmds[0]
+
+
+def test_update_commands_never_fall_back_to_pypi_or_main(monkeypatch):
+    """pip/pipx 路径必须装 **release tag 的 git 源**，不许碰 PyPI，也不许装 main。
+
+    两个实测事实：
+      1. `ivyea-agent` 从来没发布到 PyPI（`pip index versions` → 404），旧实现却
+         对 pip 用户返回 `pip install --upgrade ivyea-agent`，那条命令必然失败；
+         而且这个名字空着可被抢注，届时会给用户装上别人的包。
+      2. 更新检测比的是 GitHub 最新 release tag，装 main 就意味着"提示更新到
+         v1.13.0、实际装了含未发布代码的 main"。
+    """
+    from ivyea_agent import updater
+
+    monkeypatch.setattr(updater, "_source_repo", lambda: None)   # 非源码仓 → 走 pip
+    cmds = updater.update_commands("v9.9.9")
+    assert cmds, "有 ref 就该给出命令"
+    flat = " ".join(cmds[0])
+    assert "git+https://github.com/Hector-xue/ivyea-agent.git@v9.9.9" in flat
+    assert "@main" not in flat
+    # 末尾那个孤零零的包名（PyPI 目标）不许再出现
+    assert cmds[0][-1].startswith("git+"), cmds
+    # 新增依赖必须能装上：1.13.0 就加了 Pillow / rapidocr，--no-deps 会让新功能装完即坏
+    assert "--no-deps" not in flat
+
+
+def test_update_commands_refuse_without_a_ref(monkeypatch):
+    """解析不出 release tag 时宁可什么都不做，也不能瞎装。"""
+    from ivyea_agent import updater
+
+    monkeypatch.setattr(updater, "_source_repo", lambda: None)
+    assert updater.update_commands("") == []
+
+
+def test_do_update_aborts_when_release_cannot_be_resolved(monkeypatch):
+    from ivyea_agent import updater
+
+    monkeypatch.setattr(updater, "_source_repo", lambda: None)
+    monkeypatch.setattr(updater, "_fetch_latest", lambda timeout=8.0: None)
+    ok, out = updater.do_update()
+    assert ok is False
+    assert "故意不回退" in out
+
+
+def test_do_update_uses_the_resolved_tag(monkeypatch):
+    from ivyea_agent import updater
+
+    ran = []
+    monkeypatch.setattr(updater, "_source_repo", lambda: None)
+    monkeypatch.setattr(updater, "_fetch_latest", lambda timeout=8.0: "v1.13.1")
+    monkeypatch.setattr(updater.subprocess, "run",
+                        lambda cmd, **k: ran.append(cmd) or types.SimpleNamespace(returncode=0, stdout="done"))
+    ok, _out = updater.do_update()
+    assert ok is True
+    assert any("@v1.13.1" in " ".join(c) for c in ran), ran


### PR DESCRIPTION
两个都会让「更新」看起来成功、实际没生效的 bug，加上 systemd 托管。

## 1. `service_stop` 谎报成功 → 「升级了但跑的还是旧代码」

`service_stop` 只认 pidfile：pidfile 缺失或里面是个陈旧 PID 时，直接
`return already_stopped=True` —— 可服务明明还在跑。这台机上实测就是这样，
pidfile 里躺着一个早就死掉的 PID（1702348），health 却是通的。

后果不只是「停不掉」。IvyeaOps 的升级流程是「先 `ivyea self service-stop` →
再启新进程 → 读 pip 刚写下的版本号当作 after」，于是：

> **升级 UI 显示成功、版本号变成新的、实际跑的还是旧代码，且毫无报错。**

凡是不经 `self service-start` 拉起的 serve 都会中招——systemd 托管的、手动
`python -m ivyea_agent.cli serve` 起的、以及 setsid 起的孤儿进程。

改法：pidfile 不可信时按端口扫 `/proc` 找真身（复用已有的 `_pid_matches_service`
做精确匹配，只在 Linux 上扫；其它平台宁可不动也不凭猜杀进程）；**端口还在响应
却找不到进程时报失败而不是「已停止」**；收尾时真探一次端口并回报
`port_still_serving`（systemd 下进程被杀会立刻拉起新的，那不是失败，但调用方
有权知道）。

## 2. 自更新指向不存在的 PyPI 包

`update_commands()` 对 pip/pipx 用户返回 `pip install --upgrade ivyea-agent`，
可这个包**从来没发布到 PyPI**（实测 `pip index versions` → 404），命令必然失败。
通过 IvyeaOps 的 install.sh 装的用户走的正是这条路。

而且这个名字在 PyPI 上空着，随时可能被抢注，届时会给用户装上**别人的包**。

改成装 GitHub 的 **release tag**：不用 PyPI，也不用 `@main`（更新检测比的是
release tag，装 main = 「提示更新到 v1.13.0、实际装了含未发布代码的 main」，
release.yml 早就刻意拒绝回退 main）。解析不出 release 就中止并说明，不猜。
去掉 `--no-deps` —— 版本之间会新增依赖（1.13.0 就加了 Pillow / rapidocr），
跳过依赖会让升级「成功」但新功能装完即坏，且坏得很安静。

## 3. systemd 托管

新增 `deploy/systemd/ivyea-agent.service`，并把 `autostart_files()` 生成的模板
补齐三个漏了就出事的字段：

| 字段 | 漏了会怎样 |
|---|---|
| `WorkingDirectory` | `python -m ivyea_agent.cli` 按 cwd 解析包，源码安装直接起不来 |
| `Environment=HOME` | systemd 不继承登录 shell 环境，缺了会**静默用一套空配置**（比起不来更难查） |
| `OOMPolicy=continue` | 跟终端复用器（ttyd/tmux）的 cgroup 连坐被杀 |

`Restart` 从 `on-failure` 改 `always`：升级时的 SIGTERM 是正常退出，
`on-failure` 不会把它拉回来。

## 验证

- `pytest -m 'not slow'`：**1069 passed, 1 skipped**
- 线上实跑：`kill -9` 后 3 秒自动拉起 ✓；`service_stop` 真停掉 systemd 托管的
  进程（`discovered_pid: True`，PID 确实变了）✓
- 顺手修了一条会随机变红的用例：`t_bash_output` 是增量返回，测试只保留最后一次
  轮询结果，机器一忙「输出」和「已结束」落在两次轮询里就必然漏掉输出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)