### PR TITLE
-p 也有输入通道：追加指令 / 选项卡 / 优雅中止

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@
 
 ---
 
+## [v1.16.1] - 2026-08-28
+
+### 新增
+
+- **`-p` 也有输入通道了**：`ivyea chat -p --input-format stream-json` 会从 stdin 逐行读
+  控制消息。此前 `-p` 是一条单行道（喂一句、读一串、退出），中间那几十分钟里调用方
+  没有任何一条路走回来 —— 于是在 IvyeaOps 的 /agents 聊天里，ivyea 这一档既插不进话、
+  也弹不出选项卡，想停只能 SIGTERM，而那样**这一轮跑出来的东西一个字都不落盘**。
+  - `{"type":"user_input","text":"…"}` —— 追加指令，在下一个步边界插进当前这一轮，
+    插进去回一条 `injected` 事件供调用方销账。
+  - `{"type":"control_response","request_id":"…","response":{"answers":{…}}}` ——
+    回答 `ask_user_question` 弹出的选项卡（进程侧发 `control_request`）。
+  - `{"type":"interrupt"}` —— **优雅中止**：在下一个安全点收摊，已经跑出来的正文/
+    执行过程/时间账照常落盘，回一条 `result.subtype=cancelled`，退出码 0。
+  - 不带这个开关时行为逐字不变（stdin 照常不读）。
+
 ## [v1.16.0] - 2026-08-28
 
 ### 新增

--- a/docs/decisions/0031-a-running-turn-can-still-be-talked-to.md
+++ b/docs/decisions/0031-a-running-turn-can-still-be-talked-to.md
@@ -81,7 +81,22 @@
   用户改了主意就抹掉。
 - **发 `cancelled` 而不是 `error`**。界面会把 error 画成红色的失败 —— 而这不是失败。
 
-### 四、时间是服务端的事实
+### 四、`-p` 也要有这三条通道（v1.16.1 补齐）
+
+上面三条通道都长在 serve（常驻 HTTP）上。但**消费方不止 serve**：IvyeaOps 的
+`/agents` 聊天走的是 `ivyea chat -p` 子进程，隔着进程边界够不着 serve 进程里的那些
+注册表。于是同样三件事在那边一件都做不成，而且"停止"只能 SIGTERM —— `_persist()`
+来不及跑，整轮产出蒸发。
+
+所以 `-p` 自己开一条：`--input-format stream-json`，stdin 逐行收控制消息
+（`user_input` / `control_response` / `interrupt`），stdout 混发 `control_request`。
+形状照抄 Claude Code 的 stdio control protocol —— IvyeaOps 的 claude_driver 已经在说
+这套话，消费方少学一套。
+
+读 stdin 的是**守护线程**，轮次线程只在自己的安全点（步边界、模型流的每个事件）
+来取：什么时候有人说话完全取决于人，不能让轮次阻塞在读上。
+
+### 五、时间是服务端的事实
 
 顺带把"这一轮什么时候开始、什么时候结束、跑了多久"落盘（`turn_times`，与 `steps`
 一样**平行于 messages**存 —— message dict 会原样回灌给 provider，多一个自定义键
@@ -93,7 +108,8 @@
 
 ## 结果
 
-- `POST /v1/chat/inject`、`POST /v1/chat/question`、`POST /v1/chat/cancel`、
+- CLI：`ivyea chat -p --input-format stream-json`（v1.16.1）。
+- serve：`POST /v1/chat/inject`、`POST /v1/chat/question`、`POST /v1/chat/cancel`、
   `GET /v1/chat/live-sessions` 四个新端点；`final` 增加 `auto_decisions` / `injected` / `injected_pending` /
   `started_ms` / `ended_ms` / `ms`；SSE 增加 `injected` / `question_request` /
   `question_timeout`。

--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.16.0"
+__version__ = "1.16.1"

--- a/ivyea_agent/cli.py
+++ b/ivyea_agent/cli.py
@@ -2368,7 +2368,8 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         "/workspace": _sh_embedded, "/patch": _sh_embedded, "/gitops": _sh_embedded,
     }
 
-    def _execute_turn(line, render, narrate, cancel_check=None, render_reasoning=None, emit=None):
+    def _execute_turn(line, render, narrate, cancel_check=None, render_reasoning=None, emit=None,
+                      inject_check=None, on_inject=None):
         """跑一轮对话，输出经 render(token)/narrate(行) 注入 —— 供 TUI 复用（行式循环仍走下方原逻辑）。
         cancel_check：运行中请求中断的钩子（TUI 用）。emit(event)：stream-json 结构化事件回调。
         返回 {text, usage, cost, blocked}。"""
@@ -2445,7 +2446,8 @@ def _cmd_chat(args: argparse.Namespace) -> int:
         out = agent_loop.run_turn_stream(provider, ctx, messages, model=mcfg.get("model", ""),
                                          render=render, narrate=narrate, cancel_check=cancel_check,
                                          render_reasoning=render_reasoning, emit=emit,
-                                         tools=routing.tools_for(route))
+                                         tools=routing.tools_for(route),
+                                         inject_check=inject_check, on_inject=on_inject)
         c = meter.add(mcfg.get("model", ""), out.get("usage") or {})
         out["cost"] = c or 0.0
         _ui["ctx"] = int((out.get("usage") or {}).get("prompt_tokens") or _ui["ctx"])
@@ -2491,8 +2493,50 @@ def _cmd_chat(args: argparse.Namespace) -> int:
                     sid, cfg.get_model_config().get("model", ""), os.getcwd(),
                     [t["function"]["name"] for t in agent_tools.TOOL_SCHEMAS],
                     "acceptEdits" if ctx.perm.accept_edits else "default"))
-            _out = _execute_turn(args.print_prompt, lambda t: None, _narrate,
-                                 emit=_sj_mod.emit_line if _sj else None)
+            # --input-format stream-json：stdin 也是一条 NDJSON 通道 —— 调用方可以在
+            # 轮次跑着的时候插一句话、回答选项卡、或者叫停。不开这个开关时行为逐字不变
+            # （stdin 照常不读，`-p` 仍是"喂一句、读一串、退出"）。
+            _ctrl = None
+            if getattr(args, "input_format", "text") == "stream-json":
+                from .stdio_control import StdioControl
+                _ctrl = StdioControl(_sj_mod.emit_line).start()
+                ctx.ask_fn = _ctrl.ask          # 选项卡走 stdout/stdin，不再是"没人可问"
+            def _on_inject_p(item: dict) -> None:
+                """追加指令真的插进这一轮了 —— 回一条事件，调用方据此销账。
+
+                调用方（IvyeaOps）靠它认领"这句话到底被读到没有"：没收到回执的，
+                本轮结束后当成下一轮发出去。
+                """
+                if _sj:
+                    _sj_mod.emit_line({"type": "injected", "session_id": sid,
+                                       "id": str(item.get("id") or ""),
+                                       "text": str(item.get("text") or ""),
+                                       "ts": item.get("ts") or 0})
+
+            try:
+                _out = _execute_turn(
+                    args.print_prompt, lambda t: None, _narrate,
+                    emit=_sj_mod.emit_line if _sj else None,
+                    cancel_check=(_ctrl.cancelled if _ctrl else None),
+                    inject_check=(_ctrl.drain if _ctrl else None),
+                    on_inject=_on_inject_p if _ctrl else None,
+                )
+            except KeyboardInterrupt:
+                # 被叫停：**这不是异常结局**。已经跑出来的东西照常落盘（下面那句
+                # `_persist()`），再明确回一条 cancelled —— SIGTERM 掉进程的老做法
+                # 正是在这里丢掉整轮产出的。
+                _persist()
+                if _ctrl:
+                    _ctrl.close()
+                if _sj:
+                    _sj_mod.emit_line({"type": "result", "subtype": "cancelled",
+                                       "is_error": False, "cancelled": True,
+                                       "session_id": sid, "result": "",
+                                       "duration_ms": int((time.time() - _t0) * 1000)})
+                return 0
+            finally:
+                if _ctrl:
+                    _ctrl.close()
             _persist()               # -p 也落盘会话：session_id 可供 --resume 真续接
             if _show_progress and _out.get("todos_panel"):
                 print(_out["todos_panel"], file=sys.stderr, flush=True)
@@ -4863,6 +4907,10 @@ def build_parser() -> argparse.ArgumentParser:
                      default="text",
                      help="-p 输出格式：text=最终答案纯文本（默认）；stream-json=逐行 NDJSON 事件"
                           "（system/init→assistant→tool_result→result，对齐 Claude Code，供程序消费）")
+    pch.add_argument("--input-format", dest="input_format", choices=["text", "stream-json"],
+                     default="text",
+                     help="-p 输入通道：text=不读 stdin（默认，行为不变）；stream-json=从 stdin 逐行读"
+                          "控制消息 —— user_input 追加指令、control_response 回答选项卡、interrupt 优雅中止")
     pch.set_defaults(func=_cmd_chat)
     return p
 

--- a/ivyea_agent/stdio_control.py
+++ b/ivyea_agent/stdio_control.py
@@ -1,0 +1,157 @@
+"""`ivyea chat -p --input-format stream-json` 的控制通道：stdin 进、stdout 出。
+
+── 为什么要有它 ──────────────────────────────────────────────────────────────
+`-p` 是一次性子进程：调用方喂一句话、读一串 NDJSON、进程退出。中间那几十分钟里，
+**没有任何一条路能从调用方走回来** —— stdin 是关着的。后果有三：
+
+  · 想在轮次跑着的时候补一句话，做不到（IvyeaOps 的 /agents 聊天就卡在这）；
+  · `ask_user_question` 弹不出选项卡（没有通道 → 立刻按推荐项走，等于没问）；
+  · 想中止只能 SIGTERM 整个进程 —— **这一轮跑出来的东西一个字都不落盘**，
+    因为 `_persist()` 根本来不及跑。
+
+serve（常驻 HTTP）那边这三件事都有解（`/v1/chat/inject`、`/question`、`/cancel`），
+但那是另一个进程里的注册表，隔着进程边界够不着。所以 `-p` 需要自己的通道。
+
+── 协议 ──────────────────────────────────────────────────────────────────────
+形状对齐 Claude Code 的 stdio control protocol（IvyeaOps 的 claude_driver 已经在
+说这套话，消费方少学一套）：
+
+  调用方 → 进程（stdin，一行一个 JSON）
+    {"type":"user_input","text":"顺便把预算也看一下"}      追加指令
+    {"type":"control_response","request_id":"…","response":{"answers":{…}}}  选项卡的答案
+    {"type":"interrupt"}                                   中止这一轮（优雅收摊）
+
+  进程 → 调用方（stdout，混在既有的 NDJSON 事件流里）
+    {"type":"control_request","request_id":"…","request":{"subtype":"ask_user_question",…}}
+
+**读 stdin 的是一个守护线程**：轮次线程在跑模型/工具，不能被读阻塞；而 stdin 上
+什么时候来消息完全取决于人。线程读到就往内存里放，轮次线程在自己的安全点（步边界、
+模型流的每个事件）来取。
+"""
+from __future__ import annotations
+
+import json
+import queue
+import secrets
+import sys
+import threading
+import time
+from typing import Any, Optional
+
+
+class StdioControl:
+    """一次 `-p` 运行的控制通道。没开 `--input-format stream-json` 时压根不构造。"""
+
+    def __init__(self, emit) -> None:
+        #: 往 stdout 写一行 NDJSON（复用 stream_json.emit_line，保证和事件流同一把锁/同一格式）
+        self._emit = emit
+        self._lock = threading.Lock()
+        self._inbox: list[dict[str, Any]] = []          # 待插入的追加指令
+        self._pending: dict[str, "queue.Queue[dict]"] = {}   # request_id → 等答案的槽
+        self._cancelled = threading.Event()
+        self._closed = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    # ── 生命周期 ────────────────────────────────────────────────────────────
+    def start(self, stream=None) -> "StdioControl":
+        self._thread = threading.Thread(target=self._read_loop, args=(stream or sys.stdin,),
+                                        name="ivyea-stdio-control", daemon=True)
+        self._thread.start()
+        return self
+
+    def close(self) -> None:
+        self._closed.set()
+        # 还挂着等答案的，一律放行成"没人答"——调用方走了，谁也不会再回了。
+        with self._lock:
+            slots = list(self._pending.values())
+        for slot in slots:
+            try:
+                slot.put_nowait({})
+            except queue.Full:
+                pass
+
+    # ── 读端（守护线程）────────────────────────────────────────────────────
+    def _read_loop(self, stream) -> None:
+        try:
+            for raw in stream:
+                if self._closed.is_set():
+                    return
+                line = (raw or "").strip()
+                if not line.startswith("{"):
+                    continue
+                try:
+                    msg = json.loads(line)
+                except (ValueError, TypeError):
+                    continue        # 半截 JSON / 噪音：跳过这一行，别把通道带崩
+                self._handle(msg)
+        except Exception:  # noqa: BLE001 —— stdin 断了就是调用方走了，不是错误
+            return
+
+    def _handle(self, msg: dict) -> None:
+        kind = str(msg.get("type") or "")
+        if kind == "user_input":
+            text = str(msg.get("text") or "").strip()
+            if text:
+                with self._lock:
+                    self._inbox.append({"id": str(msg.get("id") or secrets.token_hex(6)),
+                                        "text": text, "ts": time.time()})
+            return
+        if kind == "interrupt":
+            self._cancelled.set()
+            return
+        if kind == "control_response":
+            request_id = str(msg.get("request_id") or "")
+            with self._lock:
+                slot = self._pending.get(request_id)
+            if slot is None:
+                return              # 已经超时收摊了：迟到的答案直接丢，不改变已发生的事
+            response = msg.get("response")
+            try:
+                slot.put_nowait(response if isinstance(response, dict) else {})
+            except queue.Full:
+                pass
+
+    # ── 写端（轮次线程在安全点调用）────────────────────────────────────────
+    def drain(self) -> list[dict[str, Any]]:
+        """取走待插入的追加指令（agent_loop 在步边界调用）。"""
+        with self._lock:
+            items, self._inbox = self._inbox, []
+        return items
+
+    def cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
+    def ask(self, questions: list[dict], timeout_s: float) -> Optional[dict]:
+        """ask.AskFn 的 stdio 实现：发 control_request → 等 control_response。
+
+        超时/调用方断开都返回 None —— 由 `ask.resolve` 收敛到"按推荐项继续"。
+        分段等待而不是一次 get(timeout)：调用方中途走了（stdin 关了）就尽早收摊，
+        没必要在一个没人会回的问题上把整轮挂满五分钟。
+        """
+        request_id = secrets.token_hex(8)
+        slot: "queue.Queue[dict]" = queue.Queue(maxsize=1)
+        with self._lock:
+            self._pending[request_id] = slot
+        deadline = time.time() + float(timeout_s)
+        try:
+            self._emit({
+                "type": "control_request",
+                "request_id": request_id,
+                "request": {"subtype": "ask_user_question", "questions": questions,
+                            "timeout_s": float(timeout_s), "expires_at": deadline},
+            })
+            while True:
+                try:
+                    got = slot.get(timeout=0.5)
+                except queue.Empty:
+                    if self._closed.is_set() or self._cancelled.is_set():
+                        return None
+                    if time.time() >= deadline:
+                        self._emit({"type": "control_request", "request_id": request_id,
+                                    "request": {"subtype": "ask_user_question_timeout"}})
+                        return None
+                    continue
+                return got or None
+        finally:
+            with self._lock:
+                self._pending.pop(request_id, None)

--- a/tests/test_stdio_control.py
+++ b/tests/test_stdio_control.py
@@ -1,0 +1,114 @@
+"""`-p --input-format stream-json` 的控制通道：stdin 进（追加指令/答案/中止）、stdout 出。
+
+为什么这条通道必须存在：`-p` 是一次性子进程，中间那几十分钟里调用方**没有任何一条路
+走回来**。于是 IvyeaOps 的 /agents 聊天里，ivyea 这一档既插不进话、也弹不出选项卡，
+想停只能 SIGTERM —— 而那样这一轮跑出来的东西一个字都不会落盘。
+"""
+from __future__ import annotations
+
+import io
+import json
+import threading
+import time
+
+from ivyea_agent.stdio_control import StdioControl
+
+
+def _pipe(lines: list[str]) -> io.StringIO:
+    return io.StringIO("".join(l + "\n" for l in lines))
+
+
+def test_user_input_lands_in_the_inbox():
+    sent: list = []
+    ctrl = StdioControl(sent.append).start(_pipe([
+        json.dumps({"type": "user_input", "text": "顺便把预算也看一下"}),
+        json.dumps({"type": "user_input", "text": "  "}),          # 空的不算
+        "不是 JSON 的一行",                                          # 噪音不该带崩通道
+    ]))
+    for _ in range(100):
+        if ctrl.drain.__self__._inbox:                              # noqa: SLF001 — 等读线程
+            break
+        time.sleep(0.01)
+    items = ctrl.drain()
+    assert [i["text"] for i in items] == ["顺便把预算也看一下"]
+    assert ctrl.drain() == []                                       # 取走即消费
+    ctrl.close()
+
+
+def test_interrupt_sets_the_cancel_flag():
+    ctrl = StdioControl(lambda _e: None).start(_pipe([json.dumps({"type": "interrupt"})]))
+    for _ in range(100):
+        if ctrl.cancelled():
+            break
+        time.sleep(0.01)
+    assert ctrl.cancelled() is True
+    ctrl.close()
+
+
+def test_ask_round_trip():
+    """选项卡：发 control_request → 调用方回 control_response → 拿到答案。"""
+    sent: list = []
+    reader, writer = io.StringIO(), None
+    ctrl = StdioControl(sent.append)
+
+    # 手工喂一条答案：先拿到 request_id，再按它回
+    def answer_later():
+        for _ in range(200):
+            if sent:
+                rid = sent[0]["request_id"]
+                ctrl._handle({"type": "control_response", "request_id": rid,     # noqa: SLF001
+                              "response": {"answers": {"口径按哪个？": "环比"}}})
+                return
+            time.sleep(0.01)
+
+    ctrl.start(reader)
+    t = threading.Thread(target=answer_later)
+    t.start()
+    got = ctrl.ask([{"question": "口径按哪个？", "options": [{"label": "环比"}, {"label": "同比"}]}], 5)
+    t.join()
+
+    assert got == {"answers": {"口径按哪个？": "环比"}}
+    assert sent[0]["type"] == "control_request"
+    assert sent[0]["request"]["subtype"] == "ask_user_question"
+    ctrl.close()
+
+
+def test_ask_times_out_and_says_so():
+    """没人答：返回 None（由 ask.resolve 收敛到"按推荐项继续"），并回一条超时事件。"""
+    sent: list = []
+    ctrl = StdioControl(sent.append).start(io.StringIO(""))
+    started = time.time()
+    assert ctrl.ask([{"question": "q", "options": [{"label": "A"}]}], 0.6) is None
+    assert time.time() - started < 3
+    assert [e["request"]["subtype"] for e in sent] == [
+        "ask_user_question", "ask_user_question_timeout"]
+    ctrl.close()
+
+
+def test_closing_the_channel_releases_a_waiting_ask():
+    """调用方走了（stdin 关了）就别再等 —— 五分钟挂在一个没人会回的问题上是纯浪费。"""
+    ctrl = StdioControl(lambda _e: None).start(io.StringIO(""))
+    box: dict = {}
+
+    def asker():
+        box["out"] = ctrl.ask([{"question": "q", "options": [{"label": "A"}]}], 300)
+
+    t = threading.Thread(target=asker)
+    t.start()
+    time.sleep(0.3)
+    started = time.time()
+    ctrl.close()
+    t.join(timeout=5)
+    assert box.get("out") in (None, {})
+    assert time.time() - started < 5
+
+
+def test_late_answer_after_timeout_is_ignored():
+    """迟到的答案不该改变已经发生的事（那一步早按推荐项走下去了）。"""
+    sent: list = []
+    ctrl = StdioControl(sent.append).start(io.StringIO(""))
+    assert ctrl.ask([{"question": "q", "options": [{"label": "A"}]}], 0.5) is None
+    rid = sent[0]["request_id"]
+    ctrl._handle({"type": "control_response", "request_id": rid,        # noqa: SLF001
+                  "response": {"answers": {"q": "A"}}})                  # 不抛、不改变什么
+    ctrl.close()


### PR DESCRIPTION
`-p` 此前是一条单行道：喂一句、读一串、退出。中间那几十分钟里调用方**没有任何一条路走回来** —— 于是在 IvyeaOps 的 `/agents` 聊天里，ivyea 这一档既插不进话、也弹不出选项卡；想停只能 SIGTERM，而那样 `_persist()` 根本来不及跑：这一轮读过的文件、吐出来的正文、时间账全部凭空消失，用户以为自己只是"点了停止"。

## `--input-format stream-json`

形状照抄 Claude Code 的 stdio control protocol（IvyeaOps 的 claude_driver 已经在说这套话，消费方少学一套）：

| stdin → 进程 | 作用 |
|---|---|
| `{"type":"user_input","text":"…"}` | 追加指令，下一个**步边界**插进当前这一轮；插进去回一条 `injected` 事件供调用方销账 |
| `{"type":"control_response","request_id":"…","response":{"answers":{…}}}` | 回答 `ask_user_question` 弹出的选项卡（进程侧发 `control_request`） |
| `{"type":"interrupt"}` | **优雅中止**：安全点收摊、照常落盘、回 `result.subtype=cancelled`、退出码 0 |

读 stdin 的是**守护线程**，轮次线程只在自己的安全点（步边界、模型流的每个事件）来取 —— 什么时候有人说话完全取决于人，不能让轮次阻塞在读上。

不带这个开关时行为**逐字不变**（stdin 照常不读）。

## 校验

- 2084 项测试通过（新增 `tests/test_stdio_control.py` 6 条：投递/中止/问答往返/超时/断开/迟到答案）。
- **真子进程 + 真主脑实跑**：第 2 步塞进去的话拿到 `injected` 回执，模型回了「收到，改为只看这两个」并真的改了做法；第 6 步叫停，25 秒内收摊，12 条消息（含那句追加指令）全部落盘。

见 ADR-0031 第四节。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UR61QuQnwfGREYieuxyXBJ