### PR TITLE
命令写出来的文件也记成产物

### DIFF
--- a/ivyea_agent/tools_general.py
+++ b/ivyea_agent/tools_general.py
@@ -972,6 +972,62 @@ def _spill_output(ctx, out: str) -> str:
         return ""
 
 
+# 扫描命令产物时跳过的目录。不跳的话，一次 `npm install` 就能把事件流灌爆，
+# 而那几万个文件里没有一个是用户要的"任务产物"。
+_SCAN_SKIP_DIRS = {
+    ".git", ".hg", ".svn", "node_modules", "__pycache__", ".venv", "venv",
+    ".mypy_cache", ".pytest_cache", ".ruff_cache", "dist", "build", ".next",
+    "target", ".cache", ".idea", ".vscode", "site-packages", ".tox", "coverage",
+}
+
+# 扫描的硬上限。工作区可能是个几十万文件的仓库，扫穿它比命令本身还慢。
+_SCAN_MAX_FILES = 4000
+_SCAN_MAX_DEPTH = 5
+
+
+def _scan_command_outputs(ctx, workdir: str, since: float) -> None:
+    """把命令**写出来的文件**记成文件变更。
+
+    存在的理由：``file_change`` 事件原本只有 write_file / edit_file 会发。可是真实
+    任务里，报表和图表大多是 `run_python` 跑脚本、`run_command` 跑命令写出来的 ——
+    那些产物一条都没被记上，界面上的「文件」那格于是永远是空的，功能等于不存在。
+
+    判据是 mtime 晚于命令开始的时间。没有 diff（拿不到改之前的内容），所以 action
+    记 ``write``：不知道是新建还是覆盖就别猜，UI 上照实说"写出"。
+    """
+    changes = getattr(ctx, "file_changes", None)
+    if changes is None or len(changes) >= _MAX_FILE_CHANGES:
+        return
+    root = Path(workdir)
+    if not root.is_dir():
+        return
+    seen = 0
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            rel_depth = len(Path(dirpath).relative_to(root).parts)
+            if rel_depth >= _SCAN_MAX_DEPTH:
+                dirnames[:] = []
+            # 原地改 dirnames 才能真的不下钻（os.walk 的约定）
+            dirnames[:] = [d for d in dirnames
+                           if d not in _SCAN_SKIP_DIRS and not d.startswith(".")]
+            for fname in filenames:
+                seen += 1
+                if seen > _SCAN_MAX_FILES:
+                    return
+                fpath = Path(dirpath) / fname
+                try:
+                    if fpath.stat().st_mtime < since:
+                        continue
+                except OSError:
+                    continue
+                changes.append({"path": str(fpath), "action": "write",
+                                "scope": "file", "diff": ""})
+                if len(changes) >= _MAX_FILE_CHANGES:
+                    return
+    except Exception:  # noqa: BLE001 — 扫描失败绝不能影响命令本身的结果
+        return
+
+
 def _run(cmd, args, ctx, kind: str, preview: str, *, auto_ok: bool = False,
          detail: dict | None = None) -> str:
     if not auto_ok:   # 只读命令(auto_ok)免审批，也可在计划模式下跑（本就只读）
@@ -980,6 +1036,9 @@ def _run(cmd, args, ctx, kind: str, preview: str, *, auto_ok: bool = False,
             return msg
     workdir = getattr(ctx, "workspace", "") or os.getcwd()
     timeout = int(args.get("timeout") or _EXEC_TIMEOUT)
+    # 减 1 秒：文件系统的 mtime 粒度和这里取的时间可能差一点，卡太紧会漏掉
+    # 命令一开始就写出来的那个文件。宁可多扫一个也别漏。
+    started = time.time() - 1.0
     try:
         proc = subprocess.run(cmd, cwd=workdir, timeout=timeout,
                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
@@ -989,6 +1048,7 @@ def _run(cmd, args, ctx, kind: str, preview: str, *, auto_ok: bool = False,
         return f"超时（>{timeout}s）已终止。"
     except Exception as e:  # noqa: BLE001
         return f"执行失败：{e}"
+    _scan_command_outputs(ctx, workdir, started)
     out = proc.stdout or ""
     head = f"[退出码 {proc.returncode}]\n"
     if not out:

--- a/tests/test_command_output_scan.py
+++ b/tests/test_command_output_scan.py
@@ -1,0 +1,93 @@
+"""命令写出来的文件也要被记成产物。
+
+存在的理由：`file_change` 原本只有 write_file / edit_file 会发。真实任务里报表和
+图表大多是 run_python / run_command 写出来的 —— 那些产物一条都没被记上，界面上
+「文件」那格永远是空的，功能等于不存在（生产库里 0 行就是这么来的）。
+"""
+from __future__ import annotations
+
+import time
+
+
+from ivyea_agent import tools_general
+from ivyea_agent.agent_tools import ToolContext
+
+
+def _Ctx(workspace):
+    c = ToolContext(workspace=str(workspace), session_id="s1", turn_id="t1")
+    c.perm.prompt_fn = lambda *a, **k: "approve"      # 审批门不在本用例的射程内
+    return c
+
+
+def _run_cmd(ctx, command: str) -> str:
+    return tools_general.t_run_command({"command": command}, ctx)
+
+
+def test_file_written_by_command_is_recorded(tmp_path):
+    ctx = _Ctx(tmp_path)
+    _run_cmd(ctx, "echo hello > report.md")
+    paths = [c["path"] for c in ctx.file_changes]
+    assert str(tmp_path / "report.md") in paths
+    entry = next(c for c in ctx.file_changes if c["path"].endswith("report.md"))
+    # 拿不到改之前的内容，就别猜是新建还是覆盖 —— 照实说"写出"
+    assert entry["action"] == "write"
+    assert entry["diff"] == ""
+
+
+def test_untouched_files_are_not_recorded(tmp_path):
+    old = tmp_path / "old.txt"
+    old.write_text("x", encoding="utf-8")
+    # 把旧文件的 mtime 推到很久以前，模拟"上一轮留下的文件"
+    long_ago = time.time() - 3600
+    import os
+    os.utime(old, (long_ago, long_ago))
+
+    ctx = _Ctx(tmp_path)
+    _run_cmd(ctx, "echo new > fresh.txt")
+    paths = [c["path"] for c in ctx.file_changes]
+    assert str(tmp_path / "fresh.txt") in paths
+    assert str(old) not in paths, "没动过的文件不该被记成这一轮的产物"
+
+
+def test_noise_directories_are_skipped(tmp_path):
+    """一次 npm install 能写几万个文件，全记下来等于把事件流灌爆。"""
+    ctx = _Ctx(tmp_path)
+    _run_cmd(ctx, "mkdir -p node_modules/pkg .git/objects && "
+                  "touch node_modules/pkg/index.js .git/objects/abc && "
+                  "echo ok > result.csv")
+    paths = [c["path"] for c in ctx.file_changes]
+    assert any(p.endswith("result.csv") for p in paths)
+    assert not any("node_modules" in p for p in paths)
+    assert not any("/.git/" in p for p in paths)
+
+
+def test_recording_is_capped(tmp_path):
+    ctx = _Ctx(tmp_path)
+    _run_cmd(ctx, f"for i in $(seq 1 {tools_general._MAX_FILE_CHANGES + 20}); "
+                  "do echo x > f$i.txt; done")
+    assert len(ctx.file_changes) <= tools_general._MAX_FILE_CHANGES
+
+
+def test_python_output_is_recorded(tmp_path):
+    ctx = _Ctx(tmp_path)
+    tools_general.t_run_python(
+        {"code": "open('out.json','w').write('{}')"}, ctx)
+    assert any(c["path"].endswith("out.json") for c in ctx.file_changes)
+
+
+def test_scan_never_breaks_the_command_itself(tmp_path, monkeypatch):
+    """扫描失败绝不能影响命令的返回 —— 产物索引是附加值，不是主线。"""
+    ctx = _Ctx(tmp_path)
+
+    def boom(*a, **k):
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(tools_general.os, "walk", boom)
+    out = _run_cmd(ctx, "echo hello")
+    assert "hello" in out
+
+
+def test_no_workspace_is_harmless(tmp_path):
+    ctx = _Ctx(tmp_path / "does-not-exist")
+    tools_general._scan_command_outputs(ctx, str(tmp_path / "nope"), time.time())
+    assert ctx.file_changes == []

--- a/tests/test_command_output_scan.py
+++ b/tests/test_command_output_scan.py
@@ -27,7 +27,7 @@ def test_file_written_by_command_is_recorded(tmp_path):
     ctx = _Ctx(tmp_path)
     _run_cmd(ctx, "echo hello > report.md")
     paths = [c["path"] for c in ctx.file_changes]
-    assert str(tmp_path / "report.md") in paths
+    assert any(p.endswith("report.md") for p in paths)
     entry = next(c for c in ctx.file_changes if c["path"].endswith("report.md"))
     # 拿不到改之前的内容，就别猜是新建还是覆盖 —— 照实说"写出"
     assert entry["action"] == "write"
@@ -35,37 +35,50 @@ def test_file_written_by_command_is_recorded(tmp_path):
 
 
 def test_untouched_files_are_not_recorded(tmp_path):
+    import os
+
     old = tmp_path / "old.txt"
     old.write_text("x", encoding="utf-8")
     # 把旧文件的 mtime 推到很久以前，模拟"上一轮留下的文件"
     long_ago = time.time() - 3600
-    import os
     os.utime(old, (long_ago, long_ago))
 
     ctx = _Ctx(tmp_path)
+    # `echo x > f` 在 bash 和 cmd 下行为一致，这条可以真走 shell
     _run_cmd(ctx, "echo new > fresh.txt")
     paths = [c["path"] for c in ctx.file_changes]
-    assert str(tmp_path / "fresh.txt") in paths
+    assert any(p.endswith("fresh.txt") for p in paths)
     assert str(old) not in paths, "没动过的文件不该被记成这一轮的产物"
 
 
+# 下面两条直接调 _scan_command_outputs，不经过 shell。
+# **这本身就是这次要修的那个毛病**：第一版用 `mkdir -p`/`touch`/`for … in $(seq)`
+# 造现场，在 Windows 的 `cmd /c` 下这些命令根本不存在，整条链失败、文件没生成，
+# 断言随之落空 —— CI 的 windows-latest 三个 Python 版本全挂。给"别假设是 Linux"
+# 写的测试自己假设了 Linux。造现场用 pathlib，跨平台才是真的一致。
+
 def test_noise_directories_are_skipped(tmp_path):
     """一次 npm install 能写几万个文件，全记下来等于把事件流灌爆。"""
+    (tmp_path / "node_modules" / "pkg").mkdir(parents=True)
+    (tmp_path / "node_modules" / "pkg" / "index.js").write_text("x", encoding="utf-8")
+    (tmp_path / ".git" / "objects").mkdir(parents=True)
+    (tmp_path / ".git" / "objects" / "abc").write_text("x", encoding="utf-8")
+    (tmp_path / "result.csv").write_text("ok", encoding="utf-8")
+
     ctx = _Ctx(tmp_path)
-    _run_cmd(ctx, "mkdir -p node_modules/pkg .git/objects && "
-                  "touch node_modules/pkg/index.js .git/objects/abc && "
-                  "echo ok > result.csv")
+    tools_general._scan_command_outputs(ctx, str(tmp_path), time.time() - 60)
     paths = [c["path"] for c in ctx.file_changes]
     assert any(p.endswith("result.csv") for p in paths)
     assert not any("node_modules" in p for p in paths)
-    assert not any("/.git/" in p for p in paths)
+    assert not any("objects" in p for p in paths)
 
 
 def test_recording_is_capped(tmp_path):
+    for i in range(tools_general._MAX_FILE_CHANGES + 20):
+        (tmp_path / f"f{i}.txt").write_text("x", encoding="utf-8")
     ctx = _Ctx(tmp_path)
-    _run_cmd(ctx, f"for i in $(seq 1 {tools_general._MAX_FILE_CHANGES + 20}); "
-                  "do echo x > f$i.txt; done")
-    assert len(ctx.file_changes) <= tools_general._MAX_FILE_CHANGES
+    tools_general._scan_command_outputs(ctx, str(tmp_path), time.time() - 60)
+    assert len(ctx.file_changes) == tools_general._MAX_FILE_CHANGES
 
 
 def test_python_output_is_recorded(tmp_path):


### PR DESCRIPTION
`file_change` 事件原本只有 `write_file` / `edit_file` 会发。可真实任务里，报表和图表大多是 `run_python` 跑脚本、`run_command` 跑命令写出来的 —— 那些产物一条都没被记上。

IvyeaOps 生产库里 `console_files` 至今 **0 行**，就是这么来的：功能做完了，但绝大多数真实产出根本走不到它。

## 改动

`_run` 里在子进程跑完后扫一遍工作区，把 mtime 晚于命令开始时间的文件记进 `ctx.file_changes`，由 `agent_loop` 照常发成 `file_change`。

## 边界

- 跳过 `.git` / `node_modules` / `__pycache__` / `dist` 这类目录 —— 一次 `npm install` 能写几万个文件，全记下来等于把事件流灌爆，而里面没有一个是用户要的产物；
- 限深 5 层、限扫 4000 个文件，条数仍受既有的 `_MAX_FILE_CHANGES` 约束；
- 扫描抛异常一律吞掉：产物索引是附加值，不能影响命令本身的结果；
- `action` 记 `write` 而不是 create/overwrite —— 拿不到改之前的内容就别猜。

## 测试

新增 7 项（命令产物被记上 / 没动过的文件不记 / 噪音目录跳过 / 条数封顶 / run_python 同样生效 / 扫描失败不影响命令 / 工作区不存在无害）。全量 2251 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hikY7erSjSgQ1zSixE8wR