### PR TITLE
v1.16.6 准备阶段发 stage 事件：让「正在准备」不再是黑盒

### DIFF
--- a/ivyea_agent/__init__.py
+++ b/ivyea_agent/__init__.py
@@ -1,3 +1,3 @@
 """Ivyea Agent — 自托管的亚马逊运营 CLI Agent。"""
 
-__version__ = "1.16.5"
+__version__ = "1.16.6"

--- a/ivyea_agent/service.py
+++ b/ivyea_agent/service.py
@@ -1844,7 +1844,23 @@ def _chat_stream(payload: dict[str, Any], send_to_client: Any, provider: Any | N
     # 这一轮的起点。created_at 是**会话**的创建时刻（_chat_messages 从存档里取的），
     # 拿它当起点算出来的是这条会话开了多久，不是这一轮跑了多久 —— 差着几天。
     turn_started = time.time()
+
+    # ── 「正在准备」不该是黑盒 ─────────────────────────────────────────────
+    # 在第一个 token 之前，这里要干的事不少：载入会话历史、召回记忆、注入知识证据、
+    # 组工具清单（可能要连 MCP）、语义匹配技能。这些加起来动辄几十秒，而此前
+    # **一个字节都不发** —— 连 start 都在 _chat_messages 之后，前端只能干等，
+    # 屏幕上就一句"正在准备"，用户不知道它在准备什么、还要多久（用户原话：
+    # "有点黑盒的感觉，有时候准备几十秒甚至更久，不知道在准备什么"）。
+    #
+    # 所以每跨过一个准备阶段就发一条 stage。第一条**在任何慢活之前**就发出去，
+    # 保证前端最迟在毫秒级就能看到"开始了，正在做 X"。
+    def stage(name: str, label: str) -> None:
+        send("stage", {"stage": name, "label": label,
+                       "elapsed_ms": int((time.time() - turn_started) * 1000)})
+
+    stage("intake", "读取这一轮的输入")
     try:
+        stage("context", "载入会话历史与记忆")
         messages, created_at, turn_base = _chat_messages(message, payload, ctx, route)
     except ValueError as exc:
         data = {"ok": False, "error": str(exc)}
@@ -1861,6 +1877,8 @@ def _chat_stream(payload: dict[str, Any], send_to_client: Any, provider: Any | N
 
     # 上下文占用：**在第一个 token 之前就发**。进度条要回答"这轮带了多少东西进去"，
     # 等收尾再说就晚了 —— 那时候用户已经在等回答，看不看进度条都无所谓了。
+    # 组工具清单可能要连 MCP（外部进程/网络），是准备阶段里最容易卡住的一步
+    stage("tools", "准备可用工具")
     turn_tools = _tools_for(payload, route)
     send("context", context.snapshot(messages, turn_tools, model_cfg.get("model", "")))
 
@@ -1872,6 +1890,7 @@ def _chat_stream(payload: dict[str, Any], send_to_client: Any, provider: Any | N
             and not route.is_chat and not route.is_quick
             # 同一道领域闸：写代码的轮次不该被塞进一本运营手册
             and _wants_domain_context(task_scope._user_said(message), ctx)):
+        stage("skills", "匹配技能")
         matched = _auto_skill_context(message, messages)
         if matched:
             send("skill_match", stream_json.skill_match_event(ctx.session_id, matched))
@@ -2031,6 +2050,10 @@ def _chat_stream(payload: dict[str, Any], send_to_client: Any, provider: Any | N
         _record_turn_memory(payload, ctx, message, _answer)
 
     try:
+        # 准备阶段的最后一条：从这里开始等的是模型，不再是我们自己在忙。
+        # 这条尤其重要 —— 用户看到"等待模型响应"就知道该等的是网络和模型，
+        # 而不是怀疑本地卡住了。
+        stage("model", "等待模型响应")
         provider = provider or build_chain(model_cfg, api_key, narrate=narrate)
         out = agent_loop.run_turn_stream(
             provider,

--- a/tests/test_retrieval_service.py
+++ b/tests/test_retrieval_service.py
@@ -703,8 +703,15 @@ def test_service_chat_stream_with_fake_provider(ivyea_home):
 
     assert result["ok"] is True
     assert result["text"] == "流式完成"
-    assert events[0][0] == "start"
-    assert [e for e, _ in events].count("token") >= 2
+    # start 是**第一条非 stage 事件**，而不是第一条事件。
+    # v1.16.6 起准备阶段会先发若干条 stage（"载入会话历史与记忆"…），
+    # 而且**刻意排在 start 之前** —— start 之前那段慢活正是要照亮的黑盒，
+    # 等到 start 才说话就等于"干完了才告诉你要开始干"。见 test_service_stage_events。
+    names = [e for e, _ in events]
+    assert "start" in names
+    assert names[0] == "stage", "准备阶段的第一条提示没有排在最前面"
+    assert next(e for e in names if e != "stage") == "start"
+    assert names.count("token") >= 2
     assert events[-1][0] == "final"
 
 

--- a/tests/test_service_stage_events.py
+++ b/tests/test_service_stage_events.py
@@ -1,0 +1,66 @@
+"""准备阶段的 stage 事件：让「正在准备」不再是黑盒。
+
+用户原话："接到指令的正在准备有点黑盒的感觉，有时候准备几十秒甚至更久，
+不知道在准备什么。"
+
+在第一个 token 之前，serve 要载入会话历史、召回记忆、注入知识证据、组工具清单
+（可能要连 MCP）、语义匹配技能 —— 这些加起来动辄几十秒，而此前**一个字节都不发**：
+连 start 都排在 _chat_messages 之后。前端只能干等。
+
+这里锁住三件事：
+  1. stage 事件确实发得出来；
+  2. **第一条 stage 早于 start** —— 这是整个修复的意义所在，晚于 start 就等于
+     "慢活干完了才告诉你要开始干活"；
+  3. 每条 stage 都带人话 label 和已耗时，前端不用自己猜该显示什么。
+"""
+from __future__ import annotations
+
+
+class _EchoProvider:
+    def stream_chat(self, messages, tools=None):
+        yield {"type": "text", "text": "好的。"}
+        yield {"type": "final", "content": "好的。", "tool_calls": [], "usage": {}}
+
+    def chat(self, messages, tools=None):
+        return {"content": "好的。", "tool_calls": []}
+
+
+def _events(message: str = "你好", **payload):
+    from ivyea_agent import service
+
+    seen: list[tuple[str, dict]] = []
+    body = {"message": message, "persist": False, "max_steps": 2, **payload}
+    service.chat_stream(body, lambda e, d: seen.append((e, d)), provider=_EchoProvider())
+    return seen
+
+
+def test_准备阶段会发出_stage_事件():
+    names = [d.get("stage") for e, d in _events() if e == "stage"]
+    assert names, "一条 stage 都没有，前端仍然只能显示一句干巴巴的「正在准备」"
+    # intake 是入口那条，必然有；其余几条随路线可能被跳过（比如闲聊不匹配技能）
+    assert "intake" in names
+    assert "model" in names, "缺少「等待模型响应」——用户无从判断是本地卡住还是在等模型"
+
+
+def test_第一条_stage_必须早于_start():
+    """晚于 start 就失去意义：_chat_messages 那段慢活正好发生在 start 之前。"""
+    seq = [e for e, _ in _events()]
+    assert "stage" in seq and "start" in seq
+    assert seq.index("stage") < seq.index("start"), (
+        "第一条 stage 排在了 start 后面 —— 准备阶段最慢的那段仍然是黑的")
+
+
+def test_每条_stage_都带人话标签和已耗时():
+    for e, d in _events():
+        if e != "stage":
+            continue
+        assert d.get("label"), f"stage {d.get('stage')} 没有 label，前端只能显示英文枚举"
+        assert isinstance(d.get("elapsed_ms"), int), "缺 elapsed_ms，界面没法显示已经等了多久"
+        assert d["elapsed_ms"] >= 0
+
+
+def test_stage_顺序与真实执行顺序一致():
+    names = [d.get("stage") for e, d in _events() if e == "stage"]
+    order = {n: i for i, n in enumerate(["intake", "context", "tools", "skills", "model"])}
+    ranks = [order[n] for n in names if n in order]
+    assert ranks == sorted(ranks), f"stage 顺序乱了：{names}"


### PR DESCRIPTION
用户反馈（IvyeaOps 任务台）：「接到指令的正在准备有点黑盒的感觉，有时候准备几十秒甚至更久，不知道在准备什么。」

## 根因

第一个 token 之前 serve 要干的活不少，而**这期间一个字节都不发**：

- 连 `start` 都排在 `_chat_messages` **之后**，而那一段正是载入会话历史、召回记忆、注入知识证据的地方；
- `start` 之后还有 `_tools_for`（可能要连 MCP，准备阶段里最容易卡住的一步）和技能语义匹配，才轮到模型。

前端只能干等，界面上就一句「正在准备」。

## 改动

每跨过一个准备阶段发一条 `stage`，**第一条在任何慢活之前**就发出去，保证前端毫秒级就能看到「开始了，正在做 X」：

| stage | label |
|---|---|
| `intake` | 读取这一轮的输入 |
| `context` | 载入会话历史与记忆 |
| `tools` | 准备可用工具 |
| `skills` | 匹配技能 |
| `model` | 等待模型响应 |

最后一条尤其有用：看到「等待模型响应」就知道该等的是网络和模型，而不是怀疑本地卡住了。每条都带 `label`（人话）和 `elapsed_ms`（已等多久），前端不用自己猜该显示什么。

## 一条既有测试的处理

`test_retrieval_service` 里 `assert events[0][0] == "start"` 红了。它**不是被碰坏的逻辑**——「第一条 stage 早于 start」正是本次修复的目的，那条断言用索引 0 只是当时的省事写法。改成表达真实意图（`start` 是第一条**非 stage** 事件），而不是放宽它。

## 门禁

`2193 passed / 1 skipped`。新增 `tests/test_service_stage_events.py` 4 条，其中一条专门锁「第一条 stage 必须早于 start」——晚于 start 就等于「慢活干完了才告诉你要开始干活」，这个修复就白做了。

ops 侧消费在另一个 PR（任务台把它显示在过程块头一行）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mvijF2eEBfcGH3ugXWYvM
