### PR TITLE
docs: 协作规约改用 AGENTS.md，并移除本机路径

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# IvyeaAgent 协作规约
+
+面向在这个仓库里干活的**任何** AI 编码助手（Claude Code / Codex / Hermes / Cursor / Kiro …），
+以及未来的自己。
+
+> 各家工具读的文件名不同，这份是唯一的正本。`CLAUDE.md` 只是指向这里的入口。
+> 改规约改这份，不要改入口文件。
+
+## 这是什么
+
+一个专做 Amazon 场景的 agent，既能在终端里对话使用（`ivyea chat`），也能被
+[IvyeaOps](https://github.com/Hector-xue/IvyeaOps) 当成服务编程驱动。Python，随 IvyeaOps
+一起打包分发。
+
+立项理由见 [ADR-0001](./docs/decisions/0001-why-build-this.md)。
+
+## 常用命令
+
+```bash
+python3 -m pytest                    # 全量测试
+python3 -m pytest -m "not slow"      # 跳过真跑构建/模型的重测试
+python3 -m ruff check .              # lint（CI 会卡）
+ivyea chat                           # 交互式对话
+ivyea chat -p "..." --output-format stream-json   # 非交互，结构化输出（IvyeaOps 走这条）
+systemctl restart ivyea-agent        # 生产 serve（127.0.0.1:8765）改完重启
+```
+
+生产的 `agent-serve` 由 systemd 托管，**不要手工 nohup / setsid 起**。
+
+## 工作方式：五步开发流
+
+收到开发任务后按顺序执行，回复里显式标出步骤：
+
+1. **理解需求边界** → 2. **制定技术方案** → 3. **复核方案并优化** → 4. **执行**（零省略）
+→ 5. **校验**
+
+**未经确认不得跳步直接写代码。**
+
+配套要求：
+
+- **动手前必须核实**消费方契约、真实数据来源、运行环境。第一步建立在猜测上，后面四步全错。
+- **声明完成前必须自检消费方**。这条也是 agent 自身的行为准则
+  （[ADR-0004](./docs/decisions/0004-self-verification-gate.md)）—— 对自己和对它要求一致。
+- 终端交互的改动要用 **pty + pyte 真实跑**来验证，不要只读代码判断显示效果。
+
+## 落档纪律（重要，每次会话都要做）
+
+**做完事必须把结果写进文档。对话会消失，文档不会。** 不管你是哪个工具，这条都适用。
+
+### 一、进仓库（会随开源发布出去，面向使用者和贡献者）
+
+| 做了什么 | 落到哪 |
+|---|---|
+| 对使用者有影响的改动 | [CHANGELOG.md](./CHANGELOG.md) 的 Unreleased 段 |
+| 方向性取舍、引入/移除依赖、踩到值得记住的坑 | 新建 [docs/decisions/](./docs/decisions/) 下的 ADR，编号顺延，并更新该目录 README 的索引表 |
+
+### 二、留本机（作者的私人记录，**不要提交进仓库**）
+
+位置：`/root/dev-history/ivyea-agent/`
+
+| 做了什么 | 落到哪 |
+|---|---|
+| 发版了、或做完一件成规模的事 | `timeline.md` 追加当天条目，标注日期与所用工具 |
+| 需求状态变化 | `roadmap.md` |
+
+同目录下的 `journal.md` 由 git 钩子自动追加，**不要手工编辑**，它是写 `timeline.md` 时的素材。
+
+`/root/dev-history/` 同时存着多个 AI CLI 的原始会话与逐日摘要。**那些原始会话含密钥和业务
+数据，连同上面两份私人记录，都不能进这个公开仓库。**
+
+## 发布纪律
+
+- **未经明确批准不要 push / 开 PR / 合并 / 打 tag 发版。** 改完本地 commit 后停下汇报。
+- 发版走 **GitHub Release 资产，不发 PyPI**。`self update` 也按这个前提设计：源码装的走
+  `git pull`，其余回落 pip / pipx。
+- 版本号只有一个来源（`ivyea_agent.__version__`），打 tag 时会校验版本与 tag 一致。
+  历史上 `__version__` 漂移导致过「永远提示有更新」。
+
+## 几条容易再犯的坑
+
+- **`service stop` 曾经只认 pidfile 就报成功**，害得「升级了却还在跑旧代码」。判断服务停没停
+  要看真实进程。
+- **`pgrep` 会匹配到自己**，写检测脚本时注意排除。
+- **知识卡的 `source_url` 必须真实核实过**，不能是模型编的链接。
+- 知识库的 `index.json` 目前靠手工维护，改了知识卡要记得同步。
+- **改完 serve 必须重启**才生效。
+- 相似度**绝对阈值不可靠**；bge 系列推荐的查询前缀实测更差，不要照搬模型卡建议。
+- 本机内存装不下 CUDA 版 torch，方案必须在 CPU 上可行。
+- 跨平台断言不要硬编码路径分隔符（`tests/conftest.py` 里记了约定）。
+
+## 想了解这个项目怎么走到今天
+
+- [CHANGELOG.md](./CHANGELOG.md) —— 81 个版本的人话说明（在仓库里）
+- [docs/decisions/](./docs/decisions/) —— 7 份 ADR，为什么这么选（在仓库里）
+- `/root/dev-history/ivyea-agent/timeline.md` —— 逐日时间线，从 2026-06-16 立项起（本机私有）
+- `/root/dev-history/ivyea-agent/milestones.md` —— 七个转折点（本机私有）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,19 +54,14 @@ systemctl restart ivyea-agent        # 生产 serve（127.0.0.1:8765）改完重
 | 对使用者有影响的改动 | [CHANGELOG.md](./CHANGELOG.md) 的 Unreleased 段 |
 | 方向性取舍、引入/移除依赖、踩到值得记住的坑 | 新建 [docs/decisions/](./docs/decisions/) 下的 ADR，编号顺延，并更新该目录 README 的索引表 |
 
-### 二、留本机（作者的私人记录，**不要提交进仓库**）
+### 二、维护者的私人记录（不在本仓库）
 
-位置：`/root/dev-history/ivyea-agent/`
+项目维护者另有一套本机私有的开发历史归档 —— 逐日时间线、里程碑、需求池，以及由 git 钩子
+自动追加的提交流水。它由本机多个 AI CLI 的会话存档还原而来，**不进这个公开仓库**：里面含
+密钥、业务数据和个人记录。
 
-| 做了什么 | 落到哪 |
-|---|---|
-| 发版了、或做完一件成规模的事 | `timeline.md` 追加当天条目，标注日期与所用工具 |
-| 需求状态变化 | `roadmap.md` |
-
-同目录下的 `journal.md` 由 git 钩子自动追加，**不要手工编辑**，它是写 `timeline.md` 时的素材。
-
-`/root/dev-history/` 同时存着多个 AI CLI 的原始会话与逐日摘要。**那些原始会话含密钥和业务
-数据，连同上面两份私人记录，都不能进这个公开仓库。**
+如果你在给维护者本人干活，那套归档的落档要求写在它自己的 README 里，按那份做。
+如果你是外部贡献者，这一节与你无关 —— 按上面第一节做就够了。
 
 ## 发布纪律
 
@@ -90,7 +85,5 @@ systemctl restart ivyea-agent        # 生产 serve（127.0.0.1:8765）改完重
 
 ## 想了解这个项目怎么走到今天
 
-- [CHANGELOG.md](./CHANGELOG.md) —— 81 个版本的人话说明（在仓库里）
-- [docs/decisions/](./docs/decisions/) —— 7 份 ADR，为什么这么选（在仓库里）
-- `/root/dev-history/ivyea-agent/timeline.md` —— 逐日时间线，从 2026-06-16 立项起（本机私有）
-- `/root/dev-history/ivyea-agent/milestones.md` —— 七个转折点（本机私有）
+- [CHANGELOG.md](./CHANGELOG.md) —— 81 个版本的人话说明
+- [docs/decisions/](./docs/decisions/) —— 7 份 ADR，为什么这么选

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,88 +1,11 @@
-# IvyeaAgent 协作规约
+# 协作规约入口
 
-面向在这个仓库里干活的 AI 助手（以及未来的自己）。
+本仓库的协作规约在 **[AGENTS.md](./AGENTS.md)**，那是唯一的正本。
 
-## 这是什么
+**请先完整读一遍 AGENTS.md 再动手。** 它规定了五步开发流、落档纪律（做完事必须写进哪些
+文档）、发布纪律，以及几条反复咬人的坑。
 
-一个专做 Amazon 场景的 agent，既能在终端里对话使用（`ivyea chat`），也能被
-[IvyeaOps](https://github.com/Hector-xue/IvyeaOps) 当成服务编程驱动。Python，随 IvyeaOps
-一起打包分发。
+之所以分成两个文件：各家 AI 工具默认读的文件名不同（Claude Code 读 `CLAUDE.md`，多数其他
+工具读 `AGENTS.md`），把内容放一处、其余做入口，才不会两边说法不一致。
 
-立项理由见 [ADR-0001](./docs/decisions/0001-why-build-this.md)。
-
-## 常用命令
-
-```bash
-python3 -m pytest                    # 全量测试
-python3 -m pytest -m "not slow"      # 跳过真跑构建/模型的重测试
-python3 -m ruff check .              # lint（CI 会卡）
-ivyea chat                           # 交互式对话
-ivyea chat -p "..." --output-format stream-json   # 非交互，结构化输出（IvyeaOps 走这条）
-systemctl restart ivyea-agent        # 生产 serve（127.0.0.1:8765）改完重启
-```
-
-生产的 `agent-serve` 由 systemd 托管，**不要手工 nohup / setsid 起**。
-
-## 工作方式：五步开发流
-
-收到开发任务后按顺序执行，回复里显式标出步骤：
-
-1. **理解需求边界** → 2. **制定技术方案** → 3. **复核方案并优化** → 4. **执行**（零省略）
-→ 5. **校验**
-
-**未经确认不得跳步直接写代码。**
-
-配套要求：
-
-- **动手前必须核实**消费方契约、真实数据来源、运行环境。第一步建立在猜测上，后面四步全错。
-- **声明完成前必须自检消费方**。这条也是 agent 自身的行为准则
-  （[ADR-0004](./docs/decisions/0004-self-verification-gate.md)）—— 对自己和对它要求一致。
-- 终端交互的改动要用 **pty + pyte 真实跑**来验证，不要只读代码判断显示效果。
-
-## 落档纪律（重要）
-
-**每次会话做完事，必须把结果落到文档里。** 对话会消失，文档不会。
-
-**进仓库的两类**（会随开源发布出去，面向使用者和贡献者）：
-
-| 做了什么 | 落到哪 |
-|---|---|
-| 对使用者有影响的改动 | [CHANGELOG.md](./CHANGELOG.md) 的 Unreleased 段 |
-| 方向性取舍、引入/移除依赖、踩到值得记住的坑 | 新建 [docs/decisions/](./docs/decisions/) 下的 ADR |
-
-**留本机的两类**（作者的私人记录，`/root/dev-history/ivyea-agent/`，**不要提交进仓库**）：
-
-| 做了什么 | 落到哪 |
-|---|---|
-| 发版了、或做完一件成规模的事 | `/root/dev-history/ivyea-agent/timeline.md` 追加当天条目 |
-| 需求状态变化 | `/root/dev-history/ivyea-agent/roadmap.md` |
-
-`/root/dev-history/` 同时存着四个 AI CLI 的原始会话与逐日摘要，2026-06 至今的历史就是从那里
-还原的。**那些原始会话含密钥和业务数据，连同上面两份私人记录，都不能进这个公开仓库。**
-
-## 发布纪律
-
-- **未经明确批准不要 push / 开 PR / 合并 / 打 tag 发版。** 改完本地 commit 后停下汇报。
-- 发版走 **GitHub Release 资产，不发 PyPI**。`self update` 也按这个前提设计：源码装的走
-  `git pull`，其余回落 pip / pipx。
-- 版本号只有一个来源（`ivyea_agent.__version__`），打 tag 时会校验版本与 tag 一致。
-  历史上 `__version__` 漂移导致过「永远提示有更新」。
-
-## 几条容易再犯的坑
-
-- **`service stop` 曾经只认 pidfile 就报成功**，害得「升级了却还在跑旧代码」。判断服务停没停
-  要看真实进程。
-- **`pgrep` 会匹配到自己**，写检测脚本时注意排除。
-- **知识卡的 `source_url` 必须真实核实过**，不能是模型编的链接。
-- 知识库的 `index.json` 目前靠手工维护，改了知识卡要记得同步。
-- **改完 serve 必须重启**才生效。
-- 相似度**绝对阈值不可靠**；bge 系列推荐的查询前缀实测更差，不要照搬模型卡建议。
-- 本机内存装不下 CUDA 版 torch，方案必须在 CPU 上可行。
-- 跨平台断言不要硬编码路径分隔符（`tests/conftest.py` 里记了约定）。
-
-## 想了解这个项目怎么走到今天
-
-- [CHANGELOG.md](./CHANGELOG.md) —— 81 个版本的人话说明（在仓库里）
-- [docs/decisions/](./docs/decisions/) —— 7 份 ADR，为什么这么选（在仓库里）
-- `/root/dev-history/ivyea-agent/timeline.md` —— 逐日时间线，从 2026-06-16 立项起（本机私有）
-- `/root/dev-history/ivyea-agent/milestones.md` —— 七个转折点（本机私有）
+**改规约请改 AGENTS.md，不要改这个文件。**

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -12,7 +12,7 @@ git log 记得住「改了什么」，记不住「为什么不选另一条路」
 - 踩了一个坑，而这个坑的根因值得让未来的自己记住
 
 日常改 bug、加功能不用写 —— 那些看 [CHANGELOG](../../CHANGELOG.md) 和
-[时间线](/root/dev-history/ivyea-agent/timeline.md)（本机私有）。
+维护者本机私有的开发时间线。
 
 ## 索引
 


### PR DESCRIPTION
两个提交，一个引入、一个收尾。

## 1. 协作规约改用 AGENTS.md

原来的规约只写在 `CLAUDE.md` 里，而那个文件名只有 Claude Code 认。换用其他 AI 工具维护时
规约读不到，落档纪律和发布纪律都会失效。改成 `AGENTS.md` 作唯一正本，`CLAUDE.md` 只留
11 行指向它。

## 2. 移除维护者的本机路径

上一版把「落档到本机私有归档」这半边的规则连同绝对路径写进了公开仓库：外部贡献者拿到的是
一份指向不存在路径、要求写维护者私人文件的指令，同时也把私有归档的位置公开了。

现在只保留「进仓库」那半 —— CHANGELOG 与 ADR；私人那半移到归档目录自己的 README。
仓库里不再出现任何本机路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)